### PR TITLE
Data list page improvements

### DIFF
--- a/cassdegrees/templates/list.html
+++ b/cassdegrees/templates/list.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 
-{% block page-title %}Template/Subplan List{% endblock %}
+{% block page-title %}Template/Subplan/Course List{% endblock %}
 
-{% block subtitle %}Template and Subplan List{% endblock %}
+{% block subtitle %}Template, Subplan, and Course List{% endblock %}
 
 {% block content %}
     {# Generates the tabs based on the keys to 'data' #}
@@ -20,15 +20,26 @@
             <table class="fullwidth tbl-cell-bdr">
                 {# Add title row based on what was in the dictionary #}
                 <tr>
-                    {% for item in content.0 %}
-                        <th>{{ item }}</th>
+                    {% for key in content.0 %}
+                        {% if key != "id" %}
+                            <th>{{ key }}</th>
+                        {% else %}
+                            <th>{{ title }}</th>
+                        {% endif %}
                     {% endfor %}
                 </tr>
                 {# Add rows containing the contents of each json data instance #}
                 {% for row in content %}
                     <tr>
-                        {% for item in row.values %}
-                            <td>{{ item }}</td>
+                        {% for key, item in row.items %}
+                            <td>
+                                {# If the item is in the ID column, generate a link to it instead #}
+                                {% if key != "id" %}
+                                    {{ item }}
+                                {% else %}
+                                    (<a href="/api/model/{{ title.lower }}/{{ item }}/">View</a>)
+                                {% endif %}
+                            </td>
                         {% endfor %}
                     </tr>
                 {% endfor %}

--- a/cassdegrees/templates/list.html
+++ b/cassdegrees/templates/list.html
@@ -5,69 +5,57 @@
 {% block subtitle %}Template and Subplan List{% endblock %}
 
 {% block content %}
-
+    {# Generates the tabs based on the keys to 'data' #}
     <div class="pagetabs-nav">
         <ul>
-            <li><a onClick="setActive(0)" id="TemplateLink">Templates</a></li>
-            <li><a onClick="setActive(1)" id="SubplanLink">Subplans</a></li>
+            {% for title in data %}
+                <li><a onClick='setActive("{{ title }}")' id="{{ title }}Link">{{ title }}s</a></li>
+            {% endfor %}
         </ul>
     </div>
 
-    <div id="TemplateTable">
-        <table class="fullwidth tbl-cell-bdr">
-            <tr>
-                {% for item in degrees.0 %}
-                    <th>{{ item }}</th>
-                {% endfor %}
-            </tr>
-            {% for row in degrees %}
+    {# Generates table instances for each table in 'data', as well as the appropriate settings to keep it hidden #}
+    {% for title, content in data.items %}
+        <div id="{{ title }}Table" hidden>
+            <table class="fullwidth tbl-cell-bdr">
+                {# Add title row based on what was in the dictionary #}
                 <tr>
-                    {% for _, item in row.items %}
-                        <td>{{ item }}</td>
+                    {% for item in content.0 %}
+                        <th>{{ item }}</th>
                     {% endfor %}
                 </tr>
-            {% endfor %}
-        </table>
-        {% if not degrees %}<p>No templates to display</p>{% endif %}
-    </div>
-
-    <div id="SubplanTable">
-        <table class="fullwidth tbl-cell-bdr">
-            <tr>
-                {% for item in subplans.0 %}
-                    <th>{{ item }}</th>
+                {# Add rows containing the contents of each json data instance #}
+                {% for row in content %}
+                    <tr>
+                        {% for item in row.values %}
+                            <td>{{ item }}</td>
+                        {% endfor %}
+                    </tr>
                 {% endfor %}
-            </tr>
-            {% for row in subplans %}
-                <tr>
-                    {% for _, item in row.items %}
-                        <td>{{ item }}</td>
-                    {% endfor %}
-                </tr>
-            {% endfor %}
-        </table>
-        {% if not subplans %}<p>No subplans to display</p>{% endif %}
-    </div>
+            </table>
+            {# If there is no data available, notify the user #}
+            {% if not content %}<p>No {{ title }}s to display</p>{% endif %}
+        </div>
+    {% endfor %}
 
+    {# Function to hide the previous tab while opening a new one #}
     <script>
-        function setActive(index){
-            document.getElementById("TemplateLink").setAttribute("class", "");
-            document.getElementById("TemplateTable").style.display = "none";
-            document.getElementById("SubplanLink").setAttribute("class", "");
-            document.getElementById("SubplanTable").style.display = "none";
+        var oldLabel = "Degree";
 
-            switch(index) {
-                case 0: //Show Templates
-                    document.getElementById("TemplateLink").setAttribute("class", "pagetabs-select");
-                    document.getElementById("TemplateTable").style.display = "block";
-                    break;
-                case 1: //Show Templates
-                    document.getElementById("SubplanLink").setAttribute("class", "pagetabs-select");
-                    document.getElementById("SubplanTable").style.display = "block";
-                    break;
-            }
+        function setActive(label){
+            if(document.getElementById(label+"Link") == null)
+                label = oldLabel;
+
+            document.getElementById(oldLabel+"Link").setAttribute("class", "");
+            document.getElementById(oldLabel+"Table").style.display = "none";
+
+            document.getElementById(label+"Link").setAttribute("class", "pagetabs-select");
+            document.getElementById(label+"Table").style.display = "block";
+
+            oldLabel = label;
         }
 
-        setActive(0)
+        var openElement = (new URLSearchParams(window.location.search)).get("view");
+        setActive(openElement)
     </script>
 {% endblock %}

--- a/cassdegrees/ui/views.py
+++ b/cassdegrees/ui/views.py
@@ -15,7 +15,7 @@ def index(request):
         {'url': "/api/model/subplan/", 'img': "../static/img/create_subplan_img.png", 'label': "Create Subplan"},
         {'url': "", 'img': "../static/img/create_list_img.png", 'label': "Create List"},
         {'url': "/list/", 'img': "../static/img/open_existing_img.png", 'label': "Open Existing"},
-        {'url': "/api/model/course/", 'img': "../static/img/manage_courses_img.png", 'label': "Manage Courses"}
+        {'url': "/list/?view=Course", 'img': "../static/img/manage_courses_img.png", 'label': "Manage Courses"}
     ]
 
     return render(request, 'index.html', context={'buttons': buttons})

--- a/cassdegrees/ui/views.py
+++ b/cassdegrees/ui/views.py
@@ -21,15 +21,20 @@ def index(request):
     return render(request, 'index.html', context={'buttons': buttons})
 
 def planList(request):
-    """ Generates a table based on whatever JSON object is stored in 'data'
+    """ Generates a table based on the JSON objects stored in 'data'
+
+    NOTE: For the page to generate the tabs correctly, the api table data must be put in the context
+    under the dictionary {'data': {'RELATION': RELATION_DATA, ...}}. To link to the actual data correctly,
+    ensure the RELATION text is the same as what is called in the API (e.g. /api/model/RELATION/?format=json)
 
     :param request:
     :return <class django.http.response.HttpResponse>:
     """
-    subplans = requests.get(request.build_absolute_uri('/api/model/subplan/?format=json')).json()
     degree = requests.get(request.build_absolute_uri('/api/model/degree/?format=json')).json()
-    
-    return render(request, 'list.html', context={'subplans': subplans, 'degrees': degree})
+    subplan = requests.get(request.build_absolute_uri('/api/model/subplan/?format=json')).json()
+    course  = requests.get(request.build_absolute_uri('/api/model/course/?format=json')).json()
+
+    return render(request, 'list.html', context={'data': {'Degree': degree, 'Subplan': subplan, 'Course': course}})
 
 # I went through this tutorial to create the form html file and this view:
 # https://docs.djangoproject.com/en/2.2/topics/forms/


### PR DESCRIPTION
Made modifications to my previously created list page to make it more dynamic and include "Courses" as one of the tabs. The Idea here is we will be able to use it as the endpoint for most of our searches for existing content (As such, I have also linked the page to the "Manage Courses" section). I've also made it possible to open a default tab on this page by specifying `?view=OPT` (OPT = Degree, Subplan, Course).

![New List Page](https://user-images.githubusercontent.com/36946090/55952915-16494700-5c9e-11e9-974a-eca6d16a654b.jpg)
