### PR TITLE
Course Creation and Specification

### DIFF
--- a/cassdegrees/static/css/style.css
+++ b/cassdegrees/static/css/style.css
@@ -27,3 +27,11 @@
     justify-content: center;
     margin: 12px;
 }
+
+select.tfull {
+    width: 70%;
+}
+
+select.text{
+    border-radius: 3px;
+}

--- a/cassdegrees/static/css/style.css
+++ b/cassdegrees/static/css/style.css
@@ -29,7 +29,7 @@
 }
 
 select.tfull {
-    width: 70%;
+    width: 70.25%;
 }
 
 select.text{

--- a/cassdegrees/templates/managecourses.html
+++ b/cassdegrees/templates/managecourses.html
@@ -31,7 +31,7 @@
             </p>
 
             <p>
-                <label for="text">Semester:</label>
+                <label for="text">Semester(s):</label>
                 <select name="semester[]" size="2" multiple>
                     <option value="semester1">Semester 1</option>
                     <option value="semester2">Semester 2</option>
@@ -41,6 +41,24 @@
              <p>
                 <label for="text">Units:</label>
                 <input class="text" id="number" type="number" name="units" min="6" max="48" step="6" aria-required="true" required>
+            </p>
+
+            <p>
+                <label for="text">Requisite Course(s):</label>
+                <select name="semester[]" size="5" multiple>
+                    {% for course in courses %}
+                        <option value="{{ course.code }}_{{ course.year }}">{{ course.code }}_{{ course.year }}</option>
+                    {% endfor %}
+                </select>
+            </p>
+
+            <p>
+                <label for="text">Incompatible Course(s):</label>
+                <select name="semester[]" size="5" multiple>
+                    {% for course in courses %}
+                        <option value="{{ course.code }}_{{ course.year }}">{{ course.code }}_{{ course.year }}</option>
+                    {% endfor %}
+                </select>
             </p>
         </fieldset>
         <p class="text-right">

--- a/cassdegrees/templates/managecourses.html
+++ b/cassdegrees/templates/managecourses.html
@@ -57,7 +57,7 @@
                 <label for="text">Incompatible Course(s):</label>
                 <select name="semester[]" size="5" multiple>
                     {% for course in courses %}
-                        <option value="{{ course.code }}_{{ course.year }}">{{ course.code }}_{{ course.year }}</option>
+                        <option value="{{ course.code }}">{{ course.code }}</option>
                     {% endfor %}
                 </select>
             </p>

--- a/cassdegrees/templates/managecourses.html
+++ b/cassdegrees/templates/managecourses.html
@@ -15,22 +15,22 @@
             <input type="hidden" name="_method" value="post">
 
             <p>
-                <label class="req" for="id">Course Name:</label>
+                <label class="req" for="id">Course Name</label>
                 <input class="text tfull" id="text" type="text" name="name" aria-required="true" required>
             </p>
 
             <p>
-                <label class="req" for="id">Course Code:</label>
+                <label class="req" for="id">Course Code</label>
                 <input class="text tfull" id="text" type="text" name="code" minlength="8" maxlength="8" size="8" aria-required="true" required>
             </p>
 
             <p>
-                <label class="req" for="text">Year:</label>
+                <label class="req" for="text">Year</label>
                 <input class="text tfull" id="number" type="number" name="year" min="1990" aria-required="true" required>
             </p>
 
             <p>
-                <label for="text">Semester(s):</label>
+                <label for="text">Semester(s)</label>
                 <select class="text tfull" name="semester[]" size="2" multiple>
                     <option value="semester1">Semester 1</option>
                     <option value="semester2">Semester 2</option>
@@ -38,13 +38,13 @@
             </p>
 
              <p>
-                <label class="req" for="text">Units:</label>
+                <label class="req" for="text">Units</label>
                  <!-- max value is chosen arbitrarily -->
                 <input class="text tfull" id="number" type="number" name="units" min="0" step="6" aria-required="true" required>
             </p>
 
             <p>
-                <label for="text">Requisite Course(s):</label>
+                <label for="text">Requisite Course(s)</label>
                 <select class="text tfull" name="semester[]" size="5" multiple>
                     {% for course in courses %}
                         <option value="{{ course.code }}">{{ course.code }}</option>
@@ -53,7 +53,7 @@
             </p>
 
             <p>
-                <label for="text">Incompatible Course(s):</label>
+                <label for="text">Incompatible Course(s)</label>
                 <select class="text tfull" name="semester[]" size="5" multiple>
                     {% for course in courses %}
                         <option value="{{ course.code }}">{{ course.code }}</option>

--- a/cassdegrees/templates/managecourses.html
+++ b/cassdegrees/templates/managecourses.html
@@ -41,7 +41,7 @@
              <p>
                 <label for="text">Units:</label>
                  <!-- max value is chosen arbitrarily -->
-                <input class="text" id="number" type="number" name="units" min="6" max="48" step="6" aria-required="true" required>
+                <input class="text tfull" id="number" type="number" name="units" min="0" step="6" aria-required="true" required>
             </p>
 
             <p>

--- a/cassdegrees/templates/managecourses.html
+++ b/cassdegrees/templates/managecourses.html
@@ -21,7 +21,7 @@
 
             <p>
                 <label for="id">Course Code:</label>
-                <input class="text" id="text" type="text" name="code" minlength="8" maxlength="8" size="8" aria-required="true" required>
+                <input class="text tfull" id="text" type="text" name="code" minlength="8" maxlength="8" size="8" aria-required="true" required>
             </p>
 
             <p>

--- a/cassdegrees/templates/managecourses.html
+++ b/cassdegrees/templates/managecourses.html
@@ -8,7 +8,7 @@
     <form class="anuform" action="/manage_courses/" method="post">
         {% csrf_token %}
         <fieldset>
-            <legend>Add Courses</legend>
+            <legend>Add Course</legend>
 
             <!-- As HTML forms only support get or post methods,
             add this hidden input for consistency with the rest of the forms -->

--- a/cassdegrees/templates/managecourses.html
+++ b/cassdegrees/templates/managecourses.html
@@ -15,17 +15,17 @@
             <input type="hidden" name="_method" value="post">
 
             <p>
-                <label for="id">Course Name:</label>
+                <label class="req" for="id">Course Name:</label>
                 <input class="text tfull" id="text" type="text" name="name" aria-required="true" required>
             </p>
 
             <p>
-                <label for="id">Course Code:</label>
+                <label class="req" for="id">Course Code:</label>
                 <input class="text tfull" id="text" type="text" name="code" minlength="8" maxlength="8" size="8" aria-required="true" required>
             </p>
 
             <p>
-                <label for="text">Year:</label>
+                <label class="req" for="text">Year:</label>
                 <input class="text tfull" id="number" type="number" name="year" min="1990" aria-required="true" required>
             </p>
 
@@ -38,7 +38,7 @@
             </p>
 
              <p>
-                <label for="text">Units:</label>
+                <label class="req" for="text">Units:</label>
                  <!-- max value is chosen arbitrarily -->
                 <input class="text tfull" id="number" type="number" name="units" min="0" step="6" aria-required="true" required>
             </p>
@@ -66,49 +66,4 @@
         </p>
     </form>
     <br />
-    <!-- not yet implemented -->
-    <form class="anuform" action="/manage_courses/" method="post">
-        {% csrf_token %}
-        <fieldset>
-            <legend>Modify Course</legend>
-
-            <!-- As HTML forms only support get or post methods,
-            add this hidden input to hint that it is actually a put request. -->
-            <input type="hidden" name="_method" value="patch">
-
-            <p>
-                <label for="id">ID:</label>
-                <input class="text" id="id" type="text" name="id" aria-required="true" required>
-            </p>
-
-            <p>
-                <label for="text">Text:</label>
-                <input class="text" id="text" type="text" name="text" aria-required="true" required>
-            </p>
-        </fieldset>
-        <p class="text-right">
-            <input class="btn-uni-grad btn-large" type ="submit" value="Update">
-        </p>
-
-    </form>
-    <br />
-    <!-- not yet implemented -->
-    <form class="anuform" action="/manage_courses/" method="post">
-        {% csrf_token %}
-        <fieldset>
-            <legend>Delete Course</legend>
-
-            <!-- As HTML forms only support get or post methods,
-            add this hidden input to hint that it is actually a delete request. -->
-            <input type="hidden" name="_method" value="delete">
-
-            <p>
-                <label for="id">ID:</label>
-                <input class="text" id="id" type="text" name="id" aria-required="true" required>
-            </p>
-        </fieldset>
-        <p class="text-right">
-            <input class="btn-uni-grad btn-large" type ="submit" value="Delete">
-        </p>
-    </form>
 {% endblock %}

--- a/cassdegrees/templates/managecourses.html
+++ b/cassdegrees/templates/managecourses.html
@@ -40,6 +40,7 @@
 
              <p>
                 <label for="text">Units:</label>
+                 <!-- max value is chosen arbitrarily -->
                 <input class="text" id="number" type="number" name="units" min="6" max="48" step="6" aria-required="true" required>
             </p>
 
@@ -66,6 +67,7 @@
         </p>
     </form>
     <br />
+    <!-- not yet implemented -->
     <form class="anuform" action="/manage_courses/" method="post">
         {% csrf_token %}
         <fieldset>
@@ -91,6 +93,7 @@
 
     </form>
     <br />
+    <!-- not yet implemented -->
     <form class="anuform" action="/manage_courses/" method="post">
         {% csrf_token %}
         <fieldset>

--- a/cassdegrees/templates/managecourses.html
+++ b/cassdegrees/templates/managecourses.html
@@ -26,8 +26,7 @@
 
             <p>
                 <label for="text">Year:</label>
-                <!-- static min max values are only temporary -->
-                <input class="text" id="number" type="number" name="year" min="1990" max="2100" aria-required="true" required>
+                <input class="text tfull" id="number" type="number" name="year" min="1990" aria-required="true" required>
             </p>
 
             <p>

--- a/cassdegrees/templates/managecourses.html
+++ b/cassdegrees/templates/managecourses.html
@@ -1,0 +1,94 @@
+{% extends "base.html" %}
+
+{% block page-title %}Manage Course{% endblock %}
+
+{% block subtitle %}Add, Modify or Delete Courses{% endblock %}
+
+{% block content %}
+    <form class="anuform" action="/manage_courses/" method="post">
+        {% csrf_token %}
+        <fieldset>
+            <legend>Add Courses</legend>
+
+            <!-- As HTML forms only support get or post methods,
+            add this hidden input for consistency with the rest of the forms -->
+            <input type="hidden" name="_method" value="post">
+
+            <p>
+                <label for="id">Course Name:</label>
+                <input class="text" id="text" type="text" name="name" aria-required="true" required>
+            </p>
+
+            <p>
+                <label for="id">Course Code:</label>
+                <input class="text" id="text" type="text" name="code" minlength="8" maxlength="8" size="8" aria-required="true" required>
+            </p>
+
+            <p>
+                <label for="text">Year:</label>
+                <!-- static min max values are only temporary -->
+                <input class="text" id="number" type="number" name="year" min="1990" max="2100" aria-required="true" required>
+            </p>
+
+            <p>
+                <label for="text">Semester:</label>
+                <select name="semester[]" size="2" multiple>
+                    <option value="semester1">Semester 1</option>
+                    <option value="semester2">Semester 2</option>
+                </select>
+            </p>
+
+             <p>
+                <label for="text">Units:</label>
+                <input class="text" id="number" type="number" name="units" min="6" max="48" step="6" aria-required="true" required>
+            </p>
+        </fieldset>
+        <p class="text-right">
+            <input class="btn-uni-grad btn-large" type ="submit" value="Create">
+        </p>
+    </form>
+    <br />
+    <form class="anuform" action="/manage_courses/" method="post">
+        {% csrf_token %}
+        <fieldset>
+            <legend>Modify Course</legend>
+
+            <!-- As HTML forms only support get or post methods,
+            add this hidden input to hint that it is actually a put request. -->
+            <input type="hidden" name="_method" value="patch">
+
+            <p>
+                <label for="id">ID:</label>
+                <input class="text" id="id" type="text" name="id" aria-required="true" required>
+            </p>
+
+            <p>
+                <label for="text">Text:</label>
+                <input class="text" id="text" type="text" name="text" aria-required="true" required>
+            </p>
+        </fieldset>
+        <p class="text-right">
+            <input class="btn-uni-grad btn-large" type ="submit" value="Update">
+        </p>
+
+    </form>
+    <br />
+    <form class="anuform" action="/manage_courses/" method="post">
+        {% csrf_token %}
+        <fieldset>
+            <legend>Delete Course</legend>
+
+            <!-- As HTML forms only support get or post methods,
+            add this hidden input to hint that it is actually a delete request. -->
+            <input type="hidden" name="_method" value="delete">
+
+            <p>
+                <label for="id">ID:</label>
+                <input class="text" id="id" type="text" name="id" aria-required="true" required>
+            </p>
+        </fieldset>
+        <p class="text-right">
+            <input class="btn-uni-grad btn-large" type ="submit" value="Delete">
+        </p>
+    </form>
+{% endblock %}

--- a/cassdegrees/templates/managecourses.html
+++ b/cassdegrees/templates/managecourses.html
@@ -2,67 +2,70 @@
 
 {% block page-title %}Manage Courses{% endblock %}
 
-{% block subtitle %}Add, Modify or Delete Courses{% endblock %}
+{% block subtitle %}{{ action }} Courses{% endblock %}
 
 {% block content %}
     <form class="anuform" action="/manage_courses/" method="post">
         {% csrf_token %}
-        <fieldset>
-            <legend>Add Course</legend>
+        {% with required='<img src="//style.anu.edu.au/_anu/4/images/styles/asterisk.png" alt=" required">' %}
+            <fieldset>
+                <legend>{{ action }} Course</legend>
 
-            <!-- As HTML forms only support get or post methods,
-            add this hidden input for consistency with the rest of the forms -->
-            <input type="hidden" name="_method" value="post">
+                <!-- As HTML forms only support get or post methods,
+                add this hidden input for consistency with the rest of the forms -->
+                <input type="hidden" name="_method" value="{{ method }}">
 
-            <p>
-                <label class="req" for="id">Course Name</label>
-                <input class="text tfull" id="text" type="text" name="name" aria-required="true" required>
-            </p>
+                <p>
+                    <label for="id">Course Name {{ required }}</label>
+                    <input class="text tfull" id="text" type="text" name="name" aria-required="true" required>
+                </p>
 
-            <p>
-                <label class="req" for="id">Course Code</label>
-                <input class="text tfull" id="text" type="text" name="code" minlength="8" maxlength="8" size="8" aria-required="true" required>
-            </p>
+                <p>
+                    <label for="id">Course Code {{ required }}</label>
+                    <input class="text tfull" id="text" type="text" name="code" minlength="8" maxlength="8" size="8" aria-required="true" required>
+                </p>
 
-            <p>
-                <label class="req" for="text">Year</label>
-                <input class="text tfull" id="number" type="number" name="year" min="1990" aria-required="true" required>
-            </p>
+                <p>
+                    <label for="text">Year {{ required }}</label>
+                    <input class="text tfull" id="number" type="number" name="year" min="1990" aria-required="true" required>
+                </p>
 
-            <p>
-                <label for="text">Semester(s)</label>
-                <select class="text tfull" name="semester[]" size="2" multiple>
-                    <option value="semester1">Semester 1</option>
-                    <option value="semester2">Semester 2</option>
-                </select>
-            </p>
+                <p>
+                    <label for="text">Semester(s)</label>
+                    <select class="text tfull" name="semester[]" size="2" multiple>
+                        <option value="semester1">Semester 1</option>
+                        <option value="semester2">Semester 2</option>
+                    </select>
+                </p>
 
-             <p>
-                <label class="req" for="text">Units</label>
-                 <!-- max value is chosen arbitrarily -->
-                <input class="text tfull" id="number" type="number" name="units" min="0" step="6" aria-required="true" required>
-            </p>
+                 <p>
+                    <label for="text">Units {{ required }}</label>
+                     <!-- max value is chosen arbitrarily -->
+                    <input class="text tfull" id="number" type="number" name="units" min="0" step="6" aria-required="true" required>
+                </p>
 
-            <p>
-                <label for="text">Requisite Course(s)</label>
-                <select class="text tfull" name="semester[]" size="5" multiple>
-                    {% for course in courses %}
-                        <option value="{{ course.code }}">{{ course.code }}</option>
-                    {% endfor %}
-                </select>
-            </p>
+                <p>
+                    <label for="text">Requisite Course(s)</label>
+                    <select class="text tfull" name="semester[]" size="5" multiple>
+                        {% for course in courses %}
+                            <option value="{{ course.code }}">{{ course.code }}</option>
+                        {% endfor %}
+                    </select>
+                </p>
 
-            <p>
-                <label for="text">Incompatible Course(s)</label>
-                <select class="text tfull" name="semester[]" size="5" multiple>
-                    {% for course in courses %}
-                        <option value="{{ course.code }}">{{ course.code }}</option>
-                    {% endfor %}
-                </select>
-            </p>
-        </fieldset>
+                <p>
+                    <label for="text">Incompatible Course(s)</label>
+                    <select class="text tfull" name="semester[]" size="5" multiple>
+                        {% for course in courses %}
+                            <option value="{{ course.code }}">{{ course.code }}</option>
+                        {% endfor %}
+                    </select>
+                </p>
+            </fieldset>
+        {% endwith %}
+
         <p class="text-right">
-            <input class="btn-uni-grad btn-large" type ="submit" value="Create">
+            <input class="btn-uni-grad btn-large" type ="submit" value="{{ action }}">
         </p>
     </form>
     <br />

--- a/cassdegrees/templates/managecourses.html
+++ b/cassdegrees/templates/managecourses.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block page-title %}Manage Course{% endblock %}
+{% block page-title %}Manage Courses{% endblock %}
 
 {% block subtitle %}Add, Modify or Delete Courses{% endblock %}
 

--- a/cassdegrees/templates/managecourses.html
+++ b/cassdegrees/templates/managecourses.html
@@ -48,7 +48,7 @@
                 <label for="text">Requisite Course(s):</label>
                 <select name="semester[]" size="5" multiple>
                     {% for course in courses %}
-                        <option value="{{ course.code }}_{{ course.year }}">{{ course.code }}_{{ course.year }}</option>
+                        <option value="{{ course.code }}">{{ course.code }}</option>
                     {% endfor %}
                 </select>
             </p>

--- a/cassdegrees/templates/managecourses.html
+++ b/cassdegrees/templates/managecourses.html
@@ -8,15 +8,11 @@
     {% if render.msg != None %}
         <p class="{% if render.is_error %}msg-error{% else %}msg-success{% endif %}">{{ render.msg }}</p>
     {% endif %}
-    <form class="anuform" action="/manage_courses/" method="post">
+    <form class="anuform" action="/manage_courses/?action=Add" method="post">
         {% csrf_token %}
         {% with required='<img src="//style.anu.edu.au/_anu/4/images/styles/asterisk.png" alt=" required">' %}
             <fieldset>
                 <legend>{{ action }} Course</legend>
-
-                <!-- As HTML forms only support get or post methods,
-                add this hidden input for consistency with the rest of the forms -->
-                <input type="hidden" name="_method" value="{{ method }}">
 
                 <p>
                     <label for="id">Course Name {{ required }}</label>

--- a/cassdegrees/templates/managecourses.html
+++ b/cassdegrees/templates/managecourses.html
@@ -32,7 +32,7 @@
 
             <p>
                 <label for="text">Semester(s):</label>
-                <select name="semester[]" size="2" multiple>
+                <select class="text tfull" name="semester[]" size="2" multiple>
                     <option value="semester1">Semester 1</option>
                     <option value="semester2">Semester 2</option>
                 </select>
@@ -46,7 +46,7 @@
 
             <p>
                 <label for="text">Requisite Course(s):</label>
-                <select name="semester[]" size="5" multiple>
+                <select class="text tfull" name="semester[]" size="5" multiple>
                     {% for course in courses %}
                         <option value="{{ course.code }}">{{ course.code }}</option>
                     {% endfor %}
@@ -55,7 +55,7 @@
 
             <p>
                 <label for="text">Incompatible Course(s):</label>
-                <select name="semester[]" size="5" multiple>
+                <select class="text tfull" name="semester[]" size="5" multiple>
                     {% for course in courses %}
                         <option value="{{ course.code }}">{{ course.code }}</option>
                     {% endfor %}

--- a/cassdegrees/templates/managecourses.html
+++ b/cassdegrees/templates/managecourses.html
@@ -16,7 +16,7 @@
 
             <p>
                 <label for="id">Course Name:</label>
-                <input class="text" id="text" type="text" name="name" aria-required="true" required>
+                <input class="text tfull" id="text" type="text" name="name" aria-required="true" required>
             </p>
 
             <p>

--- a/cassdegrees/templates/managecourses.html
+++ b/cassdegrees/templates/managecourses.html
@@ -2,70 +2,108 @@
 
 {% block page-title %}Manage Courses{% endblock %}
 
-{% block subtitle %}{{ action }} Courses{% endblock %}
+{% block subtitle %}Manage Courses{% endblock %}
 
 {% block content %}
+    {# Generates the tabs based on the keys #}
+    <div class="pagetabs-nav">
+        <ul>
+            {% for title in actions %}
+                <li><a onClick='setActive("{{ title }}")' id="{{ title }}Link">{{ title }}</a></li>
+            {% endfor %}
+        </ul>
+    </div>
     {% if render.msg != None %}
         <p class="{% if render.is_error %}msg-error{% else %}msg-success{% endif %}">{{ render.msg }}</p>
     {% endif %}
-    <form class="anuform" action="/manage_courses/?action=Add" method="post">
-        {% csrf_token %}
-        {% with required='<img src="//style.anu.edu.au/_anu/4/images/styles/asterisk.png" alt=" required">' %}
-            <fieldset>
-                <legend>{{ action }} Course</legend>
 
-                <p>
-                    <label for="id">Course Name {{ required }}</label>
-                    <input class="text tfull" id="text" type="text" name="name" aria-required="true" required>
-                </p>
+    {% for action in actions %}
+        <div id="{{ action }}Page" hidden>
+            {% if action == 'Add' %}
+                <form class="anuform" action="/manage_courses/?action=Add" method="post">
+                    {% csrf_token %}
+                    {% with required='<img src="//style.anu.edu.au/_anu/4/images/styles/asterisk.png" alt=" required">' %}
+                        <fieldset>
+                            <legend>Add Course</legend>
 
-                <p>
-                    <label for="id">Course Code {{ required }}</label>
-                    <input class="text tfull" id="text" type="text" name="code" minlength="8" maxlength="8" size="8" aria-required="true" required>
-                </p>
+                            <p>
+                                <label for="id">Course Name {{ required }}</label>
+                                <input class="text tfull" id="text" type="text" name="name" aria-required="true" required>
+                            </p>
 
-                <p>
-                    <label for="text">Year {{ required }}</label>
-                    <input class="text tfull" id="number" type="number" name="year" min="1990" aria-required="true" required>
-                </p>
+                            <p>
+                                <label for="id">Course Code {{ required }}</label>
+                                <input class="text tfull" id="text" type="text" name="code" minlength="8" maxlength="8" size="8" aria-required="true" required>
+                            </p>
 
-                <p>
-                    <label for="text">Semester(s)</label>
-                    <select class="text tfull" name="semesters[]" size="2" multiple>
-                        <option value="semester1">Semester 1</option>
-                        <option value="semester2">Semester 2</option>
-                    </select>
-                </p>
+                            <p>
+                                <label for="text">Year {{ required }}</label>
+                                <input class="text tfull" id="number" type="number" name="year" min="1990" aria-required="true" required>
+                            </p>
 
-                 <p>
-                    <label for="text">Units {{ required }}</label>
-                     <!-- max value is chosen arbitrarily -->
-                    <input class="text tfull" id="number" type="number" name="units" min="0" step="6" aria-required="true" required>
-                </p>
+                            <p>
+                                <label for="text">Semester(s)</label>
+                                <select class="text tfull" name="semesters[]" size="2" multiple>
+                                    <option value="semester1">Semester 1</option>
+                                    <option value="semester2">Semester 2</option>
+                                </select>
+                            </p>
 
-                <p>
-                    <label for="text">Requisite Course(s)</label>
-                    <select class="text tfull" name="requisites[]" size="5" multiple>
-                        {% for course in courses %}
-                            <option value="{{ course.code }}">{{ course.code }}</option>
-                        {% endfor %}
-                    </select>
-                </p>
+                             <p>
+                                <label for="text">Units {{ required }}</label>
+                                 <!-- max value is chosen arbitrarily -->
+                                <input class="text tfull" id="number" type="number" name="units" min="0" step="6" aria-required="true" required>
+                            </p>
 
-                <p>
-                    <label for="text">Incompatible Course(s)</label>
-                    <select class="text tfull" name="incompatibles[]" size="5" multiple>
-                        {% for course in courses %}
-                            <option value="{{ course.code }}">{{ course.code }}</option>
-                        {% endfor %}
-                    </select>
-                </p>
-            </fieldset>
-        {% endwith %}
+                            <p>
+                                <label for="text">Requisite Course(s)</label>
+                                <select class="text tfull" name="requisites[]" size="5" multiple>
+                                    {% for course in courses %}
+                                        <option value="{{ course.code }}">{{ course.code }}</option>
+                                    {% endfor %}
+                                </select>
+                            </p>
 
-        <p class="text-right">
-            <input class="btn-uni-grad btn-large" type ="submit" value="{{ action }}">
-        </p>
-    </form>
-    <br />
+                            <p>
+                                <label for="text">Incompatible Course(s)</label>
+                                <select class="text tfull" name="incompatibles[]" size="5" multiple>
+                                    {% for course in courses %}
+                                        <option value="{{ course.code }}">{{ course.code }}</option>
+                                    {% endfor %}
+                                </select>
+                            </p>
+                        </fieldset>
+                    {% endwith %}
+
+                    <p class="text-right">
+                        <input class="btn-uni-grad btn-large" type ="submit" value="{{ action }}">
+                    </p>
+                </form>
+            {% elif action == 'Edit' %}
+                <p>Edit</p>
+            {% else %}
+                <p>Delete</p>
+            {% endif %}
+        </div>
+    {% endfor %}
+    {# Function to hide the previous tab while opening a new one #}
+    <script>
+        var oldLabel = "Add";
+
+        function setActive(label){
+            if(document.getElementById(label+"Link") == null)
+                label = oldLabel;
+
+            document.getElementById(oldLabel+"Link").setAttribute("class", "");
+            document.getElementById(oldLabel+"Page").style.display = "none";
+
+            document.getElementById(label+"Link").setAttribute("class", "pagetabs-select");
+            document.getElementById(label+"Page").style.display = "block";
+
+            oldLabel = label;
+        }
+
+        var openElement = (new URLSearchParams(window.location.search)).get("action");
+        setActive(openElement)
+    </script>
 {% endblock %}

--- a/cassdegrees/templates/managecourses.html
+++ b/cassdegrees/templates/managecourses.html
@@ -5,6 +5,9 @@
 {% block subtitle %}{{ action }} Courses{% endblock %}
 
 {% block content %}
+    {% if render.msg != None %}
+        <p class="{% if render.is_error %}msg-error{% else %}msg-success{% endif %}">{{ render.msg }}</p>
+    {% endif %}
     <form class="anuform" action="/manage_courses/" method="post">
         {% csrf_token %}
         {% with required='<img src="//style.anu.edu.au/_anu/4/images/styles/asterisk.png" alt=" required">' %}
@@ -32,7 +35,7 @@
 
                 <p>
                     <label for="text">Semester(s)</label>
-                    <select class="text tfull" name="semester[]" size="2" multiple>
+                    <select class="text tfull" name="semesters[]" size="2" multiple>
                         <option value="semester1">Semester 1</option>
                         <option value="semester2">Semester 2</option>
                     </select>
@@ -46,7 +49,7 @@
 
                 <p>
                     <label for="text">Requisite Course(s)</label>
-                    <select class="text tfull" name="semester[]" size="5" multiple>
+                    <select class="text tfull" name="requisites[]" size="5" multiple>
                         {% for course in courses %}
                             <option value="{{ course.code }}">{{ course.code }}</option>
                         {% endfor %}
@@ -55,7 +58,7 @@
 
                 <p>
                     <label for="text">Incompatible Course(s)</label>
-                    <select class="text tfull" name="semester[]" size="5" multiple>
+                    <select class="text tfull" name="incompatibles[]" size="5" multiple>
                         {% for course in courses %}
                             <option value="{{ course.code }}">{{ course.code }}</option>
                         {% endfor %}

--- a/cassdegrees/ui/urls.py
+++ b/cassdegrees/ui/urls.py
@@ -15,11 +15,12 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
-from .views import index, sampleform, create_subplan, planList
+from .views import index, sampleform, create_subplan, planList, manage_courses
 
 urlpatterns = [
     path('', index),
     path('sampleform/', sampleform),
     path('create_subplan/', create_subplan),
     path('list/', planList),
+    path('manage_courses/', manage_courses)
 ]

--- a/cassdegrees/ui/views.py
+++ b/cassdegrees/ui/views.py
@@ -102,6 +102,7 @@ def create_subplan(request):
 # inspired by the samepleform function created by Daniel Jang
 def manage_courses(request):
     # Reads the 'action' attribute from the url (i.e. manage/?action=Add) and determines the submission method
+    actions = ['Add', 'Edit', 'Delete']
     action = request.GET.get('action', 'Add')
 
     courses = requests.get(request.build_absolute_uri('/api/model/course/?format=json')).json()
@@ -172,4 +173,4 @@ def manage_courses(request):
                 render_properties['msg'] = "Failed to delete course. An unknown error has occurred. Please try again."
 
     return render(request, 'managecourses.html',
-                  context={'action': action, 'courses': courses, 'render': render_properties})
+                  context={'action': action, 'courses': courses, 'render': render_properties, 'actions': actions})

--- a/cassdegrees/ui/views.py
+++ b/cassdegrees/ui/views.py
@@ -169,8 +169,7 @@ def manage_courses(request):
                 render_properties['msg'] = 'Course successfully deleted!'
             else:
                 render_properties['is_error'] = True
-                render_properties['msg'] = \
-                    "Failed to delete course. An unknown error has occurred. Please try again."
+                render_properties['msg'] = "Failed to delete course. An unknown error has occurred. Please try again."
 
     return render(request, 'managecourses.html',
                   context={'action': action, 'courses': courses, 'render': render_properties})

--- a/cassdegrees/ui/views.py
+++ b/cassdegrees/ui/views.py
@@ -20,6 +20,7 @@ def index(request):
 
     return render(request, 'index.html', context={'buttons': buttons})
 
+
 def planList(request):
     """ Generates a table based on the JSON objects stored in 'data'
 
@@ -35,6 +36,7 @@ def planList(request):
     course = requests.get(request.build_absolute_uri('/api/model/course/?format=json')).json()
 
     return render(request, 'list.html', context={'data': {'Degree': degree, 'Subplan': subplan, 'Course': course}})
+
 
 # I went through this tutorial to create the form html file and this view:
 # https://docs.djangoproject.com/en/2.2/topics/forms/
@@ -101,16 +103,9 @@ def create_subplan(request):
 def manage_courses(request):
     # Reads the 'action' attribute from the url (i.e. manage/?action=Add) and determines the submission method
     action = request.GET.get('action', 'Add')
-    if   action == 'Add'   : method = 'post'
-    elif action == 'Edit'  : method = 'patch'
-    elif action == 'Delete': method = 'delete'
-    else:
-         action =  'Add'   ; method = 'post'
-
-    action = 'Add'; method = 'post' # TODO Remove once other methods are implemented
 
     courses = requests.get(request.build_absolute_uri('/api/model/course/?format=json')).json()
-    courses = [{'code': course} for course in  set([x['code'] for x in courses])]
+    courses = [{'code': course} for course in set([x['code'] for x in courses])]
     # If POST request, redirect the received information to the backend:
     render_properties = {
         'msg': None,
@@ -120,11 +115,9 @@ def manage_courses(request):
         # hard coded url; only temporary
         model_api_url = request.build_absolute_uri('/api/model/course/')
         post_data = request.POST
-        actual_request = post_data.get('_method')
+        # actual_request = post_data.get('_method')
 
-        # This method of transferring data to the API was inspired by:
-        # https://stackoverflow.com/questions/11663945/calling-a-rest-api-from-django-view
-        if actual_request == "post":
+        if action == 'Add':
             # Create a python dictionary with exactly the same fields as the model (in this case, CourseModel)
             offered_sems = post_data.getlist('semesters[]')
             course_instance = \
@@ -147,8 +140,9 @@ def manage_courses(request):
                     render_properties['msg'] = "The course you are trying to create already exists!"
                 else:
                     render_properties['msg'] = "Unknown error while submitting document. Please try again."
+
         # to be implemented, currently has the sample model code
-        elif actual_request == "patch":
+        elif action == 'Edit':
             id_to_edit = post_data.get('id')
             # Patch requests (editing an already existing resource only requires fields that are changed
             course_instance = \
@@ -164,8 +158,9 @@ def manage_courses(request):
                 render_properties['is_error'] = True
                 render_properties['msg'] = \
                     "Failed to edit course information (unknown error). Please try again."
+
         # to be implemented, currently has the sample model code
-        else:
+        elif action == 'Delete':
             id_to_delete = post_data.get('id')
 
             rest_api = requests.delete(model_api_url + id_to_delete + '/')
@@ -176,5 +171,6 @@ def manage_courses(request):
                 render_properties['is_error'] = True
                 render_properties['msg'] = \
                     "Failed to delete course. An unknown error has occurred. Please try again."
+
     return render(request, 'managecourses.html',
-                      context={'action': action, 'method': method, 'courses': courses, 'render': render_properties})
+                  context={'action': action, 'courses': courses, 'render': render_properties})

--- a/cassdegrees/ui/views.py
+++ b/cassdegrees/ui/views.py
@@ -97,8 +97,18 @@ def create_subplan(request):
     return render(request, 'createsubplan.html')
 
 
-# inspired by the samepleform function creatd by Daniel Jang
+# inspired by the samepleform function created by Daniel Jang
 def manage_courses(request):
+    # Reads the 'action' attribute from the url (i.e. manage/?action=Add) and determines the submission method
+    action = request.GET.get('action', 'Add')
+    if   action == 'Add'   : method = 'post'
+    elif action == 'Edit'  : method = 'patch'
+    elif action == 'Delete': method = 'delete'
+    else:
+         action =  'Add'   ; method = 'post'
+
+    action = 'Add'; method = 'post' # TODO Remove once other methods are implemented
+
     courses = requests.get(request.build_absolute_uri('/api/model/course/?format=json')).json()
     courses = [{'code': course} for course in  set([x['code'] for x in courses])]
     # If POST request, redirect the received information to the backend:
@@ -158,4 +168,4 @@ def manage_courses(request):
             else:
                 return HttpResponse('Failed to delete record!')
     else:
-        return render(request, 'managecourses.html', context={'courses': courses})
+        return render(request, 'managecourses.html', context={'action': action, 'method': method, 'courses': courses})

--- a/cassdegrees/ui/views.py
+++ b/cassdegrees/ui/views.py
@@ -113,7 +113,6 @@ def manage_courses(request):
         'is_error': False
     }
     if request.method == 'POST':
-        # hard coded url; only temporary
         model_api_url = request.build_absolute_uri('/api/model/course/')
         post_data = request.POST
         # actual_request = post_data.get('_method')

--- a/cassdegrees/ui/views.py
+++ b/cassdegrees/ui/views.py
@@ -97,7 +97,7 @@ def create_subplan(request):
     return render(request, 'createsubplan.html')
 
 
-# inspired by the samepleform function creatd by Daniel
+# inspired by the samepleform function creatd by Daniel Jang
 def manage_courses(request):
     courses = requests.get(request.build_absolute_uri('/api/model/course/?format=json')).json()
     # If POST request, redirect the received information to the backend:

--- a/cassdegrees/ui/views.py
+++ b/cassdegrees/ui/views.py
@@ -159,9 +159,11 @@ def manage_courses(request):
             rest_api = requests.patch(model_api_url + id_to_edit + '/', data=course_instance)
 
             if rest_api.status_code == 200:
-                return HttpResponse('Record successfully edited!')
+                render_properties['msg'] = 'Course information successfully modified!'
             else:
-                return HttpResponse('Failed to edit record!')
+                render_properties['is_error'] = True
+                render_properties['msg'] = \
+                    "Failed to edit course information (unknown error). Please try again."
         # to be implemented, currently has the sample model code
         else:
             id_to_delete = post_data.get('id')
@@ -169,8 +171,10 @@ def manage_courses(request):
             rest_api = requests.delete(model_api_url + id_to_delete + '/')
 
             if rest_api.status_code == 204:
-                return HttpResponse('Record successfully deleted!')
+                render_properties['msg'] = 'Course successfully deleted!'
             else:
-                return HttpResponse('Failed to delete record!')
+                render_properties['is_error'] = True
+                render_properties['msg'] = \
+                    "Failed to delete course. An unknown error has occurred. Please try again."
     return render(request, 'managecourses.html',
                       context={'action': action, 'method': method, 'courses': courses, 'render': render_properties})

--- a/cassdegrees/ui/views.py
+++ b/cassdegrees/ui/views.py
@@ -126,7 +126,7 @@ def manage_courses(request):
         # https://stackoverflow.com/questions/11663945/calling-a-rest-api-from-django-view
         if actual_request == "post":
             # Create a python dictionary with exactly the same fields as the model (in this case, CourseModel)
-            offered_sems = post_data.getlist('semester[]')
+            offered_sems = post_data.getlist('semesters[]')
             course_instance = \
                 {
                     'code': post_data.get('code'),

--- a/cassdegrees/ui/views.py
+++ b/cassdegrees/ui/views.py
@@ -100,6 +100,7 @@ def create_subplan(request):
 # inspired by the samepleform function creatd by Daniel Jang
 def manage_courses(request):
     courses = requests.get(request.build_absolute_uri('/api/model/course/?format=json')).json()
+    courses = [{'code': course} for course in  set([x['code'] for x in courses])]
     # If POST request, redirect the received information to the backend:
     if request.method == 'POST':
         # hard coded url; only temporary

--- a/cassdegrees/ui/views.py
+++ b/cassdegrees/ui/views.py
@@ -156,8 +156,7 @@ def manage_courses(request):
                 render_properties['msg'] = 'Course information successfully modified!'
             else:
                 render_properties['is_error'] = True
-                render_properties['msg'] = \
-                    "Failed to edit course information (unknown error). Please try again."
+                render_properties['msg'] = "Failed to edit course information (unknown error). Please try again."
 
         # to be implemented, currently has the sample model code
         elif action == 'Delete':
@@ -171,5 +170,5 @@ def manage_courses(request):
                 render_properties['is_error'] = True
                 render_properties['msg'] = "Failed to delete course. An unknown error has occurred. Please try again."
 
-    return render(request, 'managecourses.html',
-                  context={'action': action, 'courses': courses, 'render': render_properties, 'actions': actions})
+    return render(request, 'managecourses.html', context={'action': action, 'courses': courses,
+                                                          'render': render_properties, 'actions': actions})

--- a/cassdegrees/ui/views.py
+++ b/cassdegrees/ui/views.py
@@ -99,6 +99,7 @@ def create_subplan(request):
 
 # inspired by the samepleform function creatd by Daniel
 def manage_courses(request):
+    courses = requests.get(request.build_absolute_uri('/api/model/course/?format=json')).json()
     # If POST request, redirect the received information to the backend:
     if request.method == 'POST':
         # hard coded url; only temporary
@@ -156,4 +157,4 @@ def manage_courses(request):
             else:
                 return HttpResponse('Failed to delete record!')
     else:
-        return render(request, 'managecourses.html')
+        return render(request, 'managecourses.html', context={'courses': courses})

--- a/cassdegrees/ui/views.py
+++ b/cassdegrees/ui/views.py
@@ -103,7 +103,7 @@ def manage_courses(request):
     # If POST request, redirect the received information to the backend:
     if request.method == 'POST':
         # hard coded url; only temporary
-        model_api_url = 'http://127.0.0.1:8000/api/model/course/'
+        model_api_url = request.build_absolute_uri('/api/model/course/')
         post_data = request.POST
         actual_request = post_data.get('_method')
 


### PR DESCRIPTION
Completed Issue #27 (Course Creation and Specification (5)).

Can access this page at `http://127.0.0.1:8000/manage_courses/`. It displays a form in 3 sections (for this user story, only 'Add Course' has been implemented).

**The acceptance criterion:** 
> If the requisite/incompatible courses aren’t in the system after the user saves the new course, the user is prompted to fill in the course details for the requisite/incompatible course

has been satisfied by listing all of the courses in the database instead of giving the option to the user to type the courses manually.
> Notify the user if they are attempting to add an existing course

was implemented with a basic HttpResponse.

**Small things:**
1. I was not sure how to concatenate 3 strings together hence `{{ course.code }}_{{ course.year }}` appeared 4 times in `managecourses.html` (solved)
2. Creation of courses can be tested by checking `http://127.0.0.1:8000/list/?view=Course`
3. Screenshot of UI  (outdated, check below for a more updated screenshot)
![image](https://user-images.githubusercontent.com/24206502/56049550-15431300-5d8d-11e9-988d-e3588fb17215.png)
