### PR TITLE
Base Code for Course Edit and Delete

### DIFF
--- a/cassdegrees/templates/list.html
+++ b/cassdegrees/templates/list.html
@@ -35,7 +35,7 @@
             <form method="post">
                 {% csrf_token %}
                 {# Allow manage_courses() function to behave appropriately based on origin of request. The post request can either come from list.html or managecourses.html #}
-                <input type="hidden" id="request_origin" name="request_origin" value="list.html">
+                <input type="hidden" id="perform_function" name="perform_function" value="retrieve view from selected">
 
                 <table class="fullwidth tbl-cell-bdr">
                     {# Add title row based on what was in the dictionary #}

--- a/cassdegrees/templates/list.html
+++ b/cassdegrees/templates/list.html
@@ -32,35 +32,57 @@
     {# Generates table instances for each table in 'data', as well as the appropriate settings to keep it hidden #}
     {% for title, content in data.items %}
         <div id="{{ title }}Table" hidden>
-            <table class="fullwidth tbl-cell-bdr">
-                {# Add title row based on what was in the dictionary #}
-                <tr>
-                    {% for key in content.0 %}
-                        {% if key != "id" %}
-                            <th>{{ key }}</th>
-                        {% else %}
-                            <th>{{ title }}</th>
-                        {% endif %}
-                    {% endfor %}
-                </tr>
-                {# Add rows containing the contents of each json data instance #}
-                {% for row in content %}
+            <form method="post">
+                {% csrf_token %}
+                {# Allow manage_courses() function to behave appropriately based on origin of request. The post request can either come from list.html or managecourses.html #}
+                <input type="hidden" id="request_origin" name="request_origin" value="list.html">
+
+                <table class="fullwidth tbl-cell-bdr">
+                    {# Add title row based on what was in the dictionary #}
                     <tr>
-                        {% for key, item in row.items %}
-                            <td>
-                                {# If the item is in the ID column, generate a link to it instead #}
-                                {% if key != "id" %}
-                                    {{ item }}
-                                {% else %}
-                                    (<a href="/api/model/{{ title.lower }}/{{ item }}/">View</a>)
-                                {% endif %}
-                            </td>
+                        {% for key in content.0 %}
+                            {% if key != "id" %}
+                                <th>{{ key }}</th>
+                            {% else %}
+                                <th>Select</th>
+                                <th>{{ title }}</th>
+                            {% endif %}
                         {% endfor %}
                     </tr>
-                {% endfor %}
-            </table>
-            {# If there is no data available, notify the user #}
-            {% if not content %}<p>No {{ title }}s to display</p>{% endif %}
+                    {# Add rows containing the contents of each json data instance #}
+                    {% for row in content %}
+                        <tr>
+                            {% for key, item in row.items %}
+
+                                    {# If the item is in the ID column, generate a link to it instead #}
+                                    {% if key != "id" %}
+                                        <td>{{ item }}</td>
+                                    {% else %}
+                                        <td><input title="Select" type="radio" name="id" value="{{ item }}"  /></td>
+                                        <td>(<a href="/api/model/{{ title.lower }}/{{ item }}/">View</a>)</td>
+                                    {% endif %}
+
+                            {% endfor %}
+                        </tr>
+                    {% endfor %}
+                </table>
+                {# If there is no data available, notify the user #}
+                {% if not content %}
+                    <p>No {{ title }}s to display</p>
+                {% else %}
+                    <div class="right">
+                        <p class="left marginright">
+                           <input class="btn-uni-grad btn-large" type ="submit" formaction="/{% if title == 'Degree' %}{% elif title == 'Subplan' %}{% elif title == 'Course' %}manage_courses{% endif %}/?action=Add" value="Add a {{ title }}">
+                        </p>
+                        <p class="left marginright">
+                           <input class="btn-uni-grad btn-large" type ="submit" formaction="/{% if title == 'Degree' %}{% elif title == 'Subplan' %}{% elif title == 'Course' %}manage_courses{% endif %}/?action=Edit" value="Edit Selected">
+                        </p>
+                        <p class="right">
+                           <input class="btn-uni-grad btn-large" type ="submit" formaction="/{% if title == 'Degree' %}{% elif title == 'Subplan' %}{% elif title == 'Course' %}manage_courses{% endif %}/?action=Delete" value="Delete Selected">
+                        </p>
+                   </div>
+                </form>
+            {% endif %}
         </div>
     {% endfor %}
 

--- a/cassdegrees/templates/list.html
+++ b/cassdegrees/templates/list.html
@@ -81,8 +81,8 @@
                            <input class="btn-uni-grad btn-large" type ="submit" formaction="/{% if title == 'Degree' %}{% elif title == 'Subplan' %}{% elif title == 'Course' %}manage_courses{% endif %}/?action=Delete" value="Delete Selected">
                         </p>
                    </div>
-                </form>
-            {% endif %}
+                {% endif %}
+            </form>
         </div>
     {% endfor %}
 

--- a/cassdegrees/templates/managecourses.html
+++ b/cassdegrees/templates/managecourses.html
@@ -13,7 +13,7 @@
         <form class="anuform" action="/manage_courses/?action={{ action }}" method="post">
             {% csrf_token %}
             {# Allow manage_courses() function to behave appropriately based on origin of request. The post request can either come from list.html or managecourses.html #}
-            <input type="hidden" id="request_origin" name="request_origin" value="managecourses.html">
+            <input type="hidden" id="perform_function" name="perform_function" value="Add/Edit data to db">
             <input type="hidden" id="id" name="id" value="{{ render.edit_course_info.id }}">
             {% with required='<img src="//style.anu.edu.au/_anu/4/images/styles/asterisk.png" alt=" required">' %}
                 <fieldset>

--- a/cassdegrees/templates/managecourses.html
+++ b/cassdegrees/templates/managecourses.html
@@ -140,7 +140,6 @@
         }
 
         let tab = (new URLSearchParams(window.location.search)).get("action");
-        // when ?action=Modify, it gets sent as ?action=modify for some reason hence the fix below
         console.log(tab);
         let openElement = tab != null ? tab.charAt(0).toUpperCase() + tab.slice(1) : "";
         setActive(openElement);

--- a/cassdegrees/templates/managecourses.html
+++ b/cassdegrees/templates/managecourses.html
@@ -80,15 +80,23 @@
                     </p>
                 </form>
             {% else %} {# action == modify #}
-                <table class="fullwidth tbl-cell-bdr">
+                <div class=" nopadbottom tools-college fullwidth">
+                    <ul class="left">
+                        <li><a title="Tick one or more checkboxes" href="#">Mass Edit</a></li>
+                        <li><a title="Tick one or more checkboxes" href="#">Mass Delete</a></li>
+                    </ul>
+                </div>
+                <table class="fullwidth tbl-row-bdr noborder anu-long-area">
                     {# Add title row based on what was in the dictionary #}
-                    <tr>
+                    <tr class="anu-sticky-header">
                         {% for key in courses.0 %}
                             {% if key != "id" %}
                                 <th>{{ key }}</th>
+                            {% else %}
+                                <th><input title="Select all" type="checkbox" name="" value="" /></th>
                             {% endif %}
                         {% endfor %}
-                        <th>Options</th>
+                        <th>Actions</th>
                     </tr>
                     {# Add rows containing the contens of each json data instance #}
                     {% for row in courses %}
@@ -96,23 +104,17 @@
                             {% for key, item in row.items %}
                                 {% if key != "id" %}
                                     <td>{{ item }}</td>
+                                {% else %}
+                                    <td><input title="Select" type="checkbox" name="" value=""  /></td>
                                 {% endif %}
                             {% endfor %}
                             <td>
-                                <ul class="iconlist iconlist_h">
+                                <ul class="iconlist iconlist_h right">
                                     <li>
-                                        {# temporary href link #}
-                                         <a title="Edit" href="http://www.google.com">
-                                             {# temporary image; contact ANU styling if you want to use #}
-                                             <img src="//style.anu.edu.au/_anu/images/icons/web/tools.png" onmouseover="this.src='//style.anu.edu.au/_anu/images/icons/web/tools-over.png'" onmouseout="this.src='//style.anu.edu.au/_anu/images/icons/web/tools.png'" alt="tools icon">
-                                         </a>
+                                        <a class="nopad" href="">Edit</a>
                                     </li>
                                     <li>
-                                        {# temporary href link #}
-                                        <a title="Delete" href="http://www.google.com">
-                                             {# temporary as ANU styling has no delete icon; contact ANU styling #}
-                                            <img src="//style.anu.edu.au/_anu/images/icons/web/thumb-down.png" onmouseover="this.src='//style.anu.edu.au/_anu/images/icons/web/thumb-down-over.png'" onmouseout="this.src='//style.anu.edu.au/_anu/images/icons/web/thumb-down.png'" alt="thumb-down icon">
-                                        </a>
+                                        <a class="nopad" href="">Delete</a>
                                     </li>
                                 </ul>
                             </td>

--- a/cassdegrees/templates/managecourses.html
+++ b/cassdegrees/templates/managecourses.html
@@ -5,6 +5,9 @@
 {% block subtitle %}Manage Courses{% endblock %}
 
 {% block content %}
+    {% if render.msg != None %}
+        <p class="{% if render.is_error %}msg-error{% else %}msg-success{% endif %}">{{ render.msg }}</p>
+    {% endif %}
     {# Generates the tabs based on the keys #}
     <div class="pagetabs-nav">
         <ul>
@@ -13,9 +16,6 @@
             {% endfor %}
         </ul>
     </div>
-    {% if render.msg != None %}
-        <p class="{% if render.is_error %}msg-error{% else %}msg-success{% endif %}">{{ render.msg }}</p>
-    {% endif %}
 
     {% for action in actions %}
         <div id="{{ action }}Page" hidden>
@@ -80,52 +80,51 @@
                     </p>
                 </form>
             {% else %} {# action == modify #}
-                <div class=" nopadbottom tools-college fullwidth">
-                    <ul class="left">
-                        <li><a title="Tick one or more checkboxes" href="#">Mass Edit</a></li>
-                        <li><a title="Tick one or more checkboxes" href="#">Mass Delete</a></li>
-                    </ul>
-                </div>
-                <table class="fullwidth tbl-row-bdr noborder anu-long-area">
-                    {# Add title row based on what was in the dictionary #}
-                    <tr class="anu-sticky-header">
-                        {% for key in courses.0 %}
-                            {% if key != "id" %}
-                                <th>{{ key }}</th>
-                            {% else %}
-                                <th><input title="Select all" type="checkbox" name="" value="" /></th>
-                            {% endif %}
-                        {% endfor %}
-                        <th>Actions</th>
-                    </tr>
-                    {# Add rows containing the contens of each json data instance #}
-                    {% for row in courses %}
-                        <tr>
-                            {% for key, item in row.items %}
-                                {% if key != "id" %}
-                                    <td>{{ item }}</td>
-                                {% else %}
-                                    <td><input title="Select" type="checkbox" name="" value=""  /></td>
-                                {% endif %}
+               <form method="post">
+                   {% csrf_token %}
+                   <table class="fullwidth tbl-row-bdr noborder anu-long-area">
+                       <tbody>
+                            {# Add title row based on what was in the dictionary #}
+                            <tr class="anu-sticky-header">
+                                {% for key in courses.0 %}
+                                    {% if key != "id" %}
+                                        <th>{{ key }}</th>
+                                    {% else %}
+                                        <th>Select</th>
+                                    {% endif %}
+                                {% endfor %}
+                            </tr>
+                            {# Add rows containing the contens of each json data instance #}
+                            {% for row in courses %}
+                                <tr>
+                                    {% for key, item in row.items %}
+                                        {% if key != "id" %}
+                                            <td>{{ item }}</td>
+                                        {% else %}
+                                            <td><input title="Select" type="radio" name="id" value="{{ item }}"  /></td>
+                                        {% endif %}
+                                    {% endfor %}
+                                </tr>
                             {% endfor %}
-                            <td>
-                                <ul class="iconlist iconlist_h right">
-                                    <li>
-                                        <a class="nopad" href="">Edit</a>
-                                    </li>
-                                    <li>
-                                        <a class="nopad" href="">Delete</a>
-                                    </li>
-                                </ul>
-                            </td>
-                        </tr>
-                    {% endfor %}
-                </table>
+                       </tbody>
+                   </table>
+                   <div class="right">
+                       <p class="left marginright">
+                           <input class="btn-uni-grad btn-large" type ="submit" formaction="/manage_courses/?action=Edit" value="Edit Selected">
+                       </p>
+                       <p class="right">
+                           <input class="btn-uni-grad btn-large" type ="submit" formaction="/manage_courses/?action=Delete" value="Delete Selected">
+                       </p>
+                   </div>
+               </form>
             {% endif %}
         </div>
     {% endfor %}
     {# Function to hide the previous tab while opening a new one #}
     <script>
+
+
+
         var oldLabel = "Add";
 
         function setActive(label){

--- a/cassdegrees/templates/managecourses.html
+++ b/cassdegrees/templates/managecourses.html
@@ -79,10 +79,46 @@
                         <input class="btn-uni-grad btn-large" type ="submit" value="{{ action }}">
                     </p>
                 </form>
-            {% elif action == 'Edit' %}
-                <p>Edit</p>
-            {% else %}
-                <p>Delete</p>
+            {% else %} {# action == modify #}
+                <table class="fullwidth tbl-cell-bdr">
+                    {# Add title row based on what was in the dictionary #}
+                    <tr>
+                        {% for key in courses.0 %}
+                            {% if key != "id" %}
+                                <th>{{ key }}</th>
+                            {% endif %}
+                        {% endfor %}
+                        <th>Options</th>
+                    </tr>
+                    {# Add rows containing the contens of each json data instance #}
+                    {% for row in courses %}
+                        <tr>
+                            {% for key, item in row.items %}
+                                {% if key != "id" %}
+                                    <td>{{ item }}</td>
+                                {% endif %}
+                            {% endfor %}
+                            <td>
+                                <ul class="iconlist iconlist_h">
+                                    <li>
+                                        {# temporary href link #}
+                                         <a title="Edit" href="http://www.google.com">
+                                             {# temporary image; contact ANU styling if you want to use #}
+                                             <img src="//style.anu.edu.au/_anu/images/icons/web/tools.png" onmouseover="this.src='//style.anu.edu.au/_anu/images/icons/web/tools-over.png'" onmouseout="this.src='//style.anu.edu.au/_anu/images/icons/web/tools.png'" alt="tools icon">
+                                         </a>
+                                    </li>
+                                    <li>
+                                        {# temporary href link #}
+                                        <a title="Delete" href="http://www.google.com">
+                                             {# temporary as ANU styling has no delete icon; contact ANU styling #}
+                                            <img src="//style.anu.edu.au/_anu/images/icons/web/thumb-down.png" onmouseover="this.src='//style.anu.edu.au/_anu/images/icons/web/thumb-down-over.png'" onmouseout="this.src='//style.anu.edu.au/_anu/images/icons/web/thumb-down.png'" alt="thumb-down icon">
+                                        </a>
+                                    </li>
+                                </ul>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </table>
             {% endif %}
         </div>
     {% endfor %}
@@ -103,7 +139,10 @@
             oldLabel = label;
         }
 
-        var openElement = (new URLSearchParams(window.location.search)).get("action");
-        setActive(openElement)
+        let tab = (new URLSearchParams(window.location.search)).get("action");
+        // when ?action=Modify, it gets sent as ?action=modify for some reason hence the fix below
+        console.log(tab);
+        let openElement = tab != null ? tab.charAt(0).toUpperCase() + tab.slice(1) : "";
+        setActive(openElement);
     </script>
 {% endblock %}

--- a/cassdegrees/templates/managecourses.html
+++ b/cassdegrees/templates/managecourses.html
@@ -1,148 +1,76 @@
 {% extends "base.html" %}
 
-{% block page-title %}Manage Courses{% endblock %}
+{% block page-title %}{{ action }} Course{% endblock %}
 
-{% block subtitle %}Manage Courses{% endblock %}
+{% block subtitle %}{{ action }} Course{% endblock %}
 
 {% block content %}
     {% if render.msg != None %}
         <p class="{% if render.is_error %}msg-error{% else %}msg-success{% endif %}">{{ render.msg }}</p>
     {% endif %}
-    {# Generates the tabs based on the keys #}
-    <div class="pagetabs-nav">
-        <ul>
-            {% for title in actions %}
-                <li><a onClick='setActive("{{ title }}")' id="{{ title }}Link">{{ title }}</a></li>
-            {% endfor %}
-        </ul>
-    </div>
 
-    {% for action in actions %}
-        <div id="{{ action }}Page" hidden>
-            {% if action == 'Add' %}
-                <form class="anuform" action="/manage_courses/?action=Add" method="post">
-                    {% csrf_token %}
-                    {% with required='<img src="//style.anu.edu.au/_anu/4/images/styles/asterisk.png" alt=" required">' %}
-                        <fieldset>
-                            <legend>Add Course</legend>
+    <div id="{{ action }}Page" {% if action == 'Delete' or render.hide_form %}hidden{% endif %}>
+        <form class="anuform" action="/manage_courses/?action={{ action }}" method="post">
+            {% csrf_token %}
+            {# Allow manage_courses() function to behave appropriately based on origin of request. The post request can either come from list.html or managecourses.html #}
+            <input type="hidden" id="request_origin" name="request_origin" value="managecourses.html">
+            <input type="hidden" id="id" name="id" value="{{ render.edit_course_info.id }}">
+            {% with required='<img src="//style.anu.edu.au/_anu/4/images/styles/asterisk.png" alt=" required">' %}
+                <fieldset>
+                    <legend>{{ action }} Course</legend>
 
-                            <p>
-                                <label for="id">Course Name {{ required }}</label>
-                                <input class="text tfull" id="text" type="text" name="name" aria-required="true" required>
-                            </p>
-
-                            <p>
-                                <label for="id">Course Code {{ required }}</label>
-                                <input class="text tfull" id="text" type="text" name="code" minlength="8" maxlength="8" size="8" aria-required="true" required>
-                            </p>
-
-                            <p>
-                                <label for="text">Year {{ required }}</label>
-                                <input class="text tfull" id="number" type="number" name="year" min="1990" aria-required="true" required>
-                            </p>
-
-                            <p>
-                                <label for="text">Semester(s)</label>
-                                <select class="text tfull" name="semesters[]" size="2" multiple>
-                                    <option value="semester1">Semester 1</option>
-                                    <option value="semester2">Semester 2</option>
-                                </select>
-                            </p>
-
-                             <p>
-                                <label for="text">Units {{ required }}</label>
-                                 <!-- max value is chosen arbitrarily -->
-                                <input class="text tfull" id="number" type="number" name="units" min="0" step="6" aria-required="true" required>
-                            </p>
-
-                            <p>
-                                <label for="text">Requisite Course(s)</label>
-                                <select class="text tfull" name="requisites[]" size="5" multiple>
-                                    {% for course in courses %}
-                                        <option value="{{ course.code }}">{{ course.code }}</option>
-                                    {% endfor %}
-                                </select>
-                            </p>
-
-                            <p>
-                                <label for="text">Incompatible Course(s)</label>
-                                <select class="text tfull" name="incompatibles[]" size="5" multiple>
-                                    {% for course in courses %}
-                                        <option value="{{ course.code }}">{{ course.code }}</option>
-                                    {% endfor %}
-                                </select>
-                            </p>
-                        </fieldset>
-                    {% endwith %}
-
-                    <p class="text-right">
-                        <input class="btn-uni-grad btn-large" type ="submit" value="{{ action }}">
+                    <p>
+                        <label for="id">Course Name {{ required }}</label>
+                        <input class="text tfull" id="text" type="text" name="name" aria-required="true" required {% if action == 'Edit' %}value="{{ render.edit_course_info.name }}"{% endif %}>
                     </p>
-                </form>
-            {% else %} {# action == modify #}
-               <form method="post">
-                   {% csrf_token %}
-                   <table class="fullwidth tbl-row-bdr noborder anu-long-area">
-                       <tbody>
-                            {# Add title row based on what was in the dictionary #}
-                            <tr class="anu-sticky-header">
-                                {% for key in courses.0 %}
-                                    {% if key != "id" %}
-                                        <th>{{ key }}</th>
-                                    {% else %}
-                                        <th>Select</th>
-                                    {% endif %}
-                                {% endfor %}
-                            </tr>
-                            {# Add rows containing the contens of each json data instance #}
-                            {% for row in courses %}
-                                <tr>
-                                    {% for key, item in row.items %}
-                                        {% if key != "id" %}
-                                            <td>{{ item }}</td>
-                                        {% else %}
-                                            <td><input title="Select" type="radio" name="id" value="{{ item }}"  /></td>
-                                        {% endif %}
-                                    {% endfor %}
-                                </tr>
+
+                    <p>
+                        <label for="id">Course Code {{ required }}</label>
+                        <input class="text tfull" id="text" type="text" name="code" minlength="8" maxlength="8" size="8" aria-required="true" required {% if action == 'Edit' %}value="{{ render.edit_course_info.code }}"{% endif %}>
+                    </p>
+
+                    <p>
+                        <label for="text">Year {{ required }}</label>
+                        <input class="text tfull" id="number" type="number" name="year" min="1990" aria-required="true" required {% if action == 'Edit' %}value="{{ render.edit_course_info.year }}"{% endif %}>
+                    </p>
+
+                    <p>
+                        <label for="text">Semester(s)</label>
+                        <select class="text tfull" name="semesters[]" size="2" multiple>
+                            <option value="semester1" {% if action == 'Edit' %}{% if render.edit_course_info.offeredSem1 %}selected{% endif %}{% endif %}>Semester 1</option>
+                            <option value="semester2" {% if action == 'Edit' %}{% if render.edit_course_info.offeredSem2 %}selected{% endif %}{% endif %}>Semester 2</option>
+                        </select>
+                    </p>
+
+                     <p>
+                        <label for="text">Units {{ required }}</label>
+                         <!-- max value is chosen arbitrarily -->
+                        <input class="text tfull" id="number" type="number" name="units" min="0" step="6" aria-required="true" required {% if action == 'Edit' %}value="{{ render.edit_course_info.units }}"{% endif %}>
+                    </p>
+
+                    <p>
+                        <label for="text">Requisite Course(s)</label>
+                        <select class="text tfull" name="requisites[]" size="5" multiple>
+                            {% for course in courses %}
+                                <option value="{{ course.code }}">{{ course.code }}</option>
                             {% endfor %}
-                       </tbody>
-                   </table>
-                   <div class="right">
-                       <p class="left marginright">
-                           <input class="btn-uni-grad btn-large" type ="submit" formaction="/manage_courses/?action=Edit" value="Edit Selected">
-                       </p>
-                       <p class="right">
-                           <input class="btn-uni-grad btn-large" type ="submit" formaction="/manage_courses/?action=Delete" value="Delete Selected">
-                       </p>
-                   </div>
-               </form>
-            {% endif %}
-        </div>
-    {% endfor %}
-    {# Function to hide the previous tab while opening a new one #}
-    <script>
+                        </select>
+                    </p>
 
+                    <p>
+                        <label for="text">Incompatible Course(s)</label>
+                        <select class="text tfull" name="incompatibles[]" size="5" multiple>
+                            {% for course in courses %}
+                                <option value="{{ course.code }}">{{ course.code }}</option>
+                            {% endfor %}
+                        </select>
+                    </p>
+                </fieldset>
+            {% endwith %}
 
-
-        var oldLabel = "Add";
-
-        function setActive(label){
-            if(document.getElementById(label+"Link") == null)
-                label = oldLabel;
-
-            document.getElementById(oldLabel+"Link").setAttribute("class", "");
-            document.getElementById(oldLabel+"Page").style.display = "none";
-
-            document.getElementById(label+"Link").setAttribute("class", "pagetabs-select");
-            document.getElementById(label+"Page").style.display = "block";
-
-            oldLabel = label;
-        }
-
-        let tab = (new URLSearchParams(window.location.search)).get("action");
-        console.log(tab);
-        let openElement = tab != null ? tab.charAt(0).toUpperCase() + tab.slice(1) : "";
-        setActive(openElement);
-    </script>
+            <p class="text-right">
+                <input class="btn-uni-grad btn-large" type ="submit" value="{{ action }}">
+            </p>
+        </form>
+    </div>
 {% endblock %}

--- a/cassdegrees/ui/views.py
+++ b/cassdegrees/ui/views.py
@@ -233,7 +233,6 @@ def manage_courses(request):
         # course information has been requested by user to be either added or edited.
         if request_origin == 'managecourses.html':
             if action == 'Add':
-                # courses = [{'code': course} for course in set([x['code'] for x in courses])]
                 # Create a python dictionary with exactly the same fields as the model (in this case, CourseModel)
                 offered_sems = post_data.getlist('semesters[]')
                 course_instance = \
@@ -307,7 +306,7 @@ def manage_courses(request):
 
                 if rest_api is None:
                     render_properties['is_error'] = True
-                    render_properties['msg'] = 'Choose a course to delete.'
+                    render_properties['msg'] = 'Please select a course to delete!'
                 else:
                     if rest_api.status_code == 204:
                         render_properties['msg'] = 'Course successfully deleted!'

--- a/cassdegrees/ui/views.py
+++ b/cassdegrees/ui/views.py
@@ -102,11 +102,10 @@ def create_subplan(request):
 # inspired by the samepleform function created by Daniel Jang
 def manage_courses(request):
     # Reads the 'action' attribute from the url (i.e. manage/?action=Add) and determines the submission method
-    actions = ['Add', 'Edit', 'Delete']
+    actions = ['Add', 'Modify'] # used to make tabs in managecourses.html
     action = request.GET.get('action', 'Add')
 
     courses = requests.get(request.build_absolute_uri('/api/model/course/?format=json')).json()
-    courses = [{'code': course} for course in set([x['code'] for x in courses])]
     # If POST request, redirect the received information to the backend:
     render_properties = {
         'msg': None,
@@ -118,6 +117,7 @@ def manage_courses(request):
         # actual_request = post_data.get('_method')
 
         if action == 'Add':
+            courses = [{'code': course} for course in set([x['code'] for x in courses])]
             # Create a python dictionary with exactly the same fields as the model (in this case, CourseModel)
             offered_sems = post_data.getlist('semesters[]')
             course_instance = \

--- a/cassdegrees/ui/views.py
+++ b/cassdegrees/ui/views.py
@@ -281,11 +281,11 @@ def manage_courses(request):
     if request.method == 'POST':
         model_api_url = request.build_absolute_uri('/api/model/course/')
         post_data = request.POST
-        request_origin = post_data.get('request_origin')
+        perform_function = post_data.get('perform_function')
 
         # If the post request came from itself (managecourses.html -> managecourses.html), then it must mean that
         # course information has been requested by user to be either added or edited.
-        if request_origin == 'managecourses.html':
+        if perform_function == 'Add/Edit data to db':
             if action == 'Add':
                 # Create a python dictionary with exactly the same fields as the model (in this case, CourseModel)
                 offered_sems = post_data.getlist('semesters[]')
@@ -338,7 +338,7 @@ def manage_courses(request):
         # If the request came from list.html (from the add, edit and delete button from the courses list page),
         # fetch and pre-fill the course info on the edit form if edit button was clicked on,
         # or delete the selected course immediately.
-        elif request_origin == 'list.html':
+        elif perform_function == 'retrieve view from selected':
             if action == 'Edit':
                 id_to_edit = post_data.get('id')
                 if id_to_edit:

--- a/cassdegrees/ui/views.py
+++ b/cassdegrees/ui/views.py
@@ -228,8 +228,9 @@ def manage_courses(request):
         model_api_url = request.build_absolute_uri('/api/model/course/')
         post_data = request.POST
         request_origin = post_data.get('request_origin')
-        print(request_origin)
 
+        # If the post request came from itself (managecourses.html -> managecourses.html), then it must mean that
+        # course information has been requested by user to be either added or edited.
         if request_origin == 'managecourses.html':
             if action == 'Add':
                 # courses = [{'code': course} for course in set([x['code'] for x in courses])]
@@ -260,7 +261,6 @@ def manage_courses(request):
                 id_to_edit = post_data.get('id')
                 if id_to_edit:
                     render_properties['hide_form'] = False
-                    print("self is true" + id_to_edit)
                     # Patch requests (editing an already existing resource only requires fields that are changed
                     offered_sems = post_data.getlist('semesters[]')
                     course_instance = \
@@ -282,21 +282,22 @@ def manage_courses(request):
                         render_properties['is_error'] = True
                         render_properties['msg'] = "Failed to edit course information. Please try again."
 
+        # If the request came from list.html (from the add, edit and delete button from the courses list page),
+        # fetch and pre-fill the course info on the edit form if edit button was clicked on,
+        # or delete the selected course immediately.
         elif request_origin == 'list.html':
             if action == 'Edit':
                 id_to_edit = post_data.get('id')
                 if id_to_edit:
                     render_properties['hide_form'] = False
-                    print("id_to_edit: " + id_to_edit)
                     current_course_info = requests.get(model_api_url + id_to_edit + '/?format=json').json()
                     current_course_info['id'] = id_to_edit
                     render_properties['edit_course_info'] = current_course_info
-                    print("all info: " + str(current_course_info))
 
                 else:
                     render_properties['is_error'] = True
                     render_properties['hide_form'] = True
-                    render_properties['msg'] = "Choose a course to edit."
+                    render_properties['msg'] = "Please select a course to edit!"
 
             elif action == 'Delete':
                 ids_to_delete = post_data.getlist('id')
@@ -312,8 +313,8 @@ def manage_courses(request):
                         render_properties['msg'] = 'Course successfully deleted!'
                     else:
                         render_properties['is_error'] = True
-                        render_properties[
-                            'msg'] = "Failed to delete course. An unknown error has occurred. Please try again."
+                        render_properties['msg'] = "Failed to delete course. " \
+                                                   "An unknown error has occurred. Please try again."
 
     return render(request, 'managecourses.html', context={'action': action, 'courses': courses,
                                                           'render': render_properties})
@@ -381,7 +382,6 @@ def bulk_data_upload(request):
                             'offeredSem1': bool(row[map['offeredSem1']]),
                             'offeredSem2': bool(row[map['offeredSem2']])
                         }
-                    print(course_instance)
 
                     # Submit a POST request to the course API with course_instance as data
                     rest_api = requests.post(base_model_url + 'course/', data=course_instance)

--- a/cassdegrees/ui/views.py
+++ b/cassdegrees/ui/views.py
@@ -161,17 +161,20 @@ def manage_courses(request):
         # to be implemented, currently has the sample model code
         elif action == 'Delete':
             ids_to_delete= post_data.getlist('id')
-
+            rest_api = None
             for id_to_delete in ids_to_delete:
                 rest_api = requests.delete(model_api_url + id_to_delete + '/')
 
-            if rest_api.status_code == 204:
-                render_properties['msg'] = 'Course successfully deleted!'
-            else:
-                print(rest_api.status_code)
-                print(rest_api.json())
+            if rest_api is None:
                 render_properties['is_error'] = True
-                render_properties['msg'] = "Failed to delete course. An unknown error has occurred. Please try again."
+                render_properties['msg'] = 'Choose a course to delete.'
+            else:
+                if rest_api.status_code == 204:
+                    render_properties['msg'] = 'Course successfully deleted!'
+                else:
+                    render_properties['is_error'] = True
+                    render_properties[
+                        'msg'] = "Failed to delete course. An unknown error has occurred. Please try again."
 
     return render(request, 'managecourses.html', context={'action': action, 'courses': courses,
                                                           'render': render_properties, 'actions': actions})

--- a/cassdegrees/ui/views.py
+++ b/cassdegrees/ui/views.py
@@ -117,7 +117,7 @@ def manage_courses(request):
         # actual_request = post_data.get('_method')
 
         if action == 'Add':
-            courses = [{'code': course} for course in set([x['code'] for x in courses])]
+            # courses = [{'code': course} for course in set([x['code'] for x in courses])]
             # Create a python dictionary with exactly the same fields as the model (in this case, CourseModel)
             offered_sems = post_data.getlist('semesters[]')
             course_instance = \
@@ -160,13 +160,16 @@ def manage_courses(request):
 
         # to be implemented, currently has the sample model code
         elif action == 'Delete':
-            id_to_delete = post_data.get('id')
+            ids_to_delete= post_data.getlist('id')
 
-            rest_api = requests.delete(model_api_url + id_to_delete + '/')
+            for id_to_delete in ids_to_delete:
+                rest_api = requests.delete(model_api_url + id_to_delete + '/')
 
             if rest_api.status_code == 204:
                 render_properties['msg'] = 'Course successfully deleted!'
             else:
+                print(rest_api.status_code)
+                print(rest_api.json())
                 render_properties['is_error'] = True
                 render_properties['msg'] = "Failed to delete course. An unknown error has occurred. Please try again."
 


### PR DESCRIPTION
As #29 _Course Deletion (8)_ is currently blocked, I created a new branch that contains base code for both #31 _Course Editing (5)_ (@Daniel-Jang) and #29 instead.
The idea was to render just one instance of the course table and have an 'Options' column where the user could choose to either edit or delete a course. 

Notes:
1. code contains placeholders (sample links and images)
2. the icons used were from http://webpublishing.anu.edu.au/web-style-guide/icons.php. However, we are expected to contact ANU styling first if we want to use their icons for the MVP.
3. ANU styling has no icons that could be used for 'Delete' (hence the weird choice of thumbs down). However, we could also contact them about this if we want.

![Capture](https://user-images.githubusercontent.com/24206502/56189655-d6061200-606b-11e9-9c02-50e032689a28.JPG)
