### PR TITLE
Added search capabilities for degrees, subplans, and courses

### DIFF
--- a/cassdegrees/static/css/style.css
+++ b/cassdegrees/static/css/style.css
@@ -28,6 +28,27 @@
     margin: 12px;
 }
 
+.custom_search_bar input[type=text]{
+    height: 30px;
+    width: 78%;
+    padding-left: 5px;
+    margin-right: 2%;
+    box-sizing: border-box;
+    display:inline-block;
+    font-size:1.0em;
+    border-radius: 5px;
+}
+.custom_search_bar input[type=submit]{
+    height: 30px;
+    margin: 0;
+    width: 20%;
+    min-width: 80px;
+    box-sizing: border-box;
+    display:inline-block;
+    border-radius: 5px;
+    float:right;
+}
+
 select.tfull {
     width: 70.25%;
 }

--- a/cassdegrees/templates/list.html
+++ b/cassdegrees/templates/list.html
@@ -5,6 +5,21 @@
 {% block subtitle %}Template, Subplan, and Course List{% endblock %}
 
 {% block content %}
+    <form class="box bdr-solid bdr-uni bg-uni50 anuform custom_search_bar" action="/list?action=Search" method="get">
+        <input class="text" name="q" size="24" maxlength="75" type="text"
+               placeholder="Search Degrees, Subplans, or Courses..."
+               value="{{ autofill }}"
+        >
+        <input class="btn-uni-grad btn-medium" type="submit" value="Search">
+    </form>
+
+    <div class="divline-solid-uni"></div><br />
+
+    {# If no data was sent, assume the user searched and got no results #}
+    {% if not data %}
+        No search results found
+    {% endif %}
+
     {# Generates the tabs based on the keys to 'data' #}
     <div class="pagetabs-nav">
         <ul>
@@ -51,7 +66,12 @@
 
     {# Function to hide the previous tab while opening a new one #}
     <script>
-        var oldLabel = "Degree";
+        {# Gets the first key in the data array (Can't find a better way of doing this) #}
+        {% for title in data %}
+            {% if forloop.first %}
+                var oldLabel = "{{ title }}";
+            {% endif %}
+        {% endfor %}
 
         function setActive(label){
             if(document.getElementById(label+"Link") == null)

--- a/cassdegrees/ui/views.py
+++ b/cassdegrees/ui/views.py
@@ -80,7 +80,7 @@ def planList(request):
 
         # If the degree, subplan, or course searches are non-empty, query the database
         data = {}
-        for target, model in [('Course', CourseModel), ('Subplan', SubplanModel), ('Degree', DegreeModel)]:
+        for target, model in [('Degree', DegreeModel), ('Subplan', SubplanModel), ('Course', CourseModel)]:
             # If the query is not blank, search for it in the database (Prevents unnecessary searches)
             if new_query[target]['AND'].children or new_query[target]['date'].children:
                 # SELECT from the the appropriate relation with the AND and OR queries

--- a/cassdegrees/ui/views.py
+++ b/cassdegrees/ui/views.py
@@ -1,6 +1,7 @@
 from django.http import HttpResponse
 from django.shortcuts import render
-import os
+from django.db.models import Q
+from api.models import DegreeModel, SubplanModel, CourseModel
 import requests
 
 
@@ -31,11 +32,71 @@ def planList(request):
     :param request:
     :return <class django.http.response.HttpResponse>:
     """
-    degree = requests.get(request.build_absolute_uri('/api/model/degree/?format=json')).json()
-    subplan = requests.get(request.build_absolute_uri('/api/model/subplan/?format=json')).json()
-    course = requests.get(request.build_absolute_uri('/api/model/course/?format=json')).json()
+    query = request.GET.get('q', '')
 
-    return render(request, 'list.html', context={'data': {'Degree': degree, 'Subplan': subplan, 'Course': course}})
+    # No search, render default page
+    if not query:
+        degree = requests.get(request.build_absolute_uri('/api/model/degree/?format=json')).json()
+        subplan = requests.get(request.build_absolute_uri('/api/model/subplan/?format=json')).json()
+        course = requests.get(request.build_absolute_uri('/api/model/course/?format=json')).json()
+
+        return render(request, 'list.html', context={'data': {'Degree': degree, 'Subplan': subplan, 'Course': course}})
+    # User search, render results
+    else:
+        # Remove common words and make the query set unique and uppercase
+        stopwords = ['and', 'or', 'for', 'in', 'the', 'of', 'on', 'to']
+        processed_query = [x.upper() for x in query.replace(',', '').split(' ') if x not in stopwords]
+
+        # Create blank queries for text and dates (Allows AND relationship between dates and text)
+        # The AND/OR representations are there to give higher priority to results that contain all keywords
+        new_query = {x: {'AND': Q(), 'OR': Q(), 'date': Q()} for x in ['Course', 'Subplan', 'Degree']}
+
+        # Function that takes an input dict and a sub-query, and appends the sub-query based on the appropriate logic
+        def build_query(target, q):
+            target['AND'] &= q
+            target['OR']  |= q
+
+        # Generate queries based on the processed query string
+        for term in processed_query:
+            # If the current term is of the form TEXT1234, perform a case insensitive search on course codes
+            if len(term) == 8 and term[:4].isalpha() and term[4:].isnumeric():
+                build_query(new_query['Course'], Q(code__iexact=term))
+            # If the term ends with '-MAJ', '-MIN', or '-SPEC', search for subplans containing the inputted term
+            elif term[-4:] == '-MAJ' or term[-4:] == '-MIN' or term[-5:] == '-SPEC':
+                build_query(new_query['Subplan'], Q(code__icontains=term))
+            # If the term is a year-like number, remove results outside that year unless the year in the course code or name
+            elif len(term) == 4 and term.isnumeric():
+                # NOTE: The name and code search is done because Program names can have numbers and course names can have dates
+                # BUG: This implementation will not return a course with a year in the name unless it matches all other keywords
+                #      e.g. CHIN2019 will not show up in a search for `COMP 2019`, but it will appear in a search for `COMP CHIN`
+                new_query['Course' ]['date'] |= Q(year=int(term)) | Q(name__icontains=term) | Q(code__icontains=term)
+                new_query['Subplan']['date'] |= Q(year=int(term)) | Q(name__icontains=term) | Q(code__icontains=term)
+                new_query['Degree' ]['date'] |= Q(year=int(term)) | Q(name__icontains=term) | Q(code__icontains=term)
+            # If the search term has no obvious structure, search for it in the code and name fields
+            else:
+                build_query(new_query['Course' ], Q(code__icontains=term) | Q(name__icontains=term))
+                build_query(new_query['Subplan'], Q(code__icontains=term) | Q(name__icontains=term))
+                build_query(new_query['Degree' ], Q(code__icontains=term) | Q(name__icontains=term))
+
+        # If the degree, subplan, or course searches are non-empty, query the database
+        data = {}
+        for target, model in [('Course', CourseModel), ('Subplan', SubplanModel), ('Degree', DegreeModel)]:
+            # If the query is not blank, search for it in the database (Prevents unnecessary searches)
+            if new_query[target]['AND'].children or new_query[target]['date'].children:
+                # SELECT from the the appropriate relation with the AND and OR queries
+                data[target] = list(model.objects.filter(new_query[target]['AND'], new_query[target]['date']).values())
+                or_query     = list(model.objects.filter(new_query[target]['OR'], new_query[target]['date']).values())
+                # Create an exclusions list of all the results found by the AND query
+                exclusions   = [elm['id'] for elm in data[target]]
+                # Add to the OR results to the end of the AND list, assuming they aren't already in there
+                # The result of this will be the list [High_Priority_Queries]+[Low_Priority_Queries]
+                data[target] += [x for x in or_query if x['id'] not in exclusions]
+
+        # Remove relations that returned no data so the tabs do not appear in the list page
+        data = {k: v for k, v in data.items() if v}
+
+        # Render the requested data and autofill the query in the search
+        return render(request, 'list.html', context={'autofill': query, 'data': data})
 
 
 # I went through this tutorial to create the form html file and this view:


### PR DESCRIPTION
This PR is meant to close issue #35. I decided to also implement course searching (which was not in the original user story) so that others could take advantage of it if required. Note that you are only able to search using the year, code, and name for any given Degree/Subplan/Course. 
![Search](https://user-images.githubusercontent.com/36946090/56202492-854fe280-6086-11e9-9a8b-4c08d2386367.jpg)
