### PR TITLE
Added Support for Degree Rules

### DIFF
--- a/cassdegrees/api/degreeRules.py
+++ b/cassdegrees/api/degreeRules.py
@@ -1,0 +1,52 @@
+class degreeRules:
+    JSONString = []
+
+    def getRule(self, ruleType, match):
+        rule = {"type": ruleType, "match": match}
+
+        return rule
+
+    """ 
+        ["(", A, "OR", "B", ")", "AND", "(", "C", "OR", "D", ")"]
+    """
+    def buildExpression(self, expressionList):
+        tree = {}
+        stack = []
+        node = tree
+        for token in expressionList:
+            if token == "(":
+                node['left'] = {}
+                stack.append(node)
+                node = node['left']
+            elif token == ")":
+                if len(stack) > 0:
+                    node = stack.pop()
+                else:
+                    print("h")
+                    parent = {}
+                    parent["left"] = node
+                    node = parent
+                    tree = parent
+            elif token in ["AND", "OR"]:
+                node['val'] = token
+                node['right'] = {}
+                stack.append(node)
+                node = node['right']
+            else:
+                node['rule'] = token
+                print(stack)
+                parent = stack.pop()
+                print(stack)
+                node = parent
+        return tree
+        #create rules, return rules. Then take a list of rules in a bool alg expression and build the json
+
+    # Add rule as another AND?
+
+
+
+degreeRule = degreeRules()
+A = degreeRule.getRule("single course", "COMP1***")
+test = ["(", A, "OR", "B", ")", "AND", "(", "C", "OR", "D", ")"]
+t = degreeRule.buildExpression(test)
+print(t)

--- a/cassdegrees/api/degreeRules.py
+++ b/cassdegrees/api/degreeRules.py
@@ -1,52 +1,161 @@
-class degreeRules:
-    JSONString = []
+import json
 
-    def getRule(self, ruleType, match):
-        rule = {"type": ruleType, "match": match}
-
-        return rule
-
-    """ 
-        ["(", A, "OR", "B", ")", "AND", "(", "C", "OR", "D", ")"]
+class DegreeRules:
     """
-    def buildExpression(self, expressionList):
-        tree = {}
+    A class which represents degree rules as a k-ary tree and stores them in a list.
+
+    Rules should be created using the rule_ functions, which return a dictionary
+    representing the rule. Rules can then be arranged into an expression and parsed
+    through the class to build their k-ary tree representation.
+
+    Calling get_rules_as_json will return the built expression as a JSON serialised string
+    that can be stored in the database under [degree].[rules].
+    """
+
+    def __init__(self, expression_list):
+        self.expressionTree = []
+        self.build_expression(expression_list)
+
+    def __init__(self):
+        self.expressionTree = []
+
+    def build_expression(self, expression_list):
+        """
+        Accepts a list of tokens that represent a boolean expression of degree rules
+        and converts them into a k-ary tree of lists and dictionaries that can be
+        stored in JSON format.
+
+        :param expression_list: (list) a list of tokens in the format of a boolean expression.
+                                A token must be one of:
+                                    "(", ")", "AND", "OR", rule
+                                where rule is some dictionary representing a rule, returned from a function below
+        :return: (list) a k-ary tree with rules as leaf nodes, and boolean operators as the other nodes
+        """
+
+        tree = [None]
         stack = []
         node = tree
-        for token in expressionList:
+        for token in expression_list:
             if token == "(":
-                node['left'] = {}
+                node.append([None])
                 stack.append(node)
-                node = node['left']
+                node = node[-1]
             elif token == ")":
                 if len(stack) > 0:
                     node = stack.pop()
                 else:
-                    print("h")
-                    parent = {}
-                    parent["left"] = node
+                    parent = [None]
+                    parent.append(node)
                     node = parent
                     tree = parent
             elif token in ["AND", "OR"]:
-                node['val'] = token
-                node['right'] = {}
+                node[0] = token
+                node.append([None])
                 stack.append(node)
-                node = node['right']
+                node = node[-1]
             else:
-                node['rule'] = token
-                print(stack)
+                node[0] = token
                 parent = stack.pop()
-                print(stack)
                 node = parent
+
+        self.expressionTree = tree
+
         return tree
-        #create rules, return rules. Then take a list of rules in a bool alg expression and build the json
 
-    # Add rule as another AND?
+    def append_rule(self, rule):
+        """
+        Takes a rule that should be independent of the existing rules for a degree
+        and appends it to the degree rules with an AND operator.
 
+        :param rule: (Dict) the rule to be appended
+        """
 
+        if self.expressionTree[0] == "AND":
+            self.expressionTree.append(rule)
+        else:
+            self.expressionTree = ["AND", self.expressionTree, rule]
 
-degreeRule = degreeRules()
-A = degreeRule.getRule("single course", "COMP1***")
-test = ["(", A, "OR", "B", ")", "AND", "(", "C", "OR", "D", ")"]
-t = degreeRule.buildExpression(test)
-print(t)
+    def get_rules_as_json(self):
+        """
+        :return: a JSON serialised string representing the rules expression tree
+        """
+
+        return json.dumps(self.expressionTree)
+
+    """
+        DEGREE RULES
+            Functions that return dictionary representations of rules
+    """
+
+    @staticmethod
+    def rule_course_selection(code):
+        """
+        Creates a rule which lists a single course code which
+        must be completed for a degree.
+
+        :param code: (String) the course code
+        :return: (Dict) a course selection rule
+        """
+
+        rule = {"type": "course selection", "code": code}
+        return rule
+
+    @staticmethod
+    def rule_subplan_selection(code):
+        """
+        Creates a rule which lists a single subplan code which
+        must be completed for a degree.
+
+        :param code: (String) the subplan code
+        :return: (Dict) a subplan selection rule
+        """
+
+        rule = {"type": "subplan selection", "code": code}
+        return rule
+
+    @staticmethod
+    def rule_electives(units):
+        """
+        Creates a rule which describes a number of units worth
+        of elective courses which must be completed for the degree.
+
+        :param units: (Int) number of units of available electives
+        :return: (Dict) an elective rule
+        """
+
+        rule = {"type": "electives", "units": units}
+        return rule
+
+    @staticmethod
+    def rule_subject_requirement(subject, level, minimum, units):
+        """
+        Creates a rule which describes a number of units which must
+        be completed, where each course is from a specific subject area
+        and of a given level (or potentially above).
+
+        :param subject: (String) a 4 letter course code i.e "ARTS", "COMP" etc.
+        :param level: (Int) a number in the range [1000, 2000, ... , 9000]
+        :param minimum: (Boolean) true = courses of the level or above count towards the rule,
+                                  false = only course equal to the level count towards the rule
+        :param units: (Int) number of units that must be completed from the subject area and level
+        :return: (Dict) a subject requirement rule
+        """
+
+        rule = {"type": "subject requirement", "subject": subject, "level": level, "minimum": minimum, "units": units}
+        return rule
+
+    @staticmethod
+    def rule_course_limit(subject, level, units):
+        """
+        Creates a rule which requires that a degree may have no
+        more than <units> units worth of courses from a given subject
+        and level.
+
+        :param subject: (String) a 4 letter course code i.e "ARTS", "COMP" etc.
+        :param level: (Int) a number in the range [1000, 2000, ... , 9000]
+        :param units: (Int) maximum number of units of this subject and level that can count to a degree
+        :return: (Dict) a subject requirement rule
+        """
+
+        rule = {"type": "subject requirement", "subject": subject, "level": level, "units": units}
+        return rule

--- a/cassdegrees/api/degreeRules.py
+++ b/cassdegrees/api/degreeRules.py
@@ -75,6 +75,9 @@ class DegreeRules:
 
         self.expressionTree = tree
 
+        if self.expressionTree[0] is None:
+            self.expressionTree[0] = "AND"
+
         return tree
 
     def append_rule(self, rule):

--- a/cassdegrees/api/degreeRules.py
+++ b/cassdegrees/api/degreeRules.py
@@ -22,6 +22,18 @@ class DegreeRules:
 
     def build_expression(self, expression_list):
         """
+        Calls the parse_tree function and assigns the value as the
+        stored tree for this DegreeRules instance.
+
+        :param expression_list: See parse_tree()
+        :return: see parse_tree()
+        """
+
+        self.expressionTree = self.parse_tree(expression_list)
+        return self.expressionTree
+
+    def parse_tree(self, expression_list):
+        """
         Accepts a list of tokens that represent a boolean expression of degree rules
         and converts them into a k-ary tree of lists and dictionaries that can be
         stored in JSON format.
@@ -73,10 +85,27 @@ class DegreeRules:
                     node = parent
                     tree = parent
 
-        self.expressionTree = tree
+        tree = self.flatten_tree(tree)
 
-        if self.expressionTree[0] is None:
-            self.expressionTree[0] = "AND"
+        return tree
+
+    def flatten_tree(self, tree):
+        """
+        Takes a tree and recursively flattens it so that children without siblings are
+        moved up. Children without siblings, by definition, will have no operator, so
+        they appear as [null, {rule}]. They are effectively moved down to the next
+        applicable rule group by changing them to just {rule}.
+
+        :param tree: the tree to be flattened
+        :return: the flattened tree
+        """
+
+        while len(tree) == 2:
+            tree = tree[1]
+
+        for child in range(len(tree)):
+            if isinstance(tree[child], list):
+                tree[child] = self.flatten_tree(tree[child])
 
         return tree
 
@@ -85,8 +114,10 @@ class DegreeRules:
         Takes a rule that should be independent of the existing rules for a degree
         and appends it to the degree rules with an AND operator.
 
-        :param rule: (Dict) the rule to be appended
+        :param rule: an expression list that follows the criteria for parse_tree
         """
+
+        rule = self.parse_tree(rule)
 
         if len(self.expressionTree) == 0:
             raise ValueError("Cannot append rules to an undefined expression. Run build_expression first.")

--- a/cassdegrees/api/degreeRules.py
+++ b/cassdegrees/api/degreeRules.py
@@ -93,7 +93,7 @@ class DegreeRules:
         """
         Takes a tree and recursively flattens it so that children without siblings are
         moved up. Children without siblings, by definition, will have no operator, so
-        they appear as [null, {rule}]. They are effectively moved down to the next
+        they appear as [null, {rule}]. They are effectively moved up to the next
         applicable rule group by changing them to just {rule}.
 
         :param tree: the tree to be flattened

--- a/cassdegrees/api/models.py
+++ b/cassdegrees/api/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+import django.contrib.postgres.fields as psql
 
 
 class SampleModel(models.Model):
@@ -69,6 +70,8 @@ class DegreeModel(models.Model):
                      (vertical_double, "Vertical Flexible Double Degree"))
 
     degreeType = models.CharField(max_length=10, choices=degreeChoices)
+
+    rules = psql.JSONField(default=list)
 
     class Meta:
         unique_together = (("code", "year"),)

--- a/cassdegrees/api/models.py
+++ b/cassdegrees/api/models.py
@@ -54,20 +54,14 @@ class DegreeModel(models.Model):
     name = models.CharField(max_length=256)
     units = models.PositiveIntegerField()
 
-    undergrad_single = "ugrad-sing"
-    undergrad_double = "ugrad-doub"
-    honours = "hon"
-    masters_single = "mast-sing"
-    masters_adv = "mast-adv"
-    masters_double = "mast-doub"
-    vertical_double = "vert_doub"
-    degreeChoices = ((undergrad_single, "Undergraduate Single Pass Degree"),
-                     (undergrad_double, "Undergraduate Flexible Double Degree"),
-                     (honours, "Honours Degree"),
-                     (masters_single, "Masters Single Degree"),
-                     (masters_adv, "Masters (Advanced) Degree"),
-                     (masters_double, "Masters Flexible Double Degree"),
-                     (vertical_double, "Vertical Flexible Double Degree"))
+    degreeChoices = (("ugrad-sing", "Undergraduate Single Pass Degree"),
+                     ("ugrad-doub", "Undergraduate Flexible Double Degree"),
+                     ("hon", "Honours Degree"),
+                     ("mast-sing", "Masters Single Degree"),
+                     ("mast-adv", "Masters (Advanced) Degree"),
+                     ("mast-doub", "Masters Flexible Double Degree"),
+                     ("vert_doub", "Vertical Flexible Double Degree"),
+                     ("other", "Other Degree"))
 
     degreeType = models.CharField(max_length=10, choices=degreeChoices)
 

--- a/cassdegrees/api/serializers.py
+++ b/cassdegrees/api/serializers.py
@@ -51,4 +51,4 @@ class CoursesInSubplanSerializer(serializers.HyperlinkedModelSerializer):
 class DegreeSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = DegreeModel
-        fields = ('id', 'code', 'year', 'name', 'units', 'degreeType')
+        fields = ('id', 'code', 'year', 'name', 'units', 'degreeType', 'rules')


### PR DESCRIPTION
Degree rules have been mapped as a k-ary tree. See the [database details document](https://docs.google.com/document/d/13rDT9u6-vEgFtUdmtDeBNE_8HUAiiQryGiRG5CbEsxA/edit) or the class docstrings for information on how this is implemented. 

Integrating this pull will allow you to build expressions for DegreeRules and store them on the database. See issue #65 

Sample expression tree representation:


        "id": 3,
        "code": "BARTS",
        "year": 2019,
        "name": "Bachelor of Arts",
        "units": 144,
        "degreeType": "ugrad-sing",
        "rules": [
            "AND",
            [
                "OR",
                [
                    {
                        "code": "ANCH-MAJ",
                        "type": "subplan selection"
                    }
                ],
                [
                    {
                        "code": "HUEB-MAJ",
                        "type": "subplan selection"
                    }
                ],
                [
                    {
                        "code": "TNSO-MAJ",
                        "type": "subplan selection"
                    }
                ]
            ],
            [
                "OR",
                [
                    {
                        "code": "AUIS-MIN",
                        "type": "subplan selection"
                    }
                ],
                [
                    {
                        "code": "DEMO-MIN",
                        "type": "subplan selection"
                    }
                ],
                [
                    {
                        "code": "FORA-MIN",
                        "type": "subplan selection"
                    }
                ]
            ],
            [
                {
                    "type": "electives",
                    "units": 48
                }
            ]
        ]
  