### PR TITLE
Add support for adding/removing global requirements from a program

### DIFF
--- a/cassdegrees/api/models.py
+++ b/cassdegrees/api/models.py
@@ -60,7 +60,7 @@ class DegreeModel(models.Model):
                      ("mast-sing", "Masters Single Degree"),
                      ("mast-adv", "Masters (Advanced) Degree"),
                      ("mast-doub", "Masters Flexible Double Degree"),
-                     ("vert_doub", "Vertical Flexible Double Degree"),
+                     ("vert-doub", "Vertical Flexible Double Degree"),
                      ("other", "Other Degree"))
 
     degreeType = models.CharField(max_length=10, choices=degreeChoices)

--- a/cassdegrees/api/models.py
+++ b/cassdegrees/api/models.py
@@ -65,6 +65,7 @@ class DegreeModel(models.Model):
 
     degreeType = models.CharField(max_length=10, choices=degreeChoices)
 
+    globalRequirements = psql.JSONField(default=list)
     rules = psql.JSONField(default=list)
 
     class Meta:

--- a/cassdegrees/api/serializers.py
+++ b/cassdegrees/api/serializers.py
@@ -51,4 +51,4 @@ class CoursesInSubplanSerializer(serializers.HyperlinkedModelSerializer):
 class DegreeSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = DegreeModel
-        fields = ('id', 'code', 'year', 'name', 'units', 'degreeType', 'rules')
+        fields = ('id', 'code', 'year', 'name', 'units', 'degreeType', 'globalRequirements', 'rules')

--- a/cassdegrees/static/css/style.css
+++ b/cassdegrees/static/css/style.css
@@ -56,3 +56,14 @@ select.tfull {
 select.text{
     border-radius: 3px;
 }
+
+/* Fixes an issue with ANU styling where buttons cannot be included in legends */
+.anuform fieldset legend input {
+    float: none;
+    margin-left: 0;
+}
+
+/* Fix padding around inline form errors */
+.anuform .form-group .msg-error {
+    margin-top: 5px;
+}

--- a/cassdegrees/static/js/pristine.js
+++ b/cassdegrees/static/js/pristine.js
@@ -1,0 +1,384 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(global.Pristine = factory());
+}(this, (function () { 'use strict';
+
+var lang = {
+    required: "This field is required",
+    email: "This field requires a valid e-mail address",
+    number: "This field requires a number",
+    url: "This field requires a valid website URL",
+    tel: "This field requires a valid telephone number",
+    maxlength: "This fields length must be < ${1}",
+    minlength: "This fields length must be > ${1}",
+    min: "Minimum value for this field is ${1}",
+    max: "Maximum value for this field is ${1}",
+    pattern: "Input must match the pattern ${1}"
+};
+
+function findAncestor(el, cls) {
+    while ((el = el.parentElement) && !el.classList.contains(cls)) {}
+    return el;
+}
+
+function tmpl(o) {
+    var _arguments = arguments;
+
+    return this.replace(/\${([^{}]*)}/g, function (a, b) {
+        return _arguments[b];
+    });
+}
+
+function groupedElemCount(input) {
+    return input.pristine.self.form.querySelectorAll('input[name="' + input.getAttribute('name') + '"]:checked').length;
+}
+
+function mergeConfig(obj1, obj2) {
+    for (var attr in obj2) {
+        if (!(attr in obj1)) {
+            obj1[attr] = obj2[attr];
+        }
+    }
+    return obj1;
+}
+
+var defaultConfig = {
+    classTo: 'form-group',
+    errorClass: 'has-danger',
+    successClass: 'has-success',
+    errorTextParent: 'form-group',
+    errorTextTag: 'div',
+    errorTextClass: 'text-help'
+};
+
+var PRISTINE_ERROR = 'pristine-error';
+var SELECTOR = "input:not([type^=hidden]):not([type^=submit]), select, textarea";
+var ALLOWED_ATTRIBUTES = ["required", "min", "max", 'minlength', 'maxlength', 'pattern'];
+
+var validators = {};
+
+var _ = function _(name, validator) {
+    validator.name = name;
+    if (!validator.msg) validator.msg = lang[name];
+    if (validator.priority === undefined) validator.priority = 1;
+    validators[name] = validator;
+};
+
+_('text', { fn: function fn(val) {
+        return true;
+    }, priority: 0 });
+_('required', { fn: function fn(val) {
+        return this.type === 'radio' || this.type === 'checkbox' ? groupedElemCount(this) : val !== undefined && val !== '';
+    }, priority: 99, halt: true });
+_('email', { fn: function fn(val) {
+        return !val || /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(val);
+    } });
+_('number', { fn: function fn(val) {
+        return !val || !isNaN(parseFloat(val));
+    }, priority: 2 });
+_('integer', { fn: function fn(val) {
+        return val && /^\d+$/.test(val);
+    } });
+_('minlength', { fn: function fn(val, length) {
+        return !val || val.length >= parseInt(length);
+    } });
+_('maxlength', { fn: function fn(val, length) {
+        return !val || val.length <= parseInt(length);
+    } });
+_('min', { fn: function fn(val, limit) {
+        return !val || (this.type === 'checkbox' ? groupedElemCount(this) >= parseInt(limit) : parseFloat(val) >= parseFloat(limit));
+    } });
+_('max', { fn: function fn(val, limit) {
+        return !val || (this.type === 'checkbox' ? groupedElemCount(this) <= parseInt(limit) : parseFloat(val) <= parseFloat(limit));
+    } });
+_('pattern', { fn: function fn(val, pattern) {
+        var m = pattern.match(new RegExp('^/(.*?)/([gimy]*)$'));return !val || new RegExp(m[1], m[2]).test(val);
+    } });
+
+function Pristine(form, config, live) {
+
+    var self = this;
+
+    init(form, config, live);
+
+    function init(form, config, live) {
+
+        form.setAttribute("novalidate", "true");
+
+        self.form = form;
+        self.config = mergeConfig(config || {}, defaultConfig);
+        self.live = !(live === false);
+        self.fields = Array.from(form.querySelectorAll(SELECTOR)).map(function (input) {
+
+            var fns = [];
+            var params = {};
+            var messages = {};
+
+            [].forEach.call(input.attributes, function (attr) {
+                if (/^data-pristine-/.test(attr.name)) {
+                    var name = attr.name.substr(14);
+                    if (name.endsWith('-message')) {
+                        messages[name.slice(0, name.length - 8)] = attr.value;
+                        return;
+                    }
+                    if (name === 'type') name = attr.value;
+                    _addValidatorToField(fns, params, name, attr.value);
+                } else if (~ALLOWED_ATTRIBUTES.indexOf(attr.name)) {
+                    _addValidatorToField(fns, params, attr.name, attr.value);
+                } else if (attr.name === 'type') {
+                    _addValidatorToField(fns, params, attr.value);
+                }
+            });
+
+            fns.sort(function (a, b) {
+                return b.priority - a.priority;
+            });
+
+            self.live && input.addEventListener(!~['radio', 'checkbox'].indexOf(input.getAttribute('type')) ? 'input' : 'change', function (e) {
+                self.validate(e.target);
+            }.bind(self));
+
+            return input.pristine = { input: input, validators: fns, params: params, messages: messages, self: self };
+        }.bind(self));
+    }
+
+    function _addValidatorToField(fns, params, name, value) {
+        var validator = validators[name];
+        if (validator) {
+            fns.push(validator);
+            if (value) {
+                var valueParams = value.split(',');
+                valueParams.unshift(null); // placeholder for input's value
+                params[name] = valueParams;
+            }
+        }
+    }
+
+    /***
+     * Checks whether the form/input elements are valid
+     * @param input => input element(s) or a jquery selector, null for full form validation
+     * @param silent => do not show error messages, just return true/false
+     * @returns {boolean} return true when valid false otherwise
+     */
+    self.validate = function (input, silent) {
+        silent = input && silent === true || input === true;
+        var fields = self.fields;
+        if (input !== true && input !== false) {
+            if (input instanceof HTMLElement) {
+                fields = [input.pristine];
+            } else if (input instanceof NodeList || input instanceof (window.$ || Array) || input instanceof Array) {
+                fields = Array.from(input).map(function (el) {
+                    return el.pristine;
+                });
+            }
+        }
+
+        var valid = true;
+
+        for (var i in fields) {
+            var field = fields[i];
+            if (_validateField(field)) {
+                !silent && _showSuccess(field);
+            } else {
+                valid = false;
+                !silent && _showError(field);
+            }
+        }
+        return valid;
+    };
+
+    /***
+     * Get errors of a specific field or the whole form
+     * @param input
+     * @returns {Array|*}
+     */
+    self.getErrors = function (input) {
+        if (!input) {
+            var erroneousFields = [];
+            for (var i = 0; i < self.fields.length; i++) {
+                var field = self.fields[i];
+                if (field.errors.length) {
+                    erroneousFields.push({ input: field.input, errors: field.errors });
+                }
+            }
+            return erroneousFields;
+        }
+        return input.length ? input[0].pristine.errors : input.pristine.errors;
+    };
+
+    /***
+     * Validates a single field, all validator functions are called and error messages are generated
+     * when a validator fails
+     * @param field
+     * @returns {boolean}
+     * @private
+     */
+    function _validateField(field) {
+        var errors = [];
+        var valid = true;
+        for (var i in field.validators) {
+            var validator = field.validators[i];
+            var params = field.params[validator.name] ? field.params[validator.name] : [];
+            params[0] = field.input.value;
+            if (!validator.fn.apply(field.input, params)) {
+                valid = false;
+                var error = field.messages[validator.name] || validator.msg;
+                errors.push(tmpl.apply(error, params));
+                if (validator.halt === true) {
+                    break;
+                }
+            }
+        }
+        field.errors = errors;
+        return valid;
+    }
+
+    /***
+     *
+     * @param elem => The dom element where the validator is applied to
+     * @param fn => validator function
+     * @param msg => message to show when validation fails. Supports templating. ${0} for the input's value, ${1} and
+     * so on are for the attribute values
+     * @param priority => priority of the validator function, higher valued function gets called first.
+     * @param halt => whether validation should stop for this field after current validation function
+     */
+    self.addValidator = function (elem, fn, msg, priority, halt) {
+        if (elem instanceof HTMLElement) {
+            elem.pristine.validators.push({ fn: fn, msg: msg, priority: priority, halt: halt });
+            elem.pristine.validators.sort(function (a, b) {
+                return b.priority - a.priority;
+            });
+        } else {
+            console.warn("The parameter elem must be a dom element");
+        }
+    };
+
+    /***
+     * An utility function that returns a 2-element array, first one is the element where error/success class is
+     * applied. 2nd one is the element where error message is displayed. 2nd element is created if doesn't exist and cached.
+     * @param field
+     * @returns {*}
+     * @private
+     */
+    function _getErrorElements(field) {
+        if (field.errorElements) {
+            return field.errorElements;
+        }
+        var errorClassElement = findAncestor(field.input, self.config.classTo);
+        var errorTextParent = null,
+            errorTextElement = null;
+        if (self.config.classTo === self.config.errorTextParent) {
+            errorTextParent = errorClassElement;
+        } else {
+            errorTextParent = errorClassElement.querySelector(self.errorTextParent);
+        }
+        if (errorTextParent) {
+            errorTextElement = errorTextParent.querySelector('.' + PRISTINE_ERROR);
+            if (!errorTextElement) {
+                errorTextElement = document.createElement(self.config.errorTextTag);
+                errorTextElement.className = PRISTINE_ERROR + ' ' + self.config.errorTextClass;
+                errorTextParent.appendChild(errorTextElement);
+                errorTextElement.pristineDisplay = errorTextElement.style.display;
+            }
+        }
+        return field.errorElements = [errorClassElement, errorTextElement];
+    }
+
+    function _showError(field) {
+        var errorElements = _getErrorElements(field);
+        var errorClassElement = errorElements[0],
+            errorTextElement = errorElements[1];
+
+        if (errorClassElement) {
+            errorClassElement.classList.remove(self.config.successClass);
+            errorClassElement.classList.add(self.config.errorClass);
+        }
+        if (errorTextElement) {
+            errorTextElement.innerHTML = field.errors.join('<br/>');
+            errorTextElement.style.display = errorTextElement.pristineDisplay || '';
+        }
+    }
+
+    /***
+     * Adds error to a specific field
+     * @param input
+     * @param error
+     */
+    self.addError = function (input, error) {
+        input = input.length ? input[0] : input;
+        input.pristine.errors.push(error);
+        _showError(input.pristine);
+    };
+
+    function _removeError(field) {
+        var errorElements = _getErrorElements(field);
+        var errorClassElement = errorElements[0],
+            errorTextElement = errorElements[1];
+        if (errorClassElement) {
+            // IE > 9 doesn't support multiple class removal
+            errorClassElement.classList.remove(self.config.errorClass);
+            errorClassElement.classList.remove(self.config.successClass);
+        }
+        if (errorTextElement) {
+            errorTextElement.innerHTML = '';
+            errorTextElement.style.display = 'none';
+        }
+        return errorElements;
+    }
+
+    function _showSuccess(field) {
+        var errorClassElement = _removeError(field)[0];
+        errorClassElement && errorClassElement.classList.add(self.config.successClass);
+    }
+
+    /***
+     * Resets the errors
+     */
+    self.reset = function () {
+        for (var i in self.fields) {
+            self.fields[i].errorElements = null;
+        }
+        Array.from(self.form.querySelectorAll('.' + PRISTINE_ERROR)).map(function (elem) {
+            elem.parentNode.removeChild(elem);
+        });
+        Array.from(self.form.querySelectorAll('.' + self.config.classTo)).map(function (elem) {
+            elem.classList.remove(self.config.successClass);
+            elem.classList.remove(self.config.errorClass);
+        });
+    };
+
+    /***
+     * Resets the errors and deletes all pristine fields
+     */
+    self.destroy = function () {
+        self.reset();
+        self.fields.forEach(function (field) {
+            delete field.input.pristine;
+        });
+        self.fields = [];
+    };
+
+    self.setGlobalConfig = function (config) {
+        defaultConfig = config;
+    };
+
+    return self;
+}
+
+/***
+ *
+ * @param name => Name of the global validator
+ * @param fn => validator function
+ * @param msg => message to show when validation fails. Supports templating. ${0} for the input's value, ${1} and
+ * so on are for the attribute values
+ * @param priority => priority of the validator function, higher valued function gets called first.
+ * @param halt => whether validation should stop for this field after current validation function
+ */
+Pristine.addValidator = function (name, fn, msg, priority, halt) {
+    _(name, { fn: fn, msg: msg, priority: priority, halt: halt });
+};
+
+return Pristine;
+
+})));

--- a/cassdegrees/static/js/programmanagement.js
+++ b/cassdegrees/static/js/programmanagement.js
@@ -1,0 +1,213 @@
+//! Basic utilities to handle serialization and deserialization of custom types (global requirements, rules)
+//! which don't fit neatly into the regular HTML form list syntax.
+
+// Incrementing pointer for global requirements. Must be unique.
+var count = 0;
+
+// Terminology:
+// (Global requirement) container: The entire fieldset + container for a singular global requirement.
+// (Global requirement) inner container: Dynamic field inside a container containing options depending
+//                                       on what rule type was selected.
+
+/**
+ * Finds the ID for the current container.
+ *
+ * @param element The element that was clicked. Search for the ID will occur automatically.
+ * @returns string A parent ID, or null if one doesn't exist.
+ */
+function searchForID(element) {
+    // Search ended without any results.
+    if (element == null) {
+        return null;
+    }
+
+    if (element.id === undefined || element.id == null || element.id === "") {
+        return searchForID(element.parentElement);
+    }
+
+    return element.id;
+}
+
+/**
+ * Creates a new global requirement.
+ *
+ * @returns string The ID of the newly created element.
+ */
+function addGlobalReq() {
+    var newElement = document.getElementById("globalReqsTemplate").cloneNode(true);
+
+    // Make this element unique and visible
+    newElement.style.display = "block";
+    newElement.id = "globalRequirement" + (count++);
+
+    // Update inner containers with new IDs.
+    // Query selector used as getElement is not available in this pseudo-element state.
+    newElement.querySelector('#globalReqsInnerPlaceholder').id = newElement.id + "Inner";
+    newElement.querySelector('#globalReqsTypePlaceholder').id = newElement.id + "Type";
+
+    document.getElementById("globalRequirementsContainer").appendChild(newElement);
+
+    return newElement.id;
+}
+
+/**
+ * Removes the referenced global requirement.
+ *
+ * @param element DOM object representing an element within the container to delete.
+ */
+function removeGlobalReq(element) {
+    document.getElementById(searchForID(element)).remove();
+}
+
+/**
+ * Switches between different option boxes in the inner container depending on the global requirement chosen.
+ *
+ * @param element The element that was clicked. Search for the ID will occur automatically.
+ */
+function onGlobalReqsTypeChanged(element) {
+    // Find the inner container to operate on
+    // Evidently, the element that was just clicked is *not* going to be the container
+    var containerID = searchForID(element.parentElement);
+    // Query selector used as getElement cannot be chained well.
+    var innerContainer = document.querySelector("#" + containerID + " #" + containerID + "Inner");
+
+    // Remove anything that is already there
+    // https://stackoverflow.com/questions/3955229/remove-all-child-elements-of-a-dom-node-in-javascript
+    while (innerContainer.firstChild) {
+        innerContainer.removeChild(innerContainer.firstChild);
+    }
+
+    switch(element.value) {
+        // Allows for other types of global requirements with this switch statement.
+        case "min":
+        case "max":
+            var innerContainerContents = document.getElementById("minMaxUnitsTemplate").cloneNode(true);
+
+            innerContainerContents.id = containerID + "InnerContents";
+            innerContainerContents.style.display = "block";
+
+            innerContainer.appendChild(innerContainerContents);
+            break;
+        default:
+
+    }
+}
+
+/**
+ * Converts a global requirement into a singular blob for submission.
+ *
+ * @param element The global requirement container to serialize.
+ */
+function serializeGlobalReq(element) {
+    var containerID = searchForID(element);
+
+    // Get the type firstly:
+    var output = {
+        'type': document.getElementById(containerID + "Type").value
+    };
+
+    // For every field in the inner container, submit that as well
+    var inner_container = document.getElementById(containerID + "Inner");
+
+    inner_container.querySelectorAll("input[name]").forEach(function (elem) {
+        var value = undefined;
+
+        // The web is... inconsistent
+        if (elem.type === "checkbox") {
+            value = elem.checked;
+        } else {
+            value = elem.value;
+        }
+
+        output[elem.name] = value;
+    });
+
+    return output;
+}
+
+/**
+ * Converts global requirements into a singular blob for submission.
+ */
+function serializeGlobalReqs() {
+    var globalReqs = [];
+
+    for (var i = 0; i < count; i++) {
+        var element = document.getElementById("globalRequirement" + i);
+        if (element !== undefined && element != null) {
+            globalReqs.push(serializeGlobalReq(element));
+        }
+    }
+
+    return globalReqs;
+}
+
+/**
+ * Deserializes incoming JSON for global requirements.
+ *
+ * @param json JSON input.
+ */
+function deserializeReqs(json) {
+    // Reset to the beginning
+    count = 0;
+    var globalRequirements = document.getElementById("globalRequirementsContainer");
+    while (globalRequirements.firstChild) {
+        globalRequirements.removeChild(globalRequirements.firstChild);
+    }
+
+    json.forEach(function(requirement) {
+        var containerID = addGlobalReq();
+        var container = document.getElementById(containerID);
+
+        // Deserialize type
+        var containerType = document.getElementById(containerID + "Type");
+        containerType.value = requirement.type;
+        onGlobalReqsTypeChanged(containerType);
+
+        // Deserialize all other data
+        for (var key in requirement) {
+            var targetElement = container.querySelector('input[name="' + key + '"]');
+            if (targetElement !== undefined && targetElement != null) {
+                if (targetElement.type === "checkbox") {
+                    targetElement.checked = requirement[key];
+                } else {
+                    targetElement.value = requirement[key];
+                }
+            }
+        }
+    });
+}
+
+
+/**
+ * Submits the program form.
+ */
+function submitProgram() {
+    // Remove built-in error message - further validation might confuse the user.
+    var serverError = document.getElementById("serverError");
+
+    if (serverError !== undefined && serverError != null) {
+        serverError.remove();
+    }
+
+    // Verify forms
+    var mainFormPristine = new Pristine(document.getElementById("mainForm"), {
+        errorTextClass: 'msg-error'
+    }, false);
+    var manuallySerializedPristine = new Pristine(document.getElementById("manualSerializedForm"), {
+        errorTextClass: 'msg-error'
+    }, false);
+
+    if (!mainFormPristine.validate(null, false)) {
+        console.log("Main form validation failed.");
+        return;
+    }
+
+    if (!manuallySerializedPristine.validate(null, false)) {
+        console.log("Manually serialized form validation failed.");
+        return;
+    }
+
+    // Serialize list structures - this doesn't translate well over POST requests normally.
+    document.getElementById("globalRequirements").value = JSON.stringify(serializeGlobalReqs());
+    document.getElementById("mainForm").submit();
+}

--- a/cassdegrees/templates/createprogram.html
+++ b/cassdegrees/templates/createprogram.html
@@ -39,7 +39,7 @@
 
             <p class="form-group">
                 <label for="degreeType">Program Type:</label>
-                <select id="degreeType" name="degreeType" aria-required="true" required value="{{ degreeType|default:"" }}>
+                <select id="degreeType" name="degreeType" aria-required="true" required value="{{ degreeType|default:"" }}">
                     <option value="ugrad-sing" selected>Undergraduate Single Pass Degree</option>
                     <option value="ugrad-doub">Undergraduate Flexible Double Degree</option>
                     <option value="hon">Honours Degree</option>

--- a/cassdegrees/templates/createprogram.html
+++ b/cassdegrees/templates/createprogram.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load static %}
 
 {% block page-title %}Create Program Template{% endblock %}
 
@@ -6,37 +7,37 @@
 
 {% block content %}
     {% if msg != None %}
-        <p class="{% if is_error %}msg-error{% else %}msg-success{% endif %}">{{ msg }}</p>
+        <p class="{% if is_error %}msg-error{% else %}msg-success{% endif %}" id="serverError">{{ msg }}</p>
     {% endif %}
 
 
-    <form class="anuform" action="" method="post">
+    <form class="anuform" id="mainForm" action="" novalidate method="post">
         {% csrf_token %}
 
         <fieldset>
             <legend>Configure Program Details</legend>
 
-            <p>
+            <p class="form-group">
                 <label for="code">Program Code:</label>
-                <input class="text" id="code" type="text" name="code" aria-required="true" placeholder="e.g. BARTS" required value="{{ code|default:"" }}">
+                <input class="text" id="code" type="text" name="code" aria-required="true" minlength="4" placeholder="e.g. BARTS" required value="{{ code|default:"" }}">
             </p>
 
-            <p>
+            <p class="form-group">
                 <label for="name">Program Name:</label>
-                <input class="text" id="name" type="text" name="name" aria-required="true" placeholder="e.g. Bachelor of Arts" required value="{{ name|default:"" }}">
+                <input class="text" id="name" type="text" name="name" aria-required="true" minlength="5" placeholder="e.g. Bachelor of Arts" required value="{{ name|default:"" }}">
             </p>
 
-            <p>
+            <p class="form-group">
                 <label for="year">Program Year:</label>
                 <input class="text" id="year" type="number" min="2000" max="2100" value="{{ year|default:"2019" }}" name="year" aria-required="true" required>
             </p>
 
-            <p>
+            <p class="form-group">
                 <label for="units">Program Units:</label>
                 <input class="text" id="units" type="number" min="0" max="1000" value="{{ units|default:"144" }}" name="units" aria-required="true" required>
             </p>
 
-            <p>
+            <p class="form-group">
                 <label for="degreeType">Program Type:</label>
                 <select id="degreeType" name="degreeType" aria-required="true" required value="{{ degreeType|default:"" }}>
                     <option value="ugrad-sing" selected>Undergraduate Single Pass Degree</option>
@@ -50,9 +51,152 @@
             </p>
         </fieldset>
 
-        <p class="text-right">
-            <input class="btn-uni-grad btn-large" type="submit" value="Create">
-        </p>
+        <!-- Everything after here is generated on the fly -->
+        <input class="text" hidden id="globalRequirements" name="globalRequirements">
     </form>
 
+    <!-- We still need a form for regular styling, though these will be serialized manually because of their list-like
+         structure -->
+    <form class="anuform" id="manualSerializedForm" novalidate>
+        <fieldset>
+            <legend>Add Global Requirements</legend>
+
+            <br />
+
+            <div id="globalRequirementsContainer">
+
+            </div>
+
+            <input class="btn-uni-grad btn-large" type="button" onclick="addGlobalReq()" value="Add New Global Requirement" />
+        </fieldset>
+    </form>
+
+    <p class="text-right">
+        <input class="btn-uni-grad btn-large" type="submit" value="Create" onclick="submitProgram()">
+    </p>
+
+    <!-- Acts as a master template for duplication, preventing inline HTML in Javascript. -->
+    <div id="minMaxUnitsTemplate" style="display: none">
+        <fieldset>
+            <legend></legend>
+
+            <p class="form-group">
+                <label>
+                    Unit Count:
+                </label>
+                <input class="text" type="number" name="unit_count" min="0" max="1000" value="48" aria-required="true" required>
+            </p>
+
+            <p>
+                <label>
+                    Year Options:
+                </label>
+            </p>
+
+            <br />
+
+            <table class="tbl-row-bdr">
+                <thead>
+                    <tr>
+                        <th>
+                            1000-level
+                        </th>
+                        <th>
+                            2000-level
+                        </th>
+                        <th>
+                            3000-level
+                        </th>
+                        <th>
+                            4000-level
+                        </th>
+                        <th>
+                            5000-level
+                        </th>
+                        <th>
+                            6000-level
+                        </th>
+                        <th>
+                            7000-level
+                        </th>
+                        <th>
+                            8000-level
+                        </th>
+                        <th>
+                            9000-level
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>
+                            <input type="checkbox" name="courses1000Level">
+                        </td>
+                        <td>
+                            <input type="checkbox" name="courses2000Level">
+                        </td>
+                        <td>
+                            <input type="checkbox" name="courses3000Level">
+                        </td>
+                        <td>
+                            <input type="checkbox" name="courses4000Level">
+                        </td>
+                        <td>
+                            <input type="checkbox" name="courses5000Level">
+                        </td>
+                        <td>
+                            <input type="checkbox" name="courses6000Level">
+                        </td>
+                        <td>
+                            <input type="checkbox" name="courses7000Level">
+                        </td>
+                        <td>
+                            <input type="checkbox" name="courses8000Level">
+                        </td>
+                        <td>
+                            <input type="checkbox" name="courses9000Level">
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </fieldset>
+
+    </div>
+
+    <div id="globalReqsTemplate" class="box bdr-top-solid bdr-bottom-solid" style="display: none">
+        <fieldset>
+            <legend>
+                Global Requirement
+
+                <input class="btn-uni-grad btn-snall" type="button" onclick="removeGlobalReq(this)" value="Remove" />
+            </legend>
+
+            <p class="form-group">
+                <label for="ruleType">
+                    Rule Type:
+                </label>
+
+                <select name="ruleType" aria-required="true" required id="globalReqsTypePlaceholder" onchange="onGlobalReqsTypeChanged(this)">
+                    <!-- https://stackoverflow.com/questions/5805059/how-do-i-make-a-placeholder-for-a-select-box -->
+                    <option value="" disabled selected>Select...</option>
+                    <option value="min">Minimum Units From Year(s)</option>
+                    <option value="max">Maximum Units From Year(s)</option>
+                </select>
+            </p>
+
+            <hr />
+
+            <!-- Placeholder for min/max templates to be injected -->
+            <div id="globalReqsInnerPlaceholder"></div>
+
+        </fieldset>
+    </div>
+
+    <script src="{% static 'js/pristine.js' %}" type="application/javascript"></script>
+    <script src="{% static 'js/programmanagement.js' %}" type="application/javascript"></script>
+    {% if globalRequirements != None %}
+        <script>
+            deserializeReqs({{ globalRequirements|safe }});
+        </script>
+    {% endif %}
 {% endblock %}

--- a/cassdegrees/templates/createprogram.html
+++ b/cassdegrees/templates/createprogram.html
@@ -39,14 +39,14 @@
 
             <p class="form-group">
                 <label for="degreeType">Program Type:</label>
-                <select id="degreeType" name="degreeType" aria-required="true" required value="{{ degreeType|default:"" }}">
-                    <option value="ugrad-sing" selected>Undergraduate Single Pass Degree</option>
-                    <option value="ugrad-doub">Undergraduate Flexible Double Degree</option>
-                    <option value="hon">Honours Degree</option>
-                    <option value="mast-sing">Masters Single Degree</option>
-                    <option value="mast-adv">Masters (Advanced) Degree</option>
-                    <option value="mast-doub">Masters Flexible Double Degree</option>
-                    <option value="vert_doub">Vertical Flexible Double Degree</option>
+                <select id="degreeType" name="degreeType" aria-required="true" required>
+                    <option value="ugrad-sing" {% if degreeType == "ugrad-sing" or degreeType == None %}selected{% endif %}>Undergraduate Single Pass Degree</option>
+                    <option value="ugrad-doub" {% if degreeType == "ugrad-doub" %}selected{% endif %}>Undergraduate Flexible Double Degree</option>
+                    <option value="hon" {% if degreeType == "hon" %}selected{% endif %}>Honours Degree</option>
+                    <option value="mast-sing" {% if degreeType == "mast-sing" %}selected{% endif %}>Masters Single Degree</option>
+                    <option value="mast-adv" {% if degreeType == "mast-adv" %}selected{% endif %}>Masters (Advanced) Degree</option>
+                    <option value="mast-doub" {% if degreeType == "mast-doub" %}selected{% endif %}>Masters Flexible Double Degree</option>
+                    <option value="vert-doub" {% if degreeType == "vert-doub" %}selected{% endif %}>Vertical Flexible Double Degree</option>
                 </select>
             </p>
         </fieldset>

--- a/cassdegrees/ui/views.py
+++ b/cassdegrees/ui/views.py
@@ -178,7 +178,8 @@ def create_program(request):
                 # Do some early validation of these fields
                 'year': int(post_data.get('year')),
                 'units': int(post_data.get('units')),
-                'degreeType': post_data.get('degreeType')
+                'degreeType': post_data.get('degreeType'),
+                'globalRequirements': post_data.get('globalRequirements')
             }
 
         for k, v in degree_dict.items():


### PR DESCRIPTION
This is quite a big PR, so buckle in!

This PR adds support for specifying global requirements when creating a program. The intent is to re-use this entire page for editing a program.

Resolves #15. Resolves #16.

![RobustWombat](https://user-images.githubusercontent.com/1404334/56334343-4b442500-61db-11e9-9d80-8e0ab98f79bd.png)

FAQ:

- Why the custom serialization stuff?

While web browsers *technically* support lists in forms, they are not designed to group elements together (in, say, a global requirement or rule). Effectively, the work for this is now done on the client, rather than what would already have to be done on the server.

- Why a JSON field?

For the same reason as degree rules, this field allows for greater flexibility in storing the data, where a minor performance hit is a non-issue.

- Why the templating system?

Different kinds of global requirements/rules do need to be modeled throughout the life of the program, and this needed some degree of flexibility. We could have relied on the server constantly regenerating the server-side template for this, but that is poor UX for reasons of constantly having the page reload.

This solution, while requiring a bit more code, solves the UX dilemma.

- Why did I use Pristine?

Web browser's validation of forms was inconsistent for this, and didn't verify stuff like select boxes. Pristine was a 3 line addon to fix this and added proper messages. Alternatives required greater amounts of manipulation, or jQuery, which was way too overkill.
