### PR TITLE
Basic program and subplan removal + bug fixes

### DIFF
--- a/cassdegrees/templates/list.html
+++ b/cassdegrees/templates/list.html
@@ -69,6 +69,11 @@
                 {# If there is no data available, notify the user #}
                 {% if not content %}
                     <p>No {{ title }}s to display</p>
+                    <div class="right">
+                        <p class="left marginright">
+                           <input class="btn-uni-grad btn-large" type ="submit" formaction="/{% if title == 'Degree' %}manage_programs{% elif title == 'Subplan' %}manage_subplans{% elif title == 'Course' %}manage_courses{% endif %}/?action=Add" value="Add a {{ title }}">
+                        </p>
+                    </div>
                 {% else %}
                     <div class="right">
                         <p class="left marginright">

--- a/cassdegrees/templates/list.html
+++ b/cassdegrees/templates/list.html
@@ -72,13 +72,13 @@
                 {% else %}
                     <div class="right">
                         <p class="left marginright">
-                           <input class="btn-uni-grad btn-large" type ="submit" formaction="/{% if title == 'Degree' %}{% elif title == 'Subplan' %}{% elif title == 'Course' %}manage_courses{% endif %}/?action=Add" value="Add a {{ title }}">
+                           <input class="btn-uni-grad btn-large" type ="submit" formaction="/{% if title == 'Degree' %}manage_programs{% elif title == 'Subplan' %}manage_subplans{% elif title == 'Course' %}manage_courses{% endif %}/?action=Add" value="Add a {{ title }}">
                         </p>
                         <p class="left marginright">
-                           <input class="btn-uni-grad btn-large" type ="submit" formaction="/{% if title == 'Degree' %}{% elif title == 'Subplan' %}{% elif title == 'Course' %}manage_courses{% endif %}/?action=Edit" value="Edit Selected">
+                           <input class="btn-uni-grad btn-large" type ="submit" formaction="/{% if title == 'Degree' %}manage_programs{% elif title == 'Subplan' %}manage_subplans{% elif title == 'Course' %}manage_courses{% endif %}/?action=Edit" value="Edit Selected">
                         </p>
                         <p class="right">
-                           <input class="btn-uni-grad btn-large" type ="submit" formaction="/{% if title == 'Degree' %}{% elif title == 'Subplan' %}{% elif title == 'Course' %}manage_courses{% endif %}/?action=Delete" value="Delete Selected">
+                           <input class="btn-uni-grad btn-large" type ="submit" formaction="/{% if title == 'Degree' %}manage_programs{% elif title == 'Subplan' %}manage_subplans{% elif title == 'Course' %}manage_courses{% endif %}/?action=Delete" value="Delete Selected">
                         </p>
                    </div>
                 {% endif %}

--- a/cassdegrees/templates/list.html
+++ b/cassdegrees/templates/list.html
@@ -60,10 +60,10 @@
                                     {% if key != "id" %}
                                         <td>{{ item }}</td>
                                     {% else %}
-                                        <td><input title="Select" type="checkbox" name="id" value="{{ item }}"  /></td>
+                                        <td><p class="text-center"><input title="Select" type="checkbox" name="id" value="{{ item }}"  /></p></td>
                                         <td>
+                                            <input class="btn-uni-grad" name="id" type ="submit" formaction="/manage_{% if title == 'Degree' %}programs{% elif title == 'Subplan' %}subplans{% elif title == 'Course' %}courses{% endif %}/?action=Edit" value="Edit {{ title }} (ID: {{ item }})">
                                             (<a href="/api/model/{{ title.lower }}/{{ item }}/">View</a>)
-                                            <input class="btn-uni-grad" name="id" type ="submit" formaction="/{% if title == 'Degree' %}manage_programs{% elif title == 'Subplan' %}manage_subplans{% elif title == 'Course' %}manage_courses{% endif %}/?action=Edit" value="Edit {{ title }} (ID: {{ item }})">
                                         </td>
                                     {% endif %}
 
@@ -79,7 +79,7 @@
                 {% else %}
                 <div class="right">
                     <p class="right">
-                       <input class="btn-uni-grad btn-large" type ="submit" formaction="/{% if title == 'Degree' %}manage_programs{% elif title == 'Subplan' %}manage_subplans{% elif title == 'Course' %}manage_courses{% endif %}/?action=Delete" value="Delete Selected">
+                       <input class="btn-uni-grad btn-large" type ="submit" formaction="/manage_{% if title == 'Degree' %}programs{% elif title == 'Subplan' %}subplans{% elif title == 'Course' %}courses{% endif %}/?action=Delete" value="Delete Selected">
                     </p>
                 </div>
                 {% endif %}

--- a/cassdegrees/templates/list.html
+++ b/cassdegrees/templates/list.html
@@ -37,7 +37,7 @@
                 {# Allow manage_courses() function to behave appropriately based on origin of request. The post request can either come from list.html or managecourses.html #}
                 <input type="hidden" id="perform_function" name="perform_function" value="retrieve view from selected">
                 <p class="left">
-                    <input class="btn-uni-grad" type ="submit" formaction="/{% if title == 'Degree' %}manage_programs{% elif title == 'Subplan' %}manage_subplans{% elif title == 'Course' %}manage_courses{% endif %}/?action=Add" value="Add a {{ title }}">
+                    <input class="btn-uni-grad" type ="submit" formaction="/manage_{% if title == 'Degree' %}programs{% elif title == 'Subplan' %}subplans{% elif title == 'Course' %}courses{% endif %}/?action=Add" value="New {{ title }}">
                 </p>
                 <table class="fullwidth tbl-cell-bdr">
                     {# Add title row based on what was in the dictionary #}

--- a/cassdegrees/templates/list.html
+++ b/cassdegrees/templates/list.html
@@ -58,7 +58,7 @@
                                     {% if key != "id" %}
                                         <td>{{ item }}</td>
                                     {% else %}
-                                        <td><input title="Select" type="radio" name="id" value="{{ item }}"  /></td>
+                                        <td><input title="Select" type="checkbox" name="id" value="{{ item }}"  /></td>
                                         <td>(<a href="/api/model/{{ title.lower }}/{{ item }}/">View</a>)</td>
                                     {% endif %}
 

--- a/cassdegrees/templates/list.html
+++ b/cassdegrees/templates/list.html
@@ -36,7 +36,9 @@
                 {% csrf_token %}
                 {# Allow manage_courses() function to behave appropriately based on origin of request. The post request can either come from list.html or managecourses.html #}
                 <input type="hidden" id="perform_function" name="perform_function" value="retrieve view from selected">
-
+                <p class="left">
+                    <input class="btn-uni-grad" type ="submit" formaction="/{% if title == 'Degree' %}manage_programs{% elif title == 'Subplan' %}manage_subplans{% elif title == 'Course' %}manage_courses{% endif %}/?action=Add" value="Add a {{ title }}">
+                </p>
                 <table class="fullwidth tbl-cell-bdr">
                     {# Add title row based on what was in the dictionary #}
                     <tr>
@@ -59,33 +61,27 @@
                                         <td>{{ item }}</td>
                                     {% else %}
                                         <td><input title="Select" type="checkbox" name="id" value="{{ item }}"  /></td>
-                                        <td>(<a href="/api/model/{{ title.lower }}/{{ item }}/">View</a>)</td>
+                                        <td>
+                                            (<a href="/api/model/{{ title.lower }}/{{ item }}/">View</a>)
+                                            <input class="btn-uni-grad" name="id" type ="submit" formaction="/{% if title == 'Degree' %}manage_programs{% elif title == 'Subplan' %}manage_subplans{% elif title == 'Course' %}manage_courses{% endif %}/?action=Edit" value="Edit {{ title }} (ID: {{ item }})">
+                                        </td>
                                     {% endif %}
 
                             {% endfor %}
                         </tr>
                     {% endfor %}
                 </table>
+
                 {# If there is no data available, notify the user #}
                 {% if not content %}
                     <p>No {{ title }}s to display</p>
-                    <div class="right">
-                        <p class="left marginright">
-                           <input class="btn-uni-grad btn-large" type ="submit" formaction="/{% if title == 'Degree' %}manage_programs{% elif title == 'Subplan' %}manage_subplans{% elif title == 'Course' %}manage_courses{% endif %}/?action=Add" value="Add a {{ title }}">
-                        </p>
-                    </div>
+                {# otherwise if theres content then have the delete button show #}
                 {% else %}
-                    <div class="right">
-                        <p class="left marginright">
-                           <input class="btn-uni-grad btn-large" type ="submit" formaction="/{% if title == 'Degree' %}manage_programs{% elif title == 'Subplan' %}manage_subplans{% elif title == 'Course' %}manage_courses{% endif %}/?action=Add" value="Add a {{ title }}">
-                        </p>
-                        <p class="left marginright">
-                           <input class="btn-uni-grad btn-large" type ="submit" formaction="/{% if title == 'Degree' %}manage_programs{% elif title == 'Subplan' %}manage_subplans{% elif title == 'Course' %}manage_courses{% endif %}/?action=Edit" value="Edit Selected">
-                        </p>
-                        <p class="right">
-                           <input class="btn-uni-grad btn-large" type ="submit" formaction="/{% if title == 'Degree' %}manage_programs{% elif title == 'Subplan' %}manage_subplans{% elif title == 'Course' %}manage_courses{% endif %}/?action=Delete" value="Delete Selected">
-                        </p>
-                   </div>
+                <div class="right">
+                    <p class="right">
+                       <input class="btn-uni-grad btn-large" type ="submit" formaction="/{% if title == 'Degree' %}manage_programs{% elif title == 'Subplan' %}manage_subplans{% elif title == 'Course' %}manage_courses{% endif %}/?action=Delete" value="Delete Selected">
+                    </p>
+                </div>
                 {% endif %}
             </form>
         </div>

--- a/cassdegrees/templates/manageprograms.html
+++ b/cassdegrees/templates/manageprograms.html
@@ -1,0 +1,203 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block page-title %}{{ action }} Program{% endblock %}
+
+{% block subtitle %}{{ action }} Program{% endblock %}
+
+{% block content %}
+    {% if render.msg != None %}
+        <p class="{% if render.is_error %}msg-error{% else %}msg-success{% endif %}">{{ render.msg }}</p>
+    {% endif %}
+
+    <div id="{{ action }}Page" {% if action == 'Delete' or render.hide_form %}hidden{% endif %}>
+        <form class="anuform" id="mainForm" action="/create_program/" novalidate method="post">
+            {% csrf_token %}
+
+            <fieldset>
+                <legend>Configure Program Details</legend>
+
+                <p class="form-group">
+                    <label for="code">Program Code:</label>
+                    <input class="text" id="code" type="text" name="code" aria-required="true" minlength="4" placeholder="e.g. BARTS" required value="{{ code|default:"" }}">
+                </p>
+
+                <p class="form-group">
+                    <label for="name">Program Name:</label>
+                    <input class="text" id="name" type="text" name="name" aria-required="true" minlength="5" placeholder="e.g. Bachelor of Arts" required value="{{ name|default:"" }}">
+                </p>
+
+                <p class="form-group">
+                    <label for="year">Program Year:</label>
+                    <input class="text" id="year" type="number" min="2000" max="2100" value="{{ year|default:"2019" }}" name="year" aria-required="true" required>
+                </p>
+
+                <p class="form-group">
+                    <label for="units">Program Units:</label>
+                    <input class="text" id="units" type="number" min="0" max="1000" value="{{ units|default:"144" }}" name="units" aria-required="true" required>
+                </p>
+
+                <p class="form-group">
+                    <label for="degreeType">Program Type:</label>
+                    <select id="degreeType" name="degreeType" aria-required="true" required>
+                        <option value="ugrad-sing" {% if degreeType == "ugrad-sing" or degreeType == None %}selected{% endif %}>Undergraduate Single Pass Degree</option>
+                        <option value="ugrad-doub" {% if degreeType == "ugrad-doub" %}selected{% endif %}>Undergraduate Flexible Double Degree</option>
+                        <option value="hon" {% if degreeType == "hon" %}selected{% endif %}>Honours Degree</option>
+                        <option value="mast-sing" {% if degreeType == "mast-sing" %}selected{% endif %}>Masters Single Degree</option>
+                        <option value="mast-adv" {% if degreeType == "mast-adv" %}selected{% endif %}>Masters (Advanced) Degree</option>
+                        <option value="mast-doub" {% if degreeType == "mast-doub" %}selected{% endif %}>Masters Flexible Double Degree</option>
+                        <option value="vert-doub" {% if degreeType == "vert-doub" %}selected{% endif %}>Vertical Flexible Double Degree</option>
+                    </select>
+                </p>
+            </fieldset>
+
+            <!-- Everything after here is generated on the fly -->
+            <input class="text" hidden id="globalRequirements" name="globalRequirements">
+        </form>
+
+        <!-- We still need a form for regular styling, though these will be serialized manually because of their list-like
+             structure -->
+        <form class="anuform" id="manualSerializedForm" novalidate>
+            <fieldset>
+                <legend>Add Global Requirements</legend>
+
+                <br />
+
+                <div id="globalRequirementsContainer">
+
+                </div>
+
+                <input class="btn-uni-grad btn-large" type="button" onclick="addGlobalReq()" value="Add New Global Requirement" />
+            </fieldset>
+        </form>
+
+        <p class="text-right">
+            <input class="btn-uni-grad btn-large" type="submit" value="Create" onclick="submitProgram()">
+        </p>
+
+        <!-- Acts as a master template for duplication, preventing inline HTML in Javascript. -->
+        <div id="minMaxUnitsTemplate" style="display: none">
+            <fieldset>
+                <legend></legend>
+
+                <p class="form-group">
+                    <label>
+                        Unit Count:
+                    </label>
+                    <input class="text" type="number" name="unit_count" min="0" max="1000" value="48" aria-required="true" required>
+                </p>
+
+                <p>
+                    <label>
+                        Year Options:
+                    </label>
+                </p>
+
+                <br />
+
+                <table class="tbl-row-bdr">
+                    <thead>
+                        <tr>
+                            <th>
+                                1000-level
+                            </th>
+                            <th>
+                                2000-level
+                            </th>
+                            <th>
+                                3000-level
+                            </th>
+                            <th>
+                                4000-level
+                            </th>
+                            <th>
+                                5000-level
+                            </th>
+                            <th>
+                                6000-level
+                            </th>
+                            <th>
+                                7000-level
+                            </th>
+                            <th>
+                                8000-level
+                            </th>
+                            <th>
+                                9000-level
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>
+                                <input type="checkbox" name="courses1000Level">
+                            </td>
+                            <td>
+                                <input type="checkbox" name="courses2000Level">
+                            </td>
+                            <td>
+                                <input type="checkbox" name="courses3000Level">
+                            </td>
+                            <td>
+                                <input type="checkbox" name="courses4000Level">
+                            </td>
+                            <td>
+                                <input type="checkbox" name="courses5000Level">
+                            </td>
+                            <td>
+                                <input type="checkbox" name="courses6000Level">
+                            </td>
+                            <td>
+                                <input type="checkbox" name="courses7000Level">
+                            </td>
+                            <td>
+                                <input type="checkbox" name="courses8000Level">
+                            </td>
+                            <td>
+                                <input type="checkbox" name="courses9000Level">
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </fieldset>
+
+        </div>
+
+        <div id="globalReqsTemplate" class="box bdr-top-solid bdr-bottom-solid" style="display: none">
+            <fieldset>
+                <legend>
+                    Global Requirement
+
+                    <input class="btn-uni-grad btn-snall" type="button" onclick="removeGlobalReq(this)" value="Remove" />
+                </legend>
+
+                <p class="form-group">
+                    <label for="ruleType">
+                        Rule Type:
+                    </label>
+
+                    <select name="ruleType" aria-required="true" required id="globalReqsTypePlaceholder" onchange="onGlobalReqsTypeChanged(this)">
+                        <!-- https://stackoverflow.com/questions/5805059/how-do-i-make-a-placeholder-for-a-select-box -->
+                        <option value="" disabled selected>Select...</option>
+                        <option value="min">Minimum Units From Year(s)</option>
+                        <option value="max">Maximum Units From Year(s)</option>
+                    </select>
+                </p>
+
+                <hr />
+
+                <!-- Placeholder for min/max templates to be injected -->
+                <div id="globalReqsInnerPlaceholder"></div>
+
+            </fieldset>
+        </div>
+
+        <script src="{% static 'js/pristine.js' %}" type="application/javascript"></script>
+        <script src="{% static 'js/programmanagement.js' %}" type="application/javascript"></script>
+        {% if globalRequirements != None %}
+            <script>
+                deserializeReqs({{ globalRequirements|safe }});
+            </script>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/cassdegrees/templates/managesubplans.html
+++ b/cassdegrees/templates/managesubplans.html
@@ -1,0 +1,59 @@
+{% extends "base.html" %}
+
+{% block page-title %}{{ action }} Subplan{% endblock %}
+
+{% block subtitle %}{{ action }} Subplan{% endblock %}
+
+{% block content %}
+    {% if render.msg != None %}
+        <p class="{% if render.is_error %}msg-error{% else %}msg-success{% endif %}">{{ render.msg }}</p>
+    {% endif %}
+
+    <div id="{{ action }}Page" {% if action == 'Delete' or render.hide_form %}hidden{% endif %}>
+        <form class="anuform" action="/create_subplan/" method="post">
+
+            {% csrf_token %}
+
+            <fieldset>
+
+                <legend>Subplan details</legend>
+
+                <!-- As HTML forms only support get or post methods,
+                add this hidden input for consistency with the rest of the forms -->
+                <input type="hidden" name="_method" value="post">
+
+                <p>
+                    <label for="code">Subplan Code:</label>
+                    <input class="text" id="code" type="text" name="code" placeholder="e.g. ANTH-MIN"
+                           aria-required="true" required value="{{ code|default:"" }}">
+                </p>
+
+                <p>
+                    <label for="year">Subplan Year:</label>
+                    <input class="text" id="year" type="number" name="year"
+                           aria-required="true" required min="2000" value="{{ year|default:"2019" }}">
+                </p>
+
+                <p>
+                    <label for="name">Subplan Name:</label>
+                    <input class="text" id="name" type="text" name="name"
+                           aria-required="true" placeholder="e.g. Anthropology" required value="{{ name|default:"" }}">
+                </p>
+
+                <p>
+                    <label for="plantype">Subplan Type:</label>
+                    <select class="text" id="planType" type="text" name="planType"
+                            aria-required="true" required">
+                        <option value="MAJ" {% if planType == "MAJ" %}selected{% endif %}>Major</option>
+                        <option value="MIN" {% if planType == "MIN" %}selected{% endif %}>Minor</option>
+                        <option value="SPEC" {% if planType == "SPEC" %}selected{% endif %}>Specialisation</option>
+                    </select>
+                </p>
+
+            </fieldset>
+            <p class="text-right">
+                <input class="btn-uni-grad btn-large" type ="submit" value="Create">
+            </p>
+        </form>
+    </div>
+{% endblock %}

--- a/cassdegrees/ui/urls.py
+++ b/cassdegrees/ui/urls.py
@@ -15,7 +15,7 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
-from .views import index, sampleform, create_program, create_subplan, planList, manage_courses, bulk_data_upload
+from .views import index, sampleform, create_program, create_subplan, planList, manage_courses, manage_subplans, manage_programs, bulk_data_upload
 
 urlpatterns = [
     path('', index),
@@ -24,5 +24,7 @@ urlpatterns = [
     path('create_subplan/', create_subplan),
     path('list/', planList),
     path('manage_courses/', manage_courses),
+    path('manage_subplans/', manage_subplans),
+    path('manage_programs/', manage_programs),
     path('bulk_upload/', bulk_data_upload),
 ]

--- a/cassdegrees/ui/views.py
+++ b/cassdegrees/ui/views.py
@@ -207,6 +207,51 @@ def create_program(request):
 
     return render(request, 'createprogram.html', context=render_properties)
 
+
+def manage_programs(request):
+    # Reads the 'action' attribute from the url (i.e. manage/?action=Add) and determines the submission method
+    action = request.GET.get('action', 'Add')
+
+    program = requests.get(request.build_absolute_uri('/api/model/degree/?format=json')).json()
+    # If POST request, redirect the received information to the backend:
+    render_properties = {
+        'msg': None,
+        'is_error': False
+    }
+
+    if request.method == 'POST':
+        model_api_url = request.build_absolute_uri('/api/model/degree/')
+        post_data = request.POST
+        perform_function = post_data.get('perform_function')
+
+        # If the request came from list.html (from the add, edit and delete button from the courses list page)
+        # Edit is pending the relevant story issue.
+        if perform_function == 'retrieve view from selected':
+            if action == 'Edit':
+                # TODO: edit programs
+                render_properties['msg'] = 'Not yet Implemented!'
+
+            elif action == 'Delete':
+                ids_to_delete = post_data.getlist('id')
+                rest_api = None
+                for id_to_delete in ids_to_delete:
+                    rest_api = requests.delete(model_api_url + id_to_delete + '/')
+
+                if rest_api is None:
+                    render_properties['is_error'] = True
+                    render_properties['msg'] = 'Please select a program to delete!'
+                else:
+                    if rest_api.status_code == 204:
+                        render_properties['msg'] = 'program successfully deleted!'
+                    else:
+                        render_properties['is_error'] = True
+                        render_properties['msg'] = "Failed to delete program. " \
+                                                   "An unknown error has occurred. Please try again."
+
+    return render(request, 'manageprograms.html', context={'action': action, 'program': program,
+                                                          'render': render_properties})
+
+
 # Using sampleform template and #59 - basic degree creation workflow as it's inspirations
 def create_subplan(request):
 
@@ -266,6 +311,53 @@ def create_subplan(request):
 
     return render(request, 'createsubplan.html', context=render_properties)
 
+
+# Will need to look into merging with create subplan later...
+# Currently acts as a liason between the two functions
+# Modification of manage_courses to work for subplans
+# editing subplans is currently pending.
+def manage_subplans(request):
+    # Reads the 'action' attribute from the url (i.e. manage/?action=Add) and determines the submission method
+    action = request.GET.get('action', 'Add')
+
+    subplan = requests.get(request.build_absolute_uri('/api/model/subplan/?format=json')).json()
+    # If POST request, redirect the received information to the backend:
+    render_properties = {
+        'msg': None,
+        'is_error': False
+    }
+
+    if request.method == 'POST':
+        model_api_url = request.build_absolute_uri('/api/model/subplan/')
+        post_data = request.POST
+        perform_function = post_data.get('perform_function')
+
+        # If the request came from list.html (from the add, edit and delete button from the courses list page)
+        # Edit is pending the relevant story issue.
+        if perform_function == 'retrieve view from selected':
+            if action == 'Edit':
+                # TODO: edit subplans
+                render_properties['msg'] = 'Not yet Implemented!'
+
+            elif action == 'Delete':
+                ids_to_delete = post_data.getlist('id')
+                rest_api = None
+                for id_to_delete in ids_to_delete:
+                    rest_api = requests.delete(model_api_url + id_to_delete + '/')
+
+                if rest_api is None:
+                    render_properties['is_error'] = True
+                    render_properties['msg'] = 'Please select a Subplan to delete!'
+                else:
+                    if rest_api.status_code == 204:
+                        render_properties['msg'] = 'Subplan successfully deleted!'
+                    else:
+                        render_properties['is_error'] = True
+                        render_properties['msg'] = "Failed to delete Subplan. " \
+                                                   "An unknown error has occurred. Please try again."
+
+    return render(request, 'managesubplans.html', context={'action': action, 'subplan': subplan,
+                                                          'render': render_properties})
 
 # inspired by the samepleform function created by Daniel Jang
 def manage_courses(request):

--- a/cassdegrees/ui/views.py
+++ b/cassdegrees/ui/views.py
@@ -434,6 +434,7 @@ def manage_courses(request):
         elif perform_function == 'retrieve view from selected':
             if action == 'Edit':
                 id_to_edit = post_data.get('id')
+                id_to_edit = ''.join(filter(lambda x: x.isdigit(), id_to_edit))
                 if id_to_edit:
                     render_properties['hide_form'] = False
                     current_course_info = requests.get(model_api_url + id_to_edit + '/?format=json').json()


### PR DESCRIPTION
So now in list view, you can add and delete programs and subplans using the relevant buttons.
It's pretty much an extension of the methods used by #61, except modified for programs and subplans
I've also fixed Bug #69 so once this PR merges I'll close the issue.

All acceptance criteria have been met except for:
- In the case of a subplan deletion, the user will be notified if it is used in any templates, and will be asked to act on these before the deletion can occur

@spencerj411 and I were going to collaborate on this since it is in both our deletion stories. 
Some of it is currently also being blocked as we don't have a way to add courses in subplans yet.

We also need to merge or discuss the program and subplan creation, as currently they're split from their relevant management sections and also editing needs to be completed.

