### PR TITLE
Finalisation of Course Deletion

### DIFF
--- a/cassdegrees/templates/list.html
+++ b/cassdegrees/templates/list.html
@@ -58,7 +58,7 @@
                                     {% if key != "id" %}
                                         <td>{{ item }}</td>
                                     {% else %}
-                                        <td><input title="Select" type="radio" name="id" value="{{ item }}"  /></td>
+                                        <td><input title="Select" type="radio" name="id" value="{{ item }}" onchange="sessionStorage.setItem('selected', {{ item }})" /></td>
                                         <td>(<a href="/api/model/{{ title.lower }}/{{ item }}/">View</a>)</td>
                                     {% endif %}
 

--- a/cassdegrees/templates/managecourses.html
+++ b/cassdegrees/templates/managecourses.html
@@ -74,17 +74,17 @@
     </div>
     {# code onwards is to confirm the user that the course is in one or more subplans #}
     {% if render.is_confirm %}
-        <form class="anuform" action="/manage_courses/?action=Delete" method="post">
+        <p class="right padtop">
+            <input class="btn-uni-grad btn-medium" onclick="history.back()" type="submit" value="No">
+        </p>
+        <form class="anuform right" action="/manage_courses/?action=Delete" method="post">
             {% csrf_token %}
             <input id="selected" title="Select" name="id" hidden/>
-            <p class="right">
+            <p class="marginright">
                 <input class="btn-uni-grad btn-medium" name="confirm_delete" type="submit" value="Yes">
             </p>
             <input type="hidden" id="perform_function" name="perform_function" value="confirm deletion">
         </form>
-        <p class="right marginright padtop">
-            <input class="btn-uni-grad btn-medium" onclick="history.back()" type="submit" value="No">
-        </p>
     {% endif %}
     {# grabs form data from list.html - reference: https://stackoverflow.com/questions/14845710/javascript-variable-access-in-html #}
     <script>

--- a/cassdegrees/templates/managecourses.html
+++ b/cassdegrees/templates/managecourses.html
@@ -5,8 +5,8 @@
 {% block subtitle %}{{ action }} Course{% endblock %}
 
 {% block content %}
-    {% if render.msg != None %}
-        <p class="{% if render.is_error %}msg-error{% else %}msg-success{% endif %}">{{ render.msg }}</p>
+    {% if render.msg != None and render.msg_type != None %}
+        <p class={{ render.msg_type }}>{{ render.msg }}</p>
     {% endif %}
 
     <div id="{{ action }}Page" {% if action == 'Delete' or render.hide_form %}hidden{% endif %}>
@@ -72,4 +72,26 @@
             </p>
         </form>
     </div>
+    {# code onwards is for confirming a deletion of a course when it is in a subplan #}
+    {% if render.is_confirm %}
+        <form class="anuform" action="/manage_courses/?action=Delete" method="post">
+            {% csrf_token %}
+            <input id="selected" title="Select" name="id" hidden/>
+            <p class="right">
+                <input class="btn-uni-grad btn-medium" name="confirm_delete" type="submit" value="Yes">
+            </p>
+            <input type="hidden" id="perform_function" name="perform_function" value="confirm deletion">
+        </form>
+        <p class="right marginright padtop">
+            <input class="btn-uni-grad btn-medium" onclick="history.back()" type="submit" value="No">
+        </p>
+    {% endif %}
+    {# grabs form data from list.html - reference: https://stackoverflow.com/questions/14845710/javascript-variable-access-in-html #}
+    <script>
+        let data = sessionStorage.getItem('selected');
+
+        window.onload = function() {
+            document.getElementById("selected").value = data;
+        }
+    </script>
 {% endblock %}

--- a/cassdegrees/templates/managecourses.html
+++ b/cassdegrees/templates/managecourses.html
@@ -72,7 +72,7 @@
             </p>
         </form>
     </div>
-    {# code onwards is for confirming a deletion of a course when it is in a subplan #}
+    {# code onwards is to confirm the user that the course is in one or more subplans #}
     {% if render.is_confirm %}
         <form class="anuform" action="/manage_courses/?action=Delete" method="post">
             {% csrf_token %}

--- a/cassdegrees/ui/views.py
+++ b/cassdegrees/ui/views.py
@@ -473,7 +473,7 @@ def manage_courses(request):
                 if used_subplans:  # if there any subplans that use the course
                     render_properties['is_confirm'] = True
                     render_properties['msg_type'] = 'msg-warn'
-                    render_properties['msg'] = 'The Sub-Plans ' + ', '.join(used_subplans) + ' use this course. Do you want to continue?'
+                    render_properties['msg'] = 'The Sub-Plan(s) ' + ', '.join(used_subplans) + ' use this course. Do you want to continue?'
                 elif rest_api is None:
                     render_properties['msg_type'] = 'msg-error'
                     render_properties['msg'] = 'Please select a course to delete!'

--- a/cassdegrees/ui/views.py
+++ b/cassdegrees/ui/views.py
@@ -362,12 +362,11 @@ def manage_courses(request):
                 rest_api = None
                 ids_to_delete = post_data.getlist('id')
                 used_subplans = []
-                if perform_function == 'confirm deletion':  # if user has clicked 'yes' on the confirmation page
-                    for id_to_delete in ids_to_delete:
+                courses_in_subplans = list(CoursesInSubplanModel.objects.all().values())
+                for id_to_delete in ids_to_delete:
+                    if perform_function == 'confirm deletion':  # if user has clicked 'yes' on the confirmation page
                         rest_api = requests.delete(model_api_url + id_to_delete + '/')
-                else:
-                    courses_in_subplans = list(CoursesInSubplanModel.objects.all().values())
-                    for id_to_delete in ids_to_delete:
+                    else:
                         if not courses_in_subplans:
                             rest_api = requests.delete(model_api_url + id_to_delete + '/')
                         else:

--- a/cassdegrees/ui/views.py
+++ b/cassdegrees/ui/views.py
@@ -1,9 +1,10 @@
 from django.http import HttpResponse
 from django.shortcuts import render
 from django.db.models import Q
-from api.models import DegreeModel, SubplanModel, CourseModel
+from api.models import DegreeModel, SubplanModel, CourseModel, CoursesInSubplanModel
 import requests
 import csv
+import operator
 from io import TextIOWrapper
 
 
@@ -273,6 +274,7 @@ def manage_courses(request):
     action = request.GET.get('action', 'Add')
 
     courses = requests.get(request.build_absolute_uri('/api/model/course/?format=json')).json()
+    subplans = requests.get(request.build_absolute_uri('/api/model/subplan/?format=json')).json()
     # If POST request, redirect the received information to the backend:
     render_properties = {
         'msg': None,
@@ -356,8 +358,17 @@ def manage_courses(request):
             elif action == 'Delete':
                 ids_to_delete = post_data.getlist('id')
                 rest_api = None
+                courses_in_subplans = list(CoursesInSubplanModel.objects.all().values())
+                print(type(courses_in_subplans))
                 for id_to_delete in ids_to_delete:
-                    rest_api = requests.delete(model_api_url + id_to_delete + '/')
+                    for course in courses_in_subplans:
+                        print(course)
+                        if int(id_to_delete) == int(course['courseId_id']):
+                            used_subplans = [subplan['name'] for subplan in subplans if course['subplanId_id'] == subplan['id']]
+                            print(used_subplans)
+                            print('yep')
+                        # else:
+                        #     rest_api = requests.delete(model_api_url + id_to_delete + '/')
 
                 if rest_api is None:
                     render_properties['is_error'] = True

--- a/cassdegrees/ui/views.py
+++ b/cassdegrees/ui/views.py
@@ -278,7 +278,8 @@ def manage_courses(request):
     # If POST request, redirect the received information to the backend:
     render_properties = {
         'msg': None,
-        'is_error': False
+        'msg_type': None,
+        'is_confirm': False
     }
 
     if request.method == 'POST':
@@ -305,8 +306,9 @@ def manage_courses(request):
                 rest_api = requests.post(model_api_url, data=course_instance)
                 if rest_api.status_code == 201:
                     render_properties['msg'] = 'Course successfully added!'
+                    render_properties['msg_type'] = 'msg-success'
                 else:
-                    render_properties['is_error'] = True
+                    render_properties['msg_type'] = 'msg-error'
                     # detects if the course already exists
                     if 'The fields code, year must make a unique set.' in rest_api.json()['non_field_errors']:
                         render_properties['msg'] = "The course you are trying to create already exists!"
@@ -334,14 +336,15 @@ def manage_courses(request):
 
                     if rest_api.status_code == 200:
                         render_properties['msg'] = 'Course information successfully modified!'
+                        render_properties['msg_type'] = 'msg-success'
                     else:
-                        render_properties['is_error'] = True
+                        render_properties['msg_type'] = 'msg-error'
                         render_properties['msg'] = "Failed to edit course information. Please try again."
 
         # If the request came from list.html (from the add, edit and delete button from the courses list page),
         # fetch and pre-fill the course info on the edit form if edit button was clicked on,
         # or delete the selected course immediately.
-        elif perform_function == 'retrieve view from selected':
+        elif perform_function == 'retrieve view from selected' or perform_function == 'confirm deletion':
             if action == 'Edit':
                 id_to_edit = post_data.get('id')
                 if id_to_edit:
@@ -351,33 +354,41 @@ def manage_courses(request):
                     render_properties['edit_course_info'] = current_course_info
 
                 else:
-                    render_properties['is_error'] = True
+                    render_properties['msg_type'] = 'msg-error'
                     render_properties['hide_form'] = True
                     render_properties['msg'] = "Please select a course to edit!"
 
             elif action == 'Delete':
-                ids_to_delete = post_data.getlist('id')
                 rest_api = None
-                courses_in_subplans = list(CoursesInSubplanModel.objects.all().values())
-                print(type(courses_in_subplans))
-                for id_to_delete in ids_to_delete:
-                    for course in courses_in_subplans:
-                        print(course)
-                        if int(id_to_delete) == int(course['courseId_id']):
-                            used_subplans = [subplan['name'] for subplan in subplans if course['subplanId_id'] == subplan['id']]
-                            print(used_subplans)
-                            print('yep')
-                        # else:
-                        #     rest_api = requests.delete(model_api_url + id_to_delete + '/')
-
-                if rest_api is None:
-                    render_properties['is_error'] = True
+                ids_to_delete = post_data.getlist('id')
+                used_subplans = []
+                if perform_function == 'confirm deletion':  # if user has clicked 'yes' on the confirmation page
+                    for id_to_delete in ids_to_delete:
+                        rest_api = requests.delete(model_api_url + id_to_delete + '/')
+                else:
+                    courses_in_subplans = list(CoursesInSubplanModel.objects.all().values())
+                    for id_to_delete in ids_to_delete:
+                        if not courses_in_subplans:
+                            rest_api = requests.delete(model_api_url + id_to_delete + '/')
+                        else:
+                            for course in courses_in_subplans:
+                                if int(id_to_delete) == int(course['courseId_id']):
+                                    used_subplans.extend(
+                                        [subplan['name'] + '(' + subplan['code'] + ')' for subplan in subplans if
+                                         course['subplanId_id'] == subplan['id']])
+                if used_subplans:  # if there any subplans that use the course
+                    render_properties['is_confirm'] = True
+                    render_properties['msg_type'] = 'msg-warn'
+                    render_properties['msg'] = 'The Sub-Plans ' + ', '.join(used_subplans) + ' use this course. Do you want to continue?'
+                elif rest_api is None:
+                    render_properties['msg_type'] = 'msg-error'
                     render_properties['msg'] = 'Please select a course to delete!'
                 else:
                     if rest_api.status_code == 204:
+                        render_properties['msg_type'] = 'msg-success'
                         render_properties['msg'] = 'Course successfully deleted!'
                     else:
-                        render_properties['is_error'] = True
+                        render_properties['msg_type'] = 'msg-error'
                         render_properties['msg'] = "Failed to delete course. " \
                                                    "An unknown error has occurred. Please try again."
 

--- a/cassdegrees/ui/views.py
+++ b/cassdegrees/ui/views.py
@@ -367,10 +367,11 @@ def manage_courses(request):
                     if perform_function == 'confirm deletion':  # if user has clicked 'yes' on the confirmation page
                         rest_api = requests.delete(model_api_url + id_to_delete + '/')
                     else:
-                        if not courses_in_subplans:
+                        if not courses_in_subplans:  # delete immediately if no subplans use the course
                             rest_api = requests.delete(model_api_url + id_to_delete + '/')
                         else:
                             for course in courses_in_subplans:
+                                # if course being deleted is in current subplan
                                 if int(id_to_delete) == int(course['courseId_id']):
                                     # TODO: improve this using django queries
                                     used_subplans.extend(

--- a/cassdegrees/ui/views.py
+++ b/cassdegrees/ui/views.py
@@ -373,6 +373,7 @@ def manage_courses(request):
                         else:
                             for course in courses_in_subplans:
                                 if int(id_to_delete) == int(course['courseId_id']):
+                                    # TODO: improve this using django queries
                                     used_subplans.extend(
                                         [subplan['name'] + '(' + subplan['code'] + ')' for subplan in subplans if
                                          course['subplanId_id'] == subplan['id']])


### PR DESCRIPTION
This pull request aims to satisfy the last acceptance criterion of #29 Course Deletion (8) and to help satisfy the last criterion of #32 Template/Subplan Removal (8).
When a course, that is being used in one or more subplan, is selected to be deleted, a confirmation page pops up asking the user to confirm the deletion. When clicked 'No' the page goes back to the previous page. When clicked 'Yes', they are prompted with a message whether or not the deletion was successful.

![image](https://user-images.githubusercontent.com/24206502/56631510-f00da900-6698-11e9-98f4-bc6100278b38.png)
