### PR TITLE
Program reference consistency

### DIFF
--- a/cassdegrees/api/admin.py
+++ b/cassdegrees/api/admin.py
@@ -5,4 +5,4 @@ from .models import *
 admin.site.register(SampleModel)
 admin.site.register(CourseModel)
 admin.site.register(SubplanModel)
-admin.site.register(DegreeModel)
+admin.site.register(ProgramModel)

--- a/cassdegrees/api/models.py
+++ b/cassdegrees/api/models.py
@@ -36,7 +36,7 @@ class SubplanModel(models.Model):
         unique_together = (("code", "year"), ("year", "name", "planType"),)
 
 
-class DegreeModel(models.Model):
+class ProgramModel(models.Model):
     id = models.AutoField(primary_key=True)
     code = models.CharField(max_length=32)
     year = models.PositiveIntegerField()
@@ -52,7 +52,7 @@ class DegreeModel(models.Model):
                      ("vert-doub", "Vertical Flexible Double Degree"),
                      ("other", "Other Degree"))
 
-    degreeType = models.CharField(max_length=10, choices=degreeChoices)
+    programType = models.CharField(max_length=10, choices=degreeChoices)
 
     globalRequirements = psql.JSONField(default=list)
     rules = psql.JSONField(default=list)

--- a/cassdegrees/api/serializers.py
+++ b/cassdegrees/api/serializers.py
@@ -21,7 +21,7 @@ class SubplanSerializer(serializers.HyperlinkedModelSerializer):
         fields = ('id', 'code', 'year', 'name', 'units', 'planType', 'courses')
 
 
-class DegreeSerializer(serializers.HyperlinkedModelSerializer):
+class ProgramSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
-        model = DegreeModel
-        fields = ('id', 'code', 'year', 'name', 'units', 'degreeType', 'globalRequirements', 'rules')
+        model = ProgramModel
+        fields = ('id', 'code', 'year', 'name', 'units', 'programType', 'globalRequirements', 'rules')

--- a/cassdegrees/api/urls.py
+++ b/cassdegrees/api/urls.py
@@ -24,7 +24,7 @@ urlpatterns = [
     path('model/course/<str:pk>/', CourseRecord.as_view()),
     path('model/subplan/', SubplanList.as_view()),
     path('model/subplan/<str:pk>/', SubplanRecord.as_view()),
-    path('model/degree/', DegreeList.as_view()),
-    path('model/degree/<str:pk>/', DegreeRecord.as_view()),
+    path('model/program/', ProgramList.as_view()),
+    path('model/program/<str:pk>/', ProgramRecord.as_view()),
     path('search/', search)
 ]

--- a/cassdegrees/api/views.py
+++ b/cassdegrees/api/views.py
@@ -40,20 +40,20 @@ class SubplanRecord(generics.RetrieveUpdateDestroyAPIView):
     serializer_class = SubplanSerializer
 
 
-class DegreeList(generics.ListCreateAPIView):
-    queryset = DegreeModel.objects.all()
-    serializer_class = DegreeSerializer
+class ProgramList(generics.ListCreateAPIView):
+    queryset = ProgramModel.objects.all()
+    serializer_class = ProgramSerializer
 
 
-class DegreeRecord(generics.RetrieveUpdateDestroyAPIView):
-    queryset = DegreeModel.objects.all()
-    serializer_class = DegreeSerializer
+class ProgramRecord(generics.RetrieveUpdateDestroyAPIView):
+    queryset = ProgramModel.objects.all()
+    serializer_class = ProgramSerializer
 
 def search(request):
     """ Queries the database based on the URL parameters
 
     Url Parameters:
-        select -> The name of the table to extract from (e.g. degree, subplan, course)
+        select -> The name of the table to extract from (e.g. program, subplan, course)
         from   -> A comma-separated list of names to get queries for
         [name] -> The name of a list and the text to search for inside that name (code=COMP finds comp courses)
 
@@ -66,13 +66,13 @@ def search(request):
 
     Example queries:
         /api/search/from=course
-        /api/search/?select=id,code&from=degree
+        /api/search/?select=id,code&from=program
         /api/search/?select=code,name,rules&from=subplan&code=COMP&name=systems%20and&20architecture
 
     :param request:
     :return <class django.http.response.JsonResponse>:
     """
-    model_map = {'degree': DegreeModel, 'subplan': SubplanModel, 'course': CourseModel}
+    model_map = {'program': ProgramModel, 'subplan': SubplanModel, 'course': CourseModel}
 
     # Extracts a model from the model_map, choosing None if an invalid model was requested
     model = model_map.get(request.GET.get('from'), None)

--- a/cassdegrees/templates/base.html
+++ b/cassdegrees/templates/base.html
@@ -4,7 +4,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>{% block page-title %}No title defined{% endblock %} - CASS Degree Planner</title>
+    <title>{% block page-title %}No title defined{% endblock %} - CASS Program Planner</title>
 
     <!-- Adapted from CASS homepage root -->
     <link href="//style.anu.edu.au/_anu/4/images/logos/anu.ico" rel="shortcut icon" type="image/x-icon"/>
@@ -41,7 +41,7 @@
                 
                 <div class="left" id="bnr-h-lines">
                     <div class="bnr-line-1 bnr-1line">
-                        <h1><a href="/">CASS Degrees Planner</a></h1>
+                        <h1><a href="/">CASS Program Planner</a></h1>
                     </div>
                 </div>
             

--- a/cassdegrees/templates/createcourse.html
+++ b/cassdegrees/templates/createcourse.html
@@ -6,7 +6,7 @@
 {% block subtitle %}{% if edit %}Edit{% else %}Create{% endif %} Course{% endblock %}
 
 {% block breadcrumb-trail %}
-    {% breadcrumb  '/list/?view=Course' 'Templates/Subplans/Courses' %}
+    {% breadcrumb  '/list/?view=Course' 'Programs/Subplans/Courses' %}
     {% if edit %}
         {% finalcrumb 'Edit Course' %}
     {% else %}

--- a/cassdegrees/templates/createprogram.html
+++ b/cassdegrees/templates/createprogram.html
@@ -7,7 +7,7 @@
 {% block subtitle %}{% if edit %}Edit{% else %}Create{% endif %} Program Template{% endblock %}
 
 {% block breadcrumb-trail %}
-    {% breadcrumb  '/list/?view=Degree' 'Templates/Subplans/Courses' %}
+    {% breadcrumb  '/list/?view=Program' 'Programs/Subplans/Courses' %}
     {% if edit %}
         {% finalcrumb 'Edit Program' %}
     {% else %}

--- a/cassdegrees/templates/createsubplan.html
+++ b/cassdegrees/templates/createsubplan.html
@@ -6,7 +6,7 @@
 {% block subtitle %}{% if edit %}Edit{% else %}Create{% endif %} Subplan{% endblock %}
 
 {% block breadcrumb-trail %}
-    {% breadcrumb  '/list/?view=Subplan' 'Templates/Subplans/Courses' %}
+    {% breadcrumb  '/list/?view=Subplan' 'Programs/Subplans/Courses' %}
     {% if edit %}
         {% finalcrumb 'Edit Subplan' %}
     {% else %}

--- a/cassdegrees/templates/deletecourses.html
+++ b/cassdegrees/templates/deletecourses.html
@@ -5,7 +5,7 @@
 {% block page-title %}Delete Courses{% endblock %}
 
 {% block breadcrumb-trail %}
-    {% breadcrumb  '/list/?view=Course' 'Templates/Subplans/Courses' %}
+    {% breadcrumb  '/list/?view=Course' 'Programs/Subplans/Courses' %}
     {% finalcrumb 'Delete Course' %}
 {% endblock %}
 

--- a/cassdegrees/templates/deletecourses.html
+++ b/cassdegrees/templates/deletecourses.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% load static %}
-{% load readcrumbs %}
+{% load breadcrumbs %}
 
 {% block page-title %}Delete Courses{% endblock %}
 

--- a/cassdegrees/templates/deleteprograms.html
+++ b/cassdegrees/templates/deleteprograms.html
@@ -5,7 +5,7 @@
 {% block page-title %}Delete Program Templates{% endblock %}
 
 {% block breadcrumb-trail %}
-    {% breadcrumb  '/list/?view=Degree' 'Templates/Subplans/Courses' %}
+    {% breadcrumb  '/list/?view=Program' 'Programs/Subplans/Courses' %}
     {% finalcrumb 'Delete Program' %}
 {% endblock %}
 

--- a/cassdegrees/templates/deletesubplans.html
+++ b/cassdegrees/templates/deletesubplans.html
@@ -5,7 +5,7 @@
 {% block page-title %}Delete Subplans{% endblock %}
 
 {% block breadcrumb-trail %}
-    {% breadcrumb  '/list/?view=Subplan' 'Templates/Subplans/Courses' %}
+    {% breadcrumb  '/list/?view=Subplan' 'Programs/Subplans/Courses' %}
     {% finalcrumb 'Delete Subplan' %}
 {% endblock %}
 

--- a/cassdegrees/templates/list.html
+++ b/cassdegrees/templates/list.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
 {% load breadcrumbs %}
 
-{% block page-title %}Template/Subplan/Course List{% endblock %}
+{% block page-title %}Program/Subplan/Course List{% endblock %}
 
-{% block subtitle %}Template, Subplan, and Course List{% endblock %}
+{% block subtitle %}Program, Subplan, and Course List{% endblock %}
 
 {% block breadcrumb-trail %}
-    {% finalcrumb 'Templates/Subplans/Courses' %}
+    {% finalcrumb 'Programs/Subplans/Courses' %}
 {% endblock %}
 
 {% block content %}
@@ -16,7 +16,7 @@
 
     <form class="box bdr-solid bdr-uni bg-uni50 anuform custom_search_bar" action="/list/?action=Search" method="get">
         <input class="text" name="q" size="24" maxlength="75" type="text"
-               placeholder="Search Degrees, Subplans, or Courses..."
+               placeholder="Search Programs, Subplans, or Courses..."
                value="{{ autofill }}"
         >
         <input class="btn-uni-grad btn-medium" type="submit" value="Search">
@@ -46,7 +46,7 @@
                 {# Allow manage_courses() function to behave appropriately based on origin of request. The post request can either come from list.html or managecourses.html #}
                 <input type="hidden" id="perform_function" name="perform_function" value="retrieve view from selected">
                 <p class="left">
-                    <input class="btn-uni-grad" type ="submit" formmethod="get" formaction="/create/{% if title == 'Degree' %}program{% elif title == 'Subplan' %}subplan{% elif title == 'Course' %}course{% endif %}/" value="New {{ title }}">
+                    <input class="btn-uni-grad" type ="submit" formmethod="get" formaction="/create/{% if title == 'Program' %}program{% elif title == 'Subplan' %}subplan{% elif title == 'Course' %}course{% endif %}/" value="New {{ title }}">
                 </p>
                 <table class="fullwidth tbl-cell-bdr">
                     {# Add title row based on what was in the dictionary #}
@@ -71,7 +71,7 @@
                                     {% else %}
                                         <td><p class="text-center"><input title="Select" type="checkbox" name="id" value="{{ item }}"  onchange="sessionStorage.setItem('selected', {{ item }})"/></p></td>
                                         <td>
-                                            <a class="btn-uni-grad" href="/edit/{% if title == 'Degree' %}program{% elif title == 'Subplan' %}subplan{% elif title == 'Course' %}course{% endif %}/?id={{ item }}">Edit</a>
+                                            <a class="btn-uni-grad" href="/edit/{% if title == 'Program' %}program{% elif title == 'Subplan' %}subplan{% elif title == 'Course' %}course{% endif %}/?id={{ item }}">Edit</a>
                                             <a class="btn-uni-grad" href="/api/model/{{ title.lower }}/{{ item }}/">View</a>
                                         </td>
                                     {% endif %}
@@ -87,7 +87,7 @@
                 {% else %}
                 <div class="right">
                     <p class="right">
-                       <input class="btn-uni-grad btn-large" type ="submit" formaction="/delete/{% if title == 'Degree' %}programs{% elif title == 'Subplan' %}subplans{% elif title == 'Course' %}courses{% endif %}/" value="Delete Selected">
+                       <input class="btn-uni-grad btn-large" type ="submit" formaction="/delete/{% if title == 'Program' %}programs{% elif title == 'Subplan' %}subplans{% elif title == 'Course' %}courses{% endif %}/" value="Delete Selected">
                     </p>
                 </div>
                 {% endif %}

--- a/cassdegrees/ui/forms.py
+++ b/cassdegrees/ui/forms.py
@@ -1,6 +1,6 @@
 import json
 
-from api.models import DegreeModel, SubplanModel, CourseModel
+from api.models import ProgramModel, SubplanModel, CourseModel
 from django import forms
 from django.core.exceptions import NON_FIELD_ERRORS
 from django.forms import ModelForm
@@ -23,17 +23,17 @@ class EditProgramFormSnippet(ModelForm):
     globalRequirements = JSONField(field_id='globalRequirements', required=False)
 
     class Meta:
-        model = DegreeModel
-        fields = ('code', 'year', 'name', 'units', 'degreeType', 'globalRequirements')
+        model = ProgramModel
+        fields = ('code', 'year', 'name', 'units', 'programType', 'globalRequirements')
         widgets = {
             'code': forms.TextInput(attrs={'class': "text tfull", 'placeholder': "e.g. BARTS"}),
             'year': forms.NumberInput(attrs={'class': "text tfull", 'min': 2000, 'max': 3000}),
             'name': forms.TextInput(attrs={'class': "text tfull", 'placeholder': "e.g. Bachelor of Arts"}),
             'units': forms.NumberInput(attrs={'class': "text tfull", 'step': 6, 'max': 512}),
-            # DegreeType auto generated
+            # ProgramType auto generated
         }
         labels = {
-            'degreeType': "Program Type",
+            'programType': "Program Type",
         }
         error_messages = {
             NON_FIELD_ERRORS: {

--- a/cassdegrees/ui/views/courses.py
+++ b/cassdegrees/ui/views/courses.py
@@ -1,4 +1,4 @@
-from api.models import CoursesInSubplanModel, CourseModel
+from api.models import CourseModel
 from django.http import HttpResponseNotFound
 from django.shortcuts import render, redirect
 

--- a/cassdegrees/ui/views/listings.py
+++ b/cassdegrees/ui/views/listings.py
@@ -1,4 +1,4 @@
-from api.models import DegreeModel, SubplanModel, CourseModel
+from api.models import ProgramModel, SubplanModel, CourseModel
 from django.db.models import Q
 from django.shortcuts import render
 
@@ -21,7 +21,7 @@ def data_list(request):
 
     # No search, render default page
     if not query:
-        return render(request, 'list.html', context={'data': {'Degree': DegreeModel.objects.values(),
+        return render(request, 'list.html', context={'data': {'Program': ProgramModel.objects.values(),
                                                               'Subplan': SubplanModel.objects.values(),
                                                               'Course': CourseModel.objects.values()},
                                                      'render': render_properties})
@@ -33,7 +33,7 @@ def data_list(request):
 
         # Create blank queries for text and dates (Allows AND relationship between dates and text)
         # The AND/OR representations are there to give higher priority to results that contain all keywords
-        new_query = {x: {'AND': Q(), 'OR': Q(), 'date': Q()} for x in ['Course', 'Subplan', 'Degree']}
+        new_query = {x: {'AND': Q(), 'OR': Q(), 'date': Q()} for x in ['Course', 'Subplan', 'Program']}
 
         # Function that takes an input dict and a sub-query, and appends the sub-query based on the appropriate logic
         def build_query(target, q):
@@ -59,16 +59,16 @@ def data_list(request):
                 #      in a search for `COMP CHIN`
                 new_query['Course']['date'] |= Q(year=int(term)) | Q(name__icontains=term) | Q(code__icontains=term)
                 new_query['Subplan']['date'] |= Q(year=int(term)) | Q(name__icontains=term) | Q(code__icontains=term)
-                new_query['Degree']['date'] |= Q(year=int(term)) | Q(name__icontains=term) | Q(code__icontains=term)
+                new_query['Program']['date'] |= Q(year=int(term)) | Q(name__icontains=term) | Q(code__icontains=term)
             # If the search term has no obvious structure, search for it in the code and name fields
             else:
                 build_query(new_query['Course'], Q(code__icontains=term) | Q(name__icontains=term))
                 build_query(new_query['Subplan'], Q(code__icontains=term) | Q(name__icontains=term))
-                build_query(new_query['Degree'], Q(code__icontains=term) | Q(name__icontains=term))
+                build_query(new_query['Program'], Q(code__icontains=term) | Q(name__icontains=term))
 
-        # If the degree, subplan, or course searches are non-empty, query the database
+        # If the program, subplan, or course searches are non-empty, query the database
         data = {}
-        for target, model in [('Degree', DegreeModel), ('Subplan', SubplanModel), ('Course', CourseModel)]:
+        for target, model in [('Program', ProgramModel), ('Subplan', SubplanModel), ('Course', CourseModel)]:
             # If the query is not blank, search for it in the database (Prevents unnecessary searches)
             if new_query[target]['AND'].children or new_query[target]['date'].children:
                 # SELECT from the the appropriate relation with the AND and OR queries

--- a/cassdegrees/ui/views/programs.py
+++ b/cassdegrees/ui/views/programs.py
@@ -1,4 +1,4 @@
-from api.models import DegreeModel
+from api.models import ProgramModel
 from django.http import HttpResponseNotFound
 from django.shortcuts import render, redirect
 
@@ -11,7 +11,7 @@ def create_program(request):
 
         if form.is_valid():
             form.save()
-            return redirect('/list/?view=Degree&msg=Successfully Added Program!')
+            return redirect('/list/?view=Program&msg=Successfully Added Program!')
 
     else:
         form = EditProgramFormSnippet()
@@ -28,13 +28,13 @@ def delete_program(request):
 
     ids_to_delete = data.getlist('id')
     for id_to_delete in ids_to_delete:
-        instances.append(DegreeModel.objects.get(id=int(id_to_delete)))
+        instances.append(ProgramModel.objects.get(id=int(id_to_delete)))
 
     if "confirm" in data:
         for instance in instances:
             instance.delete()
 
-        return redirect('/list/?view=Degree&msg=Successfully Deleted Program(s)!')
+        return redirect('/list/?view=Program&msg=Successfully Deleted Program(s)!')
     else:
         return render(request, 'deleteprograms.html', context={
             "instances": instances
@@ -47,14 +47,14 @@ def edit_program(request):
         return HttpResponseNotFound("Specified ID not found")
 
     # Find the program to specifically edit
-    instance = DegreeModel.objects.get(id=int(id))
+    instance = ProgramModel.objects.get(id=int(id))
 
     if request.method == 'POST':
         form = EditProgramFormSnippet(request.POST, instance=instance)
 
         if form.is_valid():
             form.save()
-            return redirect('/list/?view=Degree&msg=Successfully Edited Program!')
+            return redirect('/list/?view=Program&msg=Successfully Edited Program!')
 
     else:
         form = EditProgramFormSnippet(instance=instance)

--- a/cassdegrees/ui/views/subplans.py
+++ b/cassdegrees/ui/views/subplans.py
@@ -6,7 +6,7 @@ from ui.forms import EditSubplanFormSnippet
 from api.models import SubplanModel
 
 
-# Using sampleform template and #59 - basic degree creation workflow as it's inspirations
+# Using sampleform template and #59 - basic program creation workflow as it's inspirations
 def create_subplan(request):
     if request.method == 'POST':
         form = EditSubplanFormSnippet(request.POST)


### PR DESCRIPTION
This PR removes the use of the words `Degree` and `Template`, and instead uses the word `Program`. 

I didn't go as far as renaming the project (which is called CassDegrees) as it doesn't really affect the rest of the project. Since the project was advertised to us as `cass degrees` I think this is fine.

Just a reminder that you will need to call the following commands to see changes:
`python manage.py makemigrations`
`python manage.py migrate`

NOTE: You will lose all of you Program data by implementing these changes