### PR TITLE
Subplan Duplication

### DIFF
--- a/cassdegrees/templates/list.html
+++ b/cassdegrees/templates/list.html
@@ -73,7 +73,7 @@
                                         <td>
                                             {# Only Programs and Subplans will need this feature #}
                                             {% if title == 'Program' or title == 'Subplan'  %}
-                                                <a class="btn-uni-grad" href="/create/{% if title == 'Program' %}program{% elif title == 'Subplan' %}subplan{% elif title == 'Course' %}course{% endif %}/?id={{ item }}&duplicate=true">Duplicate</a>
+                                                <a class="btn-uni-grad" href="/create/{% if title == 'Program' %}program{% elif title == 'Subplan' %}subplan{% endif %}/?id={{ item }}&duplicate=true">Duplicate</a>
                                             {% endif %}
                                             <a class="btn-uni-grad" href="/edit/{% if title == 'Program' %}program{% elif title == 'Subplan' %}subplan{% elif title == 'Course' %}course{% endif %}/?id={{ item }}">Edit</a>
                                             <a class="btn-uni-grad" href="/api/model/{{ title.lower }}/{{ item }}/">View</a>

--- a/cassdegrees/templates/list.html
+++ b/cassdegrees/templates/list.html
@@ -71,6 +71,10 @@
                                     {% else %}
                                         <td><p class="text-center"><input title="Select" type="checkbox" name="id" value="{{ item }}"  onchange="sessionStorage.setItem('selected', {{ item }})"/></p></td>
                                         <td>
+                                            {# Only Degree and Subplans will need this feature #}
+                                            {% if title == 'Degree' or title == 'Subplan'  %}
+                                                <a class="btn-uni-grad" href="/create/{% if title == 'Degree' %}program{% elif title == 'Subplan' %}subplan{% elif title == 'Course' %}course{% endif %}/?id={{ item }}&duplicate=true">Duplicate</a>
+                                            {% endif %}
                                             <a class="btn-uni-grad" href="/edit/{% if title == 'Degree' %}program{% elif title == 'Subplan' %}subplan{% elif title == 'Course' %}course{% endif %}/?id={{ item }}">Edit</a>
                                             <a class="btn-uni-grad" href="/api/model/{{ title.lower }}/{{ item }}/">View</a>
                                         </td>

--- a/cassdegrees/ui/views/subplans.py
+++ b/cassdegrees/ui/views/subplans.py
@@ -8,6 +8,24 @@ from api.models import SubplanModel
 
 # Using sampleform template and #59 - basic degree creation workflow as it's inspirations
 def create_subplan(request):
+    duplicate = request.GET.get('duplicate', 'false')
+    if duplicate == 'true':
+        duplicate = True
+    elif duplicate == 'false':
+        duplicate = False
+
+    # Initialise instance with an empty string so that we don't get a "may be referenced before assignment" error below
+    instance = ""
+
+    # If we are creating a subplan from a duplicate, we retrieve the instance with the given id
+    # (should always come along with 'duplicate' variable) and return that data to the user.
+    if duplicate:
+        id = request.GET.get('id')
+        if not id:
+            return HttpResponseNotFound("Specified ID not found")
+        # Find the subplan to specifically create from:
+        instance = SubplanModel.objects.get(id=int(id))
+
     if request.method == 'POST':
         form = EditSubplanFormSnippet(request.POST)
 
@@ -16,7 +34,10 @@ def create_subplan(request):
             return redirect('/list/?view=Subplan&msg=Successfully Added Subplan!')
 
     else:
-        form = EditSubplanFormSnippet()
+        if duplicate:
+            form = EditSubplanFormSnippet(instance=instance)
+        else:
+            form = EditSubplanFormSnippet()
 
     return render(request, 'createsubplan.html', context={
         "form": form


### PR DESCRIPTION
Original Issue: https://github.com/cass-degrees/CASS-Degrees-Code/issues/25

Like the Template Duplication counterpart, users can choose to create a new subplan based off an existing subplan by clicking on "Duplicate" button corresponding to a specific subplan.