### PR TITLE
Subplan Saving

### DIFF
--- a/cassdegrees/api/models.py
+++ b/cassdegrees/api/models.py
@@ -26,7 +26,8 @@ class SubplanModel(models.Model):
     year = models.PositiveIntegerField()
     name = models.CharField(max_length=256)
     units = models.PositiveIntegerField()
-    courses = psql.JSONField(default=list)
+    rules = psql.JSONField(default=list)
+    publish = models.BooleanField(default=False)
 
     subplanChoices = (("MAJ", "Major"), ("MIN", "Minor"), ("SPEC", "Specialisation"))
 

--- a/cassdegrees/api/serializers.py
+++ b/cassdegrees/api/serializers.py
@@ -18,7 +18,7 @@ class CourseSerializer(serializers.HyperlinkedModelSerializer):
 class SubplanSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = SubplanModel
-        fields = ('id', 'code', 'year', 'name', 'units', 'planType', 'courses')
+        fields = ('id', 'code', 'year', 'name', 'units', 'planType', 'rules', 'publish')
 
 
 class ProgramSerializer(serializers.HyperlinkedModelSerializer):

--- a/cassdegrees/ui/forms.py
+++ b/cassdegrees/ui/forms.py
@@ -66,11 +66,12 @@ class EditSubplanFormSnippet(ModelForm):
 
     class Meta:
         model = SubplanModel
-        fields = ('code', 'year', 'name', 'units', 'planType')
+        fields = ('code', 'year', 'name', 'units', 'planType', 'publish')
         widgets = {
             'code': forms.TextInput(attrs={'class': "text tfull", 'placeholder': "e.g. ARTH-MIN"}),
             'year': forms.NumberInput(attrs={'class': "text tfull", 'min': 2000, 'max': 3000}),
             'name': forms.TextInput(attrs={'class': "text tfull", 'placeholder': "e.g. Art History Minor"}),
+            'publish': forms.CheckboxInput()
             # See units above
             # planType auto generated
         }


### PR DESCRIPTION
This PR is a re-do of #73, and implements the same changes on the updated system. This mostly includes the ability to save Subplans as a draft or final subplan.