### PR TITLE
Subplan deletion now checks if the subplan is used by a degree

### DIFF
--- a/cassdegrees/templates/list.html
+++ b/cassdegrees/templates/list.html
@@ -13,8 +13,8 @@
     {% if render.msg != None %}
         <p class="msg-success">{{ render.msg }}</p>
     {% endif %}
-    {% if render.errmsg != None %}
-        <p class="msg-error">{{ render.errmsg }}</p>
+    {% if render.error != None %}
+        <p class="msg-error">{{ render.error }}</p>
     {% endif %}
 
     <form class="box bdr-solid bdr-uni bg-uni50 anuform custom_search_bar" action="/list/?action=Search" method="get">

--- a/cassdegrees/templates/list.html
+++ b/cassdegrees/templates/list.html
@@ -13,8 +13,9 @@
     {% if render.msg != None %}
         <p class="msg-success">{{ render.msg }}</p>
     {% endif %}
+    {# linebreaksbr adds a <br> whenever there is a \n in a string #}
     {% if render.error != None %}
-        <p class="msg-error">{{ render.error }}</p>
+        <p class="msg-error">{{ render.error|linebreaksbr }}</p>
     {% endif %}
 
     <form class="box bdr-solid bdr-uni bg-uni50 anuform custom_search_bar" action="/list/?action=Search" method="get">

--- a/cassdegrees/templates/list.html
+++ b/cassdegrees/templates/list.html
@@ -13,6 +13,9 @@
     {% if render.msg != None %}
         <p class="msg-success">{{ render.msg }}</p>
     {% endif %}
+    {% if render.errmsg != None %}
+        <p class="msg-error">{{ render.errmsg }}</p>
+    {% endif %}
 
     <form class="box bdr-solid bdr-uni bg-uni50 anuform custom_search_bar" action="/list/?action=Search" method="get">
         <input class="text" name="q" size="24" maxlength="75" type="text"

--- a/cassdegrees/ui/views/listings.py
+++ b/cassdegrees/ui/views/listings.py
@@ -16,7 +16,8 @@ def data_list(request):
     query = request.GET.get('q', '')
 
     render_properties = {
-        'msg': request.GET.get('msg')
+        'msg': request.GET.get('msg'),
+        'errmsg': request.GET.get('errmsg')
     }
 
     # No search, render default page

--- a/cassdegrees/ui/views/listings.py
+++ b/cassdegrees/ui/views/listings.py
@@ -17,7 +17,7 @@ def data_list(request):
 
     render_properties = {
         'msg': request.GET.get('msg'),
-        'errmsg': request.GET.get('errmsg')
+        'error': request.GET.get('error')
     }
 
     # No search, render default page

--- a/cassdegrees/ui/views/subplans.py
+++ b/cassdegrees/ui/views/subplans.py
@@ -53,14 +53,14 @@ def delete_subplan(request):
     # This is used to get the ids of subplans which are used by programs.
     # Generates an internal request to the search api made by Jack
     gen_request = HttpRequest()
-    gen_request.GET = {'select': 'code,rules', 'from': 'program'}
+    gen_request.GET = {'select': 'code,rules,year', 'from': 'program'}
     # Sends the request to the search api
     send_search_request = search(gen_request)
     subplans_in_programs = json.loads(send_search_request.content.decode())
 
     # Generate another request to get the subplan codes and ids
     # This is so we can get the code of the subplan from the id we are given
-    gen_request.GET = {'select': 'code,id', 'from': 'subplan'}
+    gen_request.GET = {'select': 'code,id,year', 'from': 'subplan'}
     send_search_request = search(gen_request)
     subplan_ids = json.loads(send_search_request.content.decode())
 
@@ -79,16 +79,17 @@ def delete_subplan(request):
                     for subplan in subplan_ids:
                         if int(id_to_delete) == subplan['id']:
                             # Populate the error message with the id's code names we found
-                            error_msg += "Subplan code: '" + subplan['code'] + \
-                                        "' is used by Program code: '" + program['code'] + "'. "
+                            error_msg += "Subplan code: '" + subplan['code'] + "' of year: " + str(subplan['year']) + \
+                                        " is used by Program code: '" + program['code'] + "' of year: " + \
+                                         str(subplan['year']) + ".\n"
 
         # Only delete if its safe to delete, otherwise notify the user of the dependencies
         if safe_to_delete:
             instances.append(SubplanModel.objects.get(id=int(id_to_delete)))
 
     if error_msg != "":
-        return redirect('/list/?view=Subplan&error=Failed to Delete Subplan(s)! ' + error_msg +
-                        'Please check dependencies!')
+        return redirect('/list/?view=Subplan&error=Failed to Delete Subplan(s)!\n\n' + error_msg +
+                        '\nPlease check dependencies!')
 
     if "confirm" in data:
         for instance in instances:

--- a/cassdegrees/ui/views/subplans.py
+++ b/cassdegrees/ui/views/subplans.py
@@ -50,24 +50,45 @@ def delete_subplan(request):
     data = request.POST
     instances = []
 
+    # This is used to get the ids of subplans which are used by programs.
+    # Generates an internal request to the search api made by Jack
     gen_request = HttpRequest()
-    gen_request.GET = {'select': 'rules', 'from': 'program'}
-
+    gen_request.GET = {'select': 'code,rules', 'from': 'program'}
+    # Sends the request to the search api
     send_search_request = search(gen_request)
-    subplans_in_degrees = json.loads(send_search_request.content.decode())
+    subplans_in_programs = json.loads(send_search_request.content.decode())
 
+    # Generate another request to get the subplan codes and ids
+    # This is so we can get the code of the subplan from the id we are given
+    gen_request.GET = {'select': 'code,id', 'from': 'subplan'}
+    send_search_request = search(gen_request)
+    subplan_ids = json.loads(send_search_request.content.decode())
+
+    # Get the ids to delete and check if they're used by any programs
     ids_to_delete = data.getlist('id')
     safe_to_delete = True
+    error_msg = ""
     for id_to_delete in ids_to_delete:
-        for degree in subplans_in_degrees:
-            for subplans in degree['rules']:
+        # find if the id matches any rules in the programs.
+        for program in subplans_in_programs:
+            for subplans in program['rules']:
+                # if we find a subplan in a program then its not safe to delete
                 if int(id_to_delete) in subplans['ids']:
                     safe_to_delete = False
+                    # Find the subplan code for the id to delete
+                    for subplan in subplan_ids:
+                        if int(id_to_delete) == subplan['id']:
+                            # Populate the error message with the id's code names we found
+                            error_msg += "Subplan code: '" + subplan['code'] + \
+                                        "' is used by Program code: '" + program['code'] + "'. "
 
-        if (safe_to_delete):
+        # Only delete if its safe to delete, otherwise notify the user of the dependencies
+        if safe_to_delete:
             instances.append(SubplanModel.objects.get(id=int(id_to_delete)))
-        else:
-            return redirect('/list/?view=Subplan&errmsg=Failed to Delete Subplan(s)! Subplan is used by a Degree. Please check dependencies')
+
+    if error_msg != "":
+        return redirect('/list/?view=Subplan&error=Failed to Delete Subplan(s)! ' + error_msg +
+                        'Please check dependencies!')
 
     if "confirm" in data:
         for instance in instances:


### PR DESCRIPTION
As the title says, subplan deletion now checks if it is used by any degrees before allowing the user to delete. This completes the final acceptance criteria of #32 
Works for if multiple are selected too. 
However, doesn't tell them which degree and subplan are affected. 
Wasn't sure how to convey this without it being a long error message. - Please tell me what you think and I'll update it before we merge

<img width="893" alt="delete fail" src="https://user-images.githubusercontent.com/44992275/57007477-42684000-6c2c-11e9-80f4-589b9a9a4ff5.PNG">
