### PR TITLE
Create Subplan During Template Creation (PR)

### DIFF
--- a/cassdegrees/templates/createprogram.html
+++ b/cassdegrees/templates/createprogram.html
@@ -39,6 +39,8 @@
                      <div class="msg-error inline-error">{{ error }}</div>
                 {% endfor %}
             {% endfor %}
+
+            <input type="hidden" name="action" value="Save" />
         </fieldset>
     </form>
 
@@ -50,7 +52,17 @@
     </form>
 
     <p class="text-right">
-        <input class="btn-uni-grad btn-large" type="submit" value="{% if edit %}Edit{% else %}Create{% endif %}"
-               onclick="if (handleProgram() && handleRules()) document.getElementById('mainForm').submit()">
+        <input class="btn-uni-grad btn-large" type="submit" value="Save"
+               onclick="submit_form(this.value)">
     </p>
+
+    <script>
+        function submit_form(form_action) {
+            if (handleProgram() && handleRules()) {
+                document.getElementById('mainForm').action.value = form_action;
+                document.getElementById('mainForm').submit()
+            }
+            return false
+        }
+    </script>
 {% endblock %}

--- a/cassdegrees/templates/createprogram.html
+++ b/cassdegrees/templates/createprogram.html
@@ -52,6 +52,7 @@
     </form>
 
     <p class="text-right">
+        <input type="submit" class="btn-uni-grad btn-large" value="Create New Subplan" onclick="submit_form(this.value)">
         <input class="btn-uni-grad btn-large" type="submit" value="Save"
                onclick="submit_form(this.value)">
     </p>

--- a/cassdegrees/templates/widgets/rules.html
+++ b/cassdegrees/templates/widgets/rules.html
@@ -26,6 +26,7 @@
         </div>
 
         <input type="button" v-on:click="add_subplan()" class="btn-uni-grad btn-snall no-left-margin" value="Add new option" />
+        <input type="submit" style="float:right" class="btn-uni-grad btn-snall" value="Create New Subplan" onclick="submit_form(this.value)">
     </fieldset>
 </script>
 

--- a/cassdegrees/templates/widgets/rules.html
+++ b/cassdegrees/templates/widgets/rules.html
@@ -26,7 +26,6 @@
         </div>
 
         <input type="button" v-on:click="add_subplan()" class="btn-uni-grad btn-snall no-left-margin" value="Add new option" />
-        <input type="submit" style="float:right" class="btn-uni-grad btn-snall" value="Create New Subplan" onclick="submit_form(this.value)">
     </fieldset>
 </script>
 

--- a/cassdegrees/ui/views/subplans.py
+++ b/cassdegrees/ui/views/subplans.py
@@ -33,7 +33,12 @@ def create_subplan(request):
 
         if form.is_valid():
             form.save()
-            return redirect('/list/?view=Subplan&msg=Successfully Added Subplan!')
+
+            # If there is cached 'program' data, redirect to that page instead
+            if request.session.get('cached_program_form_data', ''):
+                return redirect(request.session.get('cached_program_form_source', '/'))
+            else:
+                return redirect('/list/?view=Subplan&msg=Successfully Added Subplan!')
 
     else:
         if duplicate:


### PR DESCRIPTION
This PR closes issue #8. 

The changes will allows users to create a subplan while they are in the middle of creating a program. Users will then be able to save their subplan and return to their original form without losing data. If users accidentally click off the subplan form, or otherwise manage to close it, they are still able to navigate to the original form and have their changes persist.

![New Button](https://user-images.githubusercontent.com/36946090/57222662-bfd5eb00-7046-11e9-8dff-2ba73a263077.jpg)
