### PR TITLE
Created Subject-Area Specific Units Rule in Program Template Creation

### DIFF
--- a/cassdegrees/static/js/rules.js
+++ b/cassdegrees/static/js/rules.js
@@ -195,7 +195,7 @@ Vue.component('rule_course', {
     template: '#courseRequirementTemplate'
 });
 
-Vue.component('rule_subject_area_specific', {
+Vue.component('rule_subject_area', {
     props: {
         "details": {
             type: Object,

--- a/cassdegrees/static/js/rules.js
+++ b/cassdegrees/static/js/rules.js
@@ -3,6 +3,7 @@
 // Translation table between internal names for components and human readable ones.
 const COMPONENT_NAMES = {
     'subplan': "Subplan",
+    'subject_area_specific': "Subject-Area Specific Units",
     'course': "Course",
     'custom_text': "Custom (Text)"
 };
@@ -192,6 +193,73 @@ Vue.component('rule_course', {
         }
     },
     template: '#courseRequirementTemplate'
+});
+
+Vue.component('rule_subject_area_specific', {
+    props: {
+        "details": {
+            type: Object,
+
+            validator: function (value) {
+                // Ensure that the object has all the attributes we need
+                if (!value.hasOwnProperty("subject")) {
+                    value.subject = "";
+                }
+
+                return true;
+            }
+        }
+    },
+    data: function() {
+        return {
+            "subject_areas": [],
+
+            // Display related warnings if true
+            "invalid_units": false,
+            "invalid_units_step": false,
+
+            "redraw": false
+        }
+    },
+    created: function() {
+        // Javascript has the best indirection...
+        var rule = this;
+
+        var request = new XMLHttpRequest();
+
+        request.addEventListener("load", function() {
+            rule.subject_areas = JSON.parse(request.response);
+            var subject_areas = [];
+            for (var index in rule.subject_areas) {
+                let subject_area = rule.subject_areas[index]["code"].slice(0,4);
+                // creates a unique list of subject_areas
+                if (subject_areas.indexOf(subject_area) === -1) subject_areas.push(subject_area);
+            }
+            rule.subject_areas = subject_areas;
+            rule.check_options();
+        });
+        request.open("GET", "/api/search/?select=code&from=course");
+        request.send();
+    },
+    methods: {
+        check_options: function() {
+
+            // Ensure Unit Count is valid:
+            if (this.details.unit_count != null) {
+                this.invalid_units = this.details.unit_count <= 0;
+                this.invalid_units_step = this.details.unit_count % 6 !== 0;
+            }
+        },
+        // https://michaelnthiessen.com/force-re-render/
+        do_redraw: function() {
+            this.redraw = true;
+
+            this.$nextTick(() => {
+                this.redraw = false;
+            });
+        }
+    },
+    template: '#subjectAreaSpecificRuleTemplate'
 });
 
 Vue.component('rule_custom_text', {

--- a/cassdegrees/static/js/rules.js
+++ b/cassdegrees/static/js/rules.js
@@ -259,7 +259,7 @@ Vue.component('rule_subject_area', {
             });
         }
     },
-    template: '#subjectAreaSpecificRuleTemplate'
+    template: '#subjectAreaRuleTemplate'
 });
 
 Vue.component('rule_custom_text', {

--- a/cassdegrees/static/js/rules.js
+++ b/cassdegrees/static/js/rules.js
@@ -3,7 +3,7 @@
 // Translation table between internal names for components and human readable ones.
 const COMPONENT_NAMES = {
     'subplan': "Subplan",
-    'subject_area_specific': "Subject-Area Specific Units",
+    'subject_area': "Subject-Area Units",
     'course': "Course",
     'custom_text': "Custom (Text)"
 };

--- a/cassdegrees/templates/widgets/rules.html
+++ b/cassdegrees/templates/widgets/rules.html
@@ -58,7 +58,7 @@
     </fieldset>
 </script>
 
-<script type="text/x-template" id="subjectAreaSpecificRuleTemplate">
+<script type="text/x-template" id="subjectAreaRuleTemplate">
     <fieldset v-if="!redraw">
         <p class="form-group">
             <label>

--- a/cassdegrees/templates/widgets/rules.html
+++ b/cassdegrees/templates/widgets/rules.html
@@ -58,6 +58,31 @@
     </fieldset>
 </script>
 
+<script type="text/x-template" id="subjectAreaSpecificRuleTemplate">
+    <fieldset v-if="!redraw">
+        <p class="form-group">
+            <label>
+                Students must complete...
+            </label>
+            <input class="text" type="number" v-on:change="check_options" v-model="details.unit_count" min="0" step="6" max="1000" aria-required="true" required>
+            units
+        </p>
+
+        <div class="msg-error" v-if="invalid_units">Unit count must be > 0!</div>
+        <div class="msg-error" v-if="invalid_units_step">Unit count should be divisible by 6!</div>
+
+        <p>
+            from the following subject area:
+        </p>
+
+        <div>
+            <select v-model="details.subject" required>
+                <option v-for="subject_area in subject_areas" v-bind:value="subject_area">{{ subject_area }}</option>
+            </select>
+        </div>
+    </fieldset>
+</script>
+
 <script type="text/x-template" id="customTextRuleTemplate">
     <fieldset>
         <p>


### PR DESCRIPTION
Aims to accomplish user story #14 . This PR gets all the course codes using the search api, creates a set of subject areas from the codes and gets displayed in a dropdown menu.
**in the midst of creating the template**
![image](https://user-images.githubusercontent.com/24206502/57424579-77434b00-725b-11e9-853f-90af11a3f330.png)
**after the template has been made**
![image](https://user-images.githubusercontent.com/24206502/57424589-83c7a380-725b-11e9-8b2d-b6090d969f7d.png)
