### PR TITLE
Created Year-Specific Units Rule in Program Template Creation

### DIFF
--- a/cassdegrees/static/js/rules.js
+++ b/cassdegrees/static/js/rules.js
@@ -220,20 +220,6 @@ Vue.component('rule_year_level', {
             "redraw": false
         }
     },
-    created: function() {
-        // Javascript has the best indirection...
-        var rule = this;
-
-        var request = new XMLHttpRequest();
-
-        request.addEventListener("load", function() {
-            rule.courses = JSON.parse(request.response);
-
-            rule.check_options();
-        });
-        request.open("GET", "/api/search/?select=code,name&from=course");
-        request.send();
-    },
     methods: {
         check_options: function() {
             // Ensure Unit Count is valid:

--- a/cassdegrees/static/js/rules.js
+++ b/cassdegrees/static/js/rules.js
@@ -3,6 +3,7 @@
 // Translation table between internal names for components and human readable ones.
 const COMPONENT_NAMES = {
     'subplan': "Subplan",
+    'year_level': 'Year-Level Specific Units',
     'course': "Course",
     'custom_text': "Custom (Text)"
 };
@@ -192,6 +193,72 @@ Vue.component('rule_course', {
         }
     },
     template: '#courseRequirementTemplate'
+});
+
+Vue.component('rule_year_level', {
+    props: {
+        "details": {
+            type: Object,
+
+            validator: function (value) {
+                // Ensure that the object has all the attributes we need
+                if (!value.hasOwnProperty("year_level")) {
+                    value.year_level = null;
+                }
+
+                return true;
+            }
+        }
+    },
+    data: function() {
+        return {
+            // Display related warnings if true
+            "invalid_units": false,
+            "invalid_units_step": false,
+            "invalid_course_year_level": false,
+
+            "redraw": false
+        }
+    },
+    created: function() {
+        // Javascript has the best indirection...
+        var rule = this;
+
+        var request = new XMLHttpRequest();
+
+        request.addEventListener("load", function() {
+            rule.courses = JSON.parse(request.response);
+
+            rule.check_options();
+        });
+        request.open("GET", "/api/search/?select=code,name&from=course");
+        request.send();
+    },
+    methods: {
+        check_options: function() {
+            // Ensure Unit Count is valid:
+            if (this.details.unit_count != null) {
+                this.invalid_units = this.details.unit_count <= 0;
+                this.invalid_units_step = this.details.unit_count % 6 !== 0;
+            }
+            // Ensure Course Year Level Input is valid
+            if (this.details.year_level != null) {
+                this.invalid_course_year_level = this.details.year_level % 1000 !== 0;
+                console.log(this.details.year_level);
+                console.log(this.details.year_level % 1000 !== 0);
+                console.log("it woooorks");
+            }
+        },
+        // https://michaelnthiessen.com/force-re-render/
+        do_redraw: function() {
+            this.redraw = true;
+
+            this.$nextTick(() => {
+                this.redraw = false;
+            });
+        }
+    },
+    template: '#yearSpecificRuleTemplate'
 });
 
 Vue.component('rule_custom_text', {

--- a/cassdegrees/static/js/rules.js
+++ b/cassdegrees/static/js/rules.js
@@ -212,6 +212,8 @@ Vue.component('rule_year_level', {
     },
     data: function() {
         return {
+            "year_level_max_range": 9000,
+
             // Display related warnings if true
             "invalid_units": false,
             "invalid_units_step": false,

--- a/cassdegrees/static/js/rules.js
+++ b/cassdegrees/static/js/rules.js
@@ -3,7 +3,7 @@
 // Translation table between internal names for components and human readable ones.
 const COMPONENT_NAMES = {
     'subplan': "Subplan",
-    'year_level': 'Course Year-Level Specific Units',
+    'year_level': 'Level-Specific Units',
     'course': "Course",
     'custom_text': "Custom (Text)"
 };

--- a/cassdegrees/static/js/rules.js
+++ b/cassdegrees/static/js/rules.js
@@ -230,9 +230,6 @@ Vue.component('rule_year_level', {
             // Ensure Course Year Level Input is valid
             if (this.details.year_level != null) {
                 this.invalid_course_year_level = this.details.year_level % 1000 !== 0;
-                console.log(this.details.year_level);
-                console.log(this.details.year_level % 1000 !== 0);
-                console.log("it woooorks");
             }
         },
         // https://michaelnthiessen.com/force-re-render/

--- a/cassdegrees/static/js/rules.js
+++ b/cassdegrees/static/js/rules.js
@@ -3,7 +3,7 @@
 // Translation table between internal names for components and human readable ones.
 const COMPONENT_NAMES = {
     'subplan': "Subplan",
-    'year_level': 'Year-Level Specific Units',
+    'year_level': 'Course Year-Level Specific Units',
     'course': "Course",
     'custom_text': "Custom (Text)"
 };

--- a/cassdegrees/static/js/rules.js
+++ b/cassdegrees/static/js/rules.js
@@ -212,7 +212,7 @@ Vue.component('rule_year_level', {
     },
     data: function() {
         return {
-            "year_level_max_range": 9000,
+            "number_of_year_levels": 9,
 
             // Display related warnings if true
             "invalid_units": false,

--- a/cassdegrees/templates/widgets/rules.html
+++ b/cassdegrees/templates/widgets/rules.html
@@ -79,7 +79,7 @@
 
         <div>
             <select v-model="details.year_level" v-on:change="check_options" required>
-                <option v-for="year_level in year_level_max_range/1000" v-bind:value="details.year_level">{{  year_level*1000 }}-level</option>
+                <option v-for="year_level in number_of_year_levels" v-bind:value="year_level*1000">{{ year_level*1000 }}-level</option>
             </select>
         </div>
     </fieldset>

--- a/cassdegrees/templates/widgets/rules.html
+++ b/cassdegrees/templates/widgets/rules.html
@@ -72,14 +72,16 @@
         <div class="msg-error" v-if="invalid_units_step">Unit count should be divisible by 6!</div>
 
         <p>
-            from the following year level:
+            from the following course year-level:
         </p>
 
-        <div class="msg-error" v-if="invalid_course_year_level">Course Year Level should be divisible by 1000!</div>
+        <div class="msg-error" v-if="invalid_course_year_level">Course Year-Level should be divisible by 1000!</div>
 
-        <p>
-            <textarea v-model="details.year_level" style="width: 100%" maxlength="4" placeholder="eg. 1000, 2000, 3000 etc..." v-on:change="check_options" aria-required="true" required></textarea>
-        </p>
+        <div>
+            <select v-model="details.year_level" v-on:change="check_options" required>
+                <option v-for="year_level in year_level_max_range/1000" v-bind:value="details.year_level">{{  year_level*1000 }}-level</option>
+            </select>
+        </div>
     </fieldset>
 </script>
 

--- a/cassdegrees/templates/widgets/rules.html
+++ b/cassdegrees/templates/widgets/rules.html
@@ -58,6 +58,31 @@
     </fieldset>
 </script>
 
+<script type="text/x-template" id="yearSpecificRuleTemplate">
+    <fieldset v-if="!redraw">
+        <p class="form-group">
+            <label>
+                Students must complete...
+            </label>
+            <input class="text" type="number" v-on:change="check_options" v-model="details.unit_count" min="0" step="6" max="1000" aria-required="true" required>
+            units
+        </p>
+
+        <div class="msg-error" v-if="invalid_units">Unit count must be > 0!</div>
+        <div class="msg-error" v-if="invalid_units_step">Unit count should be divisible by 6!</div>
+
+        <p>
+            from the following year level:
+        </p>
+
+        <div class="msg-error" v-if="invalid_course_year_level">Course Year Level should be divisible by 1000!</div>
+
+        <p>
+            <textarea v-model="details.year_level" style="width: 100%" maxlength="4" placeholder="eg. 1000, 2000, 3000 etc..." v-on:change="check_options" aria-required="true" required></textarea>
+        </p>
+    </fieldset>
+</script>
+
 <script type="text/x-template" id="customTextRuleTemplate">
     <fieldset>
         <p>


### PR DESCRIPTION
Aims to accomplish #13. The rule uses a textbox for the user to type in the course year level in (with a max string length constraint of 4). An error message will pop up if the user has entered a number that is not divisible by 1000 (similar to how the unit count is checked).
**whilst creating a template**
![image](https://user-images.githubusercontent.com/24206502/57426190-a066da00-7261-11e9-9d09-8d68a290c35f.png)
**after the template has been made**
![image](https://user-images.githubusercontent.com/24206502/57426208-b1175000-7261-11e9-823c-a4b60d70a258.png)
