### PR TITLE
Fixed Bug in Duplicate Error Message

### DIFF
--- a/cassdegrees/ui/forms.py
+++ b/cassdegrees/ui/forms.py
@@ -94,7 +94,7 @@ class EditSubplanFormSnippet(ModelForm):
         }
         error_messages = {
             NON_FIELD_ERRORS: {
-                'unique_together': "A plan with the same %(field_labels)s already exists!",
+                'unique_together': "A Subplan with the same %(field_labels)s already exists!",
             }
         }
 

--- a/cassdegrees/ui/forms.py
+++ b/cassdegrees/ui/forms.py
@@ -145,7 +145,7 @@ class EditCourseFormSnippet(ModelForm):
         }
         error_messages = {
             NON_FIELD_ERRORS: {
-                'unique_together': "A plan with the same %(field_labels)s already exists!",
+                'unique_together': "A Course with the same %(field_labels)s already exists!",
             }
         }
 

--- a/cassdegrees/ui/forms.py
+++ b/cassdegrees/ui/forms.py
@@ -50,7 +50,7 @@ class EditProgramFormSnippet(ModelForm):
         }
         error_messages = {
             NON_FIELD_ERRORS: {
-                'unique_together': "A program with the same %(field_labels)s already exists!",
+                'unique_together': "A Program with the same %(field_labels)s already exists!",
             }
         }
 


### PR DESCRIPTION
changed:
- 'plan' to 'Course' (in Course Duplication)
- 'plan' to 'Subplan' (in Subplan Duplication)
- 'program' to 'Program' (in Program Duplication)