### PR TITLE
Implement PDF rendering of programs

### DIFF
--- a/cassdegrees/static/js/rules.js
+++ b/cassdegrees/static/js/rules.js
@@ -20,6 +20,10 @@ Vue.component('rule_subplan', {
                     value.ids = [-1];
                 }
 
+                if (!value.hasOwnProperty("kind")) {
+                    value.kind = "";
+                }
+
                 return true;
             }
         }
@@ -326,6 +330,10 @@ Vue.component('rule_custom_text', {
 
                 if (!value.hasOwnProperty("units")) {
                     value.units = 0;
+                }
+
+                if (!value.hasOwnProperty("show_course_boxes")) {
+                    value.show_course_boxes = false;
                 }
 
                 return true;

--- a/cassdegrees/templates/list.html
+++ b/cassdegrees/templates/list.html
@@ -81,6 +81,7 @@
                                             <a class="btn-uni-grad" href="/create/{% if title == 'Program' %}program{% elif title == 'Subplan' %}subplan{% elif title == 'Course' %}course{% endif %}/?id={{ item }}&duplicate=true">Duplicate</a>
                                             <a class="btn-uni-grad" href="/edit/{% if title == 'Program' %}program{% elif title == 'Subplan' %}subplan{% elif title == 'Course' %}course{% endif %}/?id={{ item }}">Edit</a>
                                             <a class="btn-uni-grad" href="/view/{% if title == 'Program' %}program{% elif title == 'Subplan' %}subplan{% elif title == 'Course' %}course{% endif %}/?id={{ item }}">View</a>
+                                            <a class="btn-uni-grad" href="/pdf/{% if title == 'Program' %}program{% elif title == 'Subplan' %}subplan{% elif title == 'Course' %}course{% endif %}/?id={{ item }}">PDF</a>
                                         </td>
                                     {% endif %}
 

--- a/cassdegrees/templates/pdf_base.html
+++ b/cassdegrees/templates/pdf_base.html
@@ -42,11 +42,18 @@
             padding: 0.25cm;
         }
 
+        .break-column {
+            break-after: right;
+        }
+
         .no-bottom-margin {
             margin-bottom: 0 !important;
             padding-bottom: 0 !important;
         }
 
+        .grey-text {
+            color: grey;
+        }
     </style>
 
 </head>

--- a/cassdegrees/templates/pdf_base.html
+++ b/cassdegrees/templates/pdf_base.html
@@ -42,6 +42,10 @@
             padding: 0.25cm;
         }
 
+        .box p {
+            margin: 0;
+        }
+
         .break-column {
             break-after: right;
         }
@@ -53,6 +57,10 @@
 
         .grey-text {
             color: grey;
+        }
+
+        .grey-box {
+            border-color: grey;
         }
 
         .small-text {

--- a/cassdegrees/templates/pdf_base.html
+++ b/cassdegrees/templates/pdf_base.html
@@ -54,6 +54,10 @@
         .grey-text {
             color: grey;
         }
+
+        .small-text {
+            font-size: 60%;
+        }
     </style>
 
 </head>

--- a/cassdegrees/templates/pdf_base.html
+++ b/cassdegrees/templates/pdf_base.html
@@ -1,0 +1,56 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{% block page-title %}No title defined{% endblock %}</title>
+
+    <!-- We don't have access to static resources here -->
+    <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
+    <style>
+        html, body {
+            height: 100%;
+        }
+
+        html, head, body, div, span {
+            font-family: "Roboto", sans-serif;
+        }
+
+        @page {
+            size: A4 landscape;
+            margin: 1cm;
+        }
+
+        /* Basic column rules */
+        .columns-2 {
+            column-count: 2;
+            column-fill: auto;
+        }
+
+        .columns-3 {
+            column-count: 3;
+            column-fill: auto;
+        }
+
+        .columns-no-gap {
+            column-gap: 0;
+        }
+
+        /* Other simple tweaks */
+        .box {
+            border: 1px solid black;
+            padding: 0.25cm;
+        }
+
+        .no-bottom-margin {
+            margin-bottom: 0 !important;
+            padding-bottom: 0 !important;
+        }
+
+    </style>
+
+</head>
+<body>
+    {% block content %}No page content defined{% endblock %}
+</body>
+</html>

--- a/cassdegrees/templates/pdf_program.html
+++ b/cassdegrees/templates/pdf_program.html
@@ -1,0 +1,74 @@
+{% extends "pdf_base.html" %}
+{% block page-title %}{{ program.name }} ({{ program.year }}){% endblock %}
+
+{% block content %}
+    <h1 class="no-bottom-margin">{{ program.name }} ({{ program.year }})</h1>
+
+    <p>
+        {% if program.programType == 'ugrad-sing' %}
+            Undergraduate Single Pass Degree
+        {% endif %}
+        {% if program.programType == 'ugrad-doub' %}
+            Undergraduate Flexible Double Degree
+        {% endif %}
+        {% if program.programType == 'hon' %}
+            Honours Degree
+        {% endif %}
+        {% if program.programType == 'mast-sing' %}
+            Masters Single Degree
+        {% endif %}
+        {% if program.programType == 'mast-adv' %}
+            Masters (Advanced) Degree
+        {% endif %}
+        {% if program.programType == 'mast-doub' %}
+            Masters Flexible Double Degree
+        {% endif %}
+        {% if program.programType == 'vert-doub' %}
+            Vertical Flexible Double Degree
+        {% endif %}
+        {% if program.programType == 'other' %}
+            Other Degree
+        {% endif %}
+    </p>
+
+    <div class="box">
+        Student name & ID number: <br />
+    </div>
+
+    <div class="columns-3 columns-no-gap">
+
+        {% for rule in program.globalRequirements %}
+            <div class="box">
+                {% if rule.type == "min" %}
+                    <p>
+                        A <b>minimum</b> of {{ rule.unit_count }} units must come from completion of {{ rule.prettyList }} courses.
+                    </p>
+                {% elif rule.type == "max" %}
+                    <p>
+                        A <b>maximum</b> of {{ rule.unit_count }} units may come from completion of {{ rule.prettyList }} courses.
+                    </p>
+                {% else %}
+                    ERROR: Unknown global requirement type "{{ rule.type }}"!
+                {% endif %}
+            </div>
+        {% endfor %}
+
+        {% for rule in program.rules %}
+            <div class="box">
+                {% if rule.type == "subplan" %}
+                    <p>Completion of one subplan from the following list:</p>
+                    {% for value in rule.contents.values %}
+                        <!-- TODO: Render subplan here -->
+                        <p>{{ value.name }}</p>
+                    {% endfor %}
+                {% elif rule.type == "custom_text" %}
+                    <p>For {{ rule.units }} units:</p>
+                    <p>{{ rule.text }}</p>
+                {% else %}
+                    ERROR: Unknown rule type "{{ rule.type }}"!
+                {% endif %}
+            </div>
+        {% endfor %}
+
+    </div>
+{% endblock %}

--- a/cassdegrees/templates/pdf_program.html
+++ b/cassdegrees/templates/pdf_program.html
@@ -1,5 +1,6 @@
 {% extends "pdf_base.html" %}
 {% load course_boxes %}
+{% load math %}
 
 {% block page-title %}{{ program.name }} ({{ program.year }}){% endblock %}
 
@@ -18,16 +19,38 @@
         {% for rule in program.rules %}
             <div class="box">
                 {% if rule.type == "subplan" %}
-                    <p>Completion of {% if rule.contents|length == 1 %} the following {% else %} one subplan from the following list {% endif %}for {{ rule.units }} units:</p>
-                    <ul>
-                        {% for value in rule.contents.values %}
-                            <li>{{ value.name }}</li>
-                        {% endfor %}
-                    </ul>
+                    <p>Completion of {{ rule.kind }} for {{ rule.units }} units:</p>
+                {% elif rule.type == "subject_area" %}
+                    {# https://stackoverflow.com/questions/4831306/need-to-convert-a-string-to-int-in-a-django-template #}
+                    {# add:"0" needed to cast units to int #}
+                    <p>Complete {{ rule.unit_count }} units from {% if rule.unit_count|add:"0" <= 6 %}a{% endif %}
+                        {{ rule.subject }} course{% if rule.unit_count|add:"0" > 6 %}s{% endif %}:</p>
+                {% elif rule.type == "year_level" %}
+                    <p>Complete {{ rule.unit_count }} units from {% if rule.unit_count|add:"0" <= 6 %}a{% endif %}
+                        {{ rule.year_level }}-level course{% if rule.unit_count|add:"0" > 6 %}s{% endif %}:</p>
+                {% elif rule.type == "course" %}
+                    {# Find out if all courses are required #}
+                    {% with courses_provided=rule.codes|length %}
+                        {% with courses_needed=rule.unit_count|divide:6 %}
+                            {% if courses_provided == courses_needed %}
+                                {# All courses specified are required - render all #}
+                                <p>Complete {{ rule.unit_count }} units from the following
+                                    {% if rule.unit_count|add:"0" <= 6 %}course{% else %}set of courses{% endif %}:</p>
+                            {% else %}
+                                {# Not all required courses - give descriptions #}
+                                <p>Complete {{ rule.unit_count }} units from a selection of:</p>
+                                {% for code in rule.codes %}
+                                    {{ code }}{% if not forloop.last %}, {% endif %}
+                                {% endfor %}
+                            {% endif %}
+                        {% endwith %}
+                    {% endwith %}
+
                 {% elif rule.type == "custom_text" %}
                     <p>For {{ rule.units }} units:</p>
                     <p>{{ rule.text }}</p>
                 {% else %}
+                <!-- TODO: courseRequirementTemplate -->
                     ERROR: Unknown rule type "{{ rule.type }}"!
                 {% endif %}
             </div>
@@ -35,8 +58,26 @@
 
             {% if rule.type == "subplan" %}
                 {% course_box rule.units %}
+            {% elif rule.type == "subject_area" %}
+                {% course_box rule.unit_count %}
+            {% elif rule.type == "year_level" %}
+                {% course_box rule.unit_count %}
+            {% elif rule.type == "course" %}
+                {% with courses_provided=rule.codes|length %}
+                    {% with courses_needed=rule.unit_count|divide:6 %}
+                        {% if courses_provided == courses_needed %}
+                            {# All courses specified are required - render all #}
+                            {% course_box_with_values rule.unit_count rule.codes %}
+                        {% else %}
+                            {# Not all required courses - map them out as blanks #}
+                            {% course_box rule.unit_count %}
+                        {% endif %}
+                    {% endwith %}
+                {% endwith %}
             {% elif rule.type == "custom_text" %}
-                <!-- TODO: render custom text courses here optionallly -->
+                {% if rule.show_course_boxes %}
+                    {% course_box rule.units %}
+                {% endif %}
             {% endif %}
 
             {% if forloop.last %}<div class="break-box"></div>{% endif %}

--- a/cassdegrees/templates/pdf_program.html
+++ b/cassdegrees/templates/pdf_program.html
@@ -1,36 +1,10 @@
 {% extends "pdf_base.html" %}
+{% load course_boxes %}
+
 {% block page-title %}{{ program.name }} ({{ program.year }}){% endblock %}
 
 {% block content %}
-    <h1 class="no-bottom-margin">{{ program.name }} ({{ program.year }})</h1>
-
-    <p>
-        {% if program.programType == 'ugrad-sing' %}
-            Undergraduate Single Pass Degree
-        {% endif %}
-        {% if program.programType == 'ugrad-doub' %}
-            Undergraduate Flexible Double Degree
-        {% endif %}
-        {% if program.programType == 'hon' %}
-            Honours Degree
-        {% endif %}
-        {% if program.programType == 'mast-sing' %}
-            Masters Single Degree
-        {% endif %}
-        {% if program.programType == 'mast-adv' %}
-            Masters (Advanced) Degree
-        {% endif %}
-        {% if program.programType == 'mast-doub' %}
-            Masters Flexible Double Degree
-        {% endif %}
-        {% if program.programType == 'vert-doub' %}
-            Vertical Flexible Double Degree
-        {% endif %}
-        {% if program.programType == 'other' %}
-            Other Degree
-        {% endif %}
-        ({{ program.units }} units)
-    </p>
+    <h1 class="no-bottom-margin">{{ program.name }} ({{ program.year }}, {{ program.units }} units)</h1>
 
     <div class="box grey-text">
         Student name & ID number: <br />
@@ -39,30 +13,14 @@
     <div class="columns-3 columns-no-gap">
 
         {% for rule in program.rules %}
-            <div class="box{% if forloop.last %} break-column{% endif %}">
+            <div class="box">
                 {% if rule.type == "subplan" %}
                     <p>Completion of {% if rule.contents|length == 1 %} the following {% else %} one subplan from the following list {% endif %}for {{ rule.units }} units:</p>
                     <ul>
                         {% for value in rule.contents.values %}
-                            <!-- TODO: Render subplan here -->
                             <li>{{ value.name }}</li>
                         {% endfor %}
                     </ul>
-
-                    {% with rule.units as n %}
-                        <!-- https://stackoverflow.com/questions/1107737/numeric-for-loop-in-django-templates -->
-                        {% with ''|center:n as range %}
-                            {% for _ in range %}
-                                <!-- https://stackoverflow.com/questions/8447913/is-there-a-filter-for-divide-for-django-template -->
-                                {% if forloop.counter|divisibleby:"6" %}
-                                    <div class="box grey-text">
-                                        Course:
-                                    </div>
-                                {% endif %}
-                            {% endfor %}
-                        {% endwith %}
-                    {% endwith %}
-
                 {% elif rule.type == "custom_text" %}
                     <p>For {{ rule.units }} units:</p>
                     <p>{{ rule.text }}</p>
@@ -70,16 +28,23 @@
                     ERROR: Unknown rule type "{{ rule.type }}"!
                 {% endif %}
             </div>
+
+
+            {% if rule.type == "subplan" %}
+                {% course_box rule.units %}
+            {% elif rule.type == "custom_text" %}
+                <!-- TODO: render custom text courses here optionallly -->
+            {% endif %}
         {% endfor %}
 
-        <div class="box">
+        <div class="break-column"></div>
+
+        <div class="box small-text">
             <p>
-                Template info:<br />
-                Some useful description here
+                Instructions for filling in:
             </p>
-        </div>
-        <div class="box" style="min-height: 3cm">
-            <p class="grey-text" style="min-height: 3cm">Student notes:</p>
+
+            {{ program.studentNotes | linebreaks }}
         </div>
 
         {% for rule in program.globalRequirements %}

--- a/cassdegrees/templates/pdf_program.html
+++ b/cassdegrees/templates/pdf_program.html
@@ -4,11 +4,14 @@
 {% block page-title %}{{ program.name }} ({{ program.year }}){% endblock %}
 
 {% block content %}
+    <div class="box" style="float: right">
+        Student name & ID number: <br />
+        <br />
+    </div>
+
     <h1 class="no-bottom-margin">{{ program.name }} ({{ program.year }}, {{ program.units }} units)</h1>
 
-    <div class="box grey-text">
-        Student name & ID number: <br />
-    </div>
+    <br />
 
     <div class="columns-3 columns-no-gap">
 
@@ -35,6 +38,8 @@
             {% elif rule.type == "custom_text" %}
                 <!-- TODO: render custom text courses here optionallly -->
             {% endif %}
+
+            {% if forloop.last %}<div class="break-box"></div>{% endif %}
         {% endfor %}
 
         <div class="break-column"></div>
@@ -51,11 +56,13 @@
             <div class="box {% if forloop.last %} break-column{% endif %}">
                 {% if rule.type == "min" %}
                     <p>
-                        A <b>minimum</b> of {{ rule.unit_count }} units must come from completion of {{ rule.prettyList }} courses.
+                        {{rule.prettyList}} courses: <br/>
+                        <u>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</u> units ({{ rule.unit_count }} <b>minimum</b>)
                     </p>
                 {% elif rule.type == "max" %}
                     <p>
-                        A <b>maximum</b> of {{ rule.unit_count }} units may come from completion of {{ rule.prettyList }} courses.
+                        {{rule.prettyList}} courses: <br/>
+                        <u>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</u> units ({{ rule.unit_count }} <b>maximum</b>)
                     </p>
                 {% else %}
                     ERROR: Unknown global requirement type "{{ rule.type }}"!

--- a/cassdegrees/templates/pdf_program.html
+++ b/cassdegrees/templates/pdf_program.html
@@ -29,16 +29,61 @@
         {% if program.programType == 'other' %}
             Other Degree
         {% endif %}
+        ({{ program.units }} units)
     </p>
 
-    <div class="box">
+    <div class="box grey-text">
         Student name & ID number: <br />
     </div>
 
     <div class="columns-3 columns-no-gap">
 
+        {% for rule in program.rules %}
+            <div class="box{% if forloop.last %} break-column{% endif %}">
+                {% if rule.type == "subplan" %}
+                    <p>Completion of {% if rule.contents|length == 1 %} the following {% else %} one subplan from the following list {% endif %}for {{ rule.units }} units:</p>
+                    <ul>
+                        {% for value in rule.contents.values %}
+                            <!-- TODO: Render subplan here -->
+                            <li>{{ value.name }}</li>
+                        {% endfor %}
+                    </ul>
+
+                    {% with rule.units as n %}
+                        <!-- https://stackoverflow.com/questions/1107737/numeric-for-loop-in-django-templates -->
+                        {% with ''|center:n as range %}
+                            {% for _ in range %}
+                                <!-- https://stackoverflow.com/questions/8447913/is-there-a-filter-for-divide-for-django-template -->
+                                {% if forloop.counter|divisibleby:"6" %}
+                                    <div class="box grey-text">
+                                        Course:
+                                    </div>
+                                {% endif %}
+                            {% endfor %}
+                        {% endwith %}
+                    {% endwith %}
+
+                {% elif rule.type == "custom_text" %}
+                    <p>For {{ rule.units }} units:</p>
+                    <p>{{ rule.text }}</p>
+                {% else %}
+                    ERROR: Unknown rule type "{{ rule.type }}"!
+                {% endif %}
+            </div>
+        {% endfor %}
+
+        <div class="box">
+            <p>
+                Template info:<br />
+                Some useful description here
+            </p>
+        </div>
+        <div class="box" style="min-height: 3cm">
+            <p class="grey-text" style="min-height: 3cm">Student notes:</p>
+        </div>
+
         {% for rule in program.globalRequirements %}
-            <div class="box">
+            <div class="box {% if forloop.last %} break-column{% endif %}">
                 {% if rule.type == "min" %}
                     <p>
                         A <b>minimum</b> of {{ rule.unit_count }} units must come from completion of {{ rule.prettyList }} courses.
@@ -52,23 +97,5 @@
                 {% endif %}
             </div>
         {% endfor %}
-
-        {% for rule in program.rules %}
-            <div class="box">
-                {% if rule.type == "subplan" %}
-                    <p>Completion of one subplan from the following list:</p>
-                    {% for value in rule.contents.values %}
-                        <!-- TODO: Render subplan here -->
-                        <p>{{ value.name }}</p>
-                    {% endfor %}
-                {% elif rule.type == "custom_text" %}
-                    <p>For {{ rule.units }} units:</p>
-                    <p>{{ rule.text }}</p>
-                {% else %}
-                    ERROR: Unknown rule type "{{ rule.type }}"!
-                {% endif %}
-            </div>
-        {% endfor %}
-
     </div>
 {% endblock %}

--- a/cassdegrees/templates/viewprogram.html
+++ b/cassdegrees/templates/viewprogram.html
@@ -77,8 +77,8 @@
         {% for rule in data.rules %}
             {% if rule.type == "subplan" %}
                 <p style="margin-left: 40px">Completion of one subplan from the following list:</p>
-                {% for id, name in rule.ids.items %}
-                    <a class="btn-uni-grad" href="/view/subplan/?id={{ id }}" style="margin-left: 80px">{{ name }}</a>
+                {% for id, value in rule.contents.items %}
+                    <a class="btn-uni-grad" href="/view/subplan/?id={{ id }}" style="margin-left: 80px">{{ value.name }}</a>
                 {% endfor %}
             {% endif %}
 

--- a/cassdegrees/templates/widgets/rules.html
+++ b/cassdegrees/templates/widgets/rules.html
@@ -15,7 +15,13 @@
         <div class="msg-error" v-if="inconsistent_units">Options have different unit values!</div>
 
         <p>
-            Students must pick one from the following:
+            Students must pick
+            <input class="text" v-model="details.kind" aria-required="true" placeholder="e.g. Arts Major - brief description for students here"
+                   style="margin-left: 0; width: 400px" required>
+            from the following:
+        </p>
+
+        <p>
         </p>
 
         <div v-for="(id, index) in details.ids">
@@ -126,6 +132,11 @@
         </p>
 
         <div class="msg-error" v-if="not_divisible">Units must be divisible by 6!</div>
+
+        <p class="form-group">
+            <label>Show 6-unit course boxes in plans (e.g. PDF):</label>
+            <input class="text" type="checkbox" v-model="details.show_course_boxes">
+        </p>
     </fieldset>
 </script>
 

--- a/cassdegrees/ui/templatetags/course_boxes.py
+++ b/cassdegrees/ui/templatetags/course_boxes.py
@@ -1,0 +1,15 @@
+from django import template
+from django.template import Template
+
+register = template.Library()
+
+
+@register.simple_tag(takes_context=True)
+def course_box(context, count):
+    output = ""
+    iters = int(int(count) / 6)
+
+    for i in range(iters):
+        output += "<div class=\"box grey-text\">Course:</div>"
+
+    return Template(output).render(context)

--- a/cassdegrees/ui/templatetags/course_boxes.py
+++ b/cassdegrees/ui/templatetags/course_boxes.py
@@ -14,6 +14,7 @@ def course_box(context, count):
 
     return Template(output).render(context)
 
+
 @register.simple_tag(takes_context=True)
 def course_box_with_values(context, count, courses):
     output = ""

--- a/cassdegrees/ui/templatetags/course_boxes.py
+++ b/cassdegrees/ui/templatetags/course_boxes.py
@@ -10,6 +10,17 @@ def course_box(context, count):
     iters = int(int(count) / 6)
 
     for i in range(iters):
-        output += "<div class=\"box grey-text\">Course:</div>"
+        output += "<div class=\"box grey-text grey-box\">Course #" + str(i + 1) + ":</div>"
+
+    return Template(output).render(context)
+
+@register.simple_tag(takes_context=True)
+def course_box_with_values(context, count, courses):
+    output = ""
+    iters = int(int(count) / 6)
+
+    for i in range(iters):
+        output += "<div class=\"box grey-box\"><span class=\"grey-text\">Course #" + str(i + 1) + ":</span> " \
+                  + courses[i] + "</div>"
 
     return Template(output).render(context)

--- a/cassdegrees/ui/templatetags/math.py
+++ b/cassdegrees/ui/templatetags/math.py
@@ -1,0 +1,8 @@
+from django import template
+
+register = template.Library()
+
+# https://stackoverflow.com/questions/18350630/multiplication-in-django-template-without-using-manually-created-template-tag
+@register.filter
+def divide(value, arg):
+    return int(int(value) / int(arg))

--- a/cassdegrees/ui/urls.py
+++ b/cassdegrees/ui/urls.py
@@ -19,6 +19,7 @@ from .views.bulk_data_upload import *
 from .views.courses import *
 from .views.index import *
 from .views.listings import *
+from .views.pdf import *
 from .views.programs import *
 from .views.sampleform import *
 from .views.subplans import *
@@ -41,4 +42,5 @@ urlpatterns = [
     path('view/program/', view_),
     path('view/subplan/', view_),
     path('view/course/', view_),
+    path('pdf/program/', view_program_pdf),
 ]

--- a/cassdegrees/ui/views/pdf.py
+++ b/cassdegrees/ui/views/pdf.py
@@ -1,0 +1,32 @@
+from api.models import ProgramModel
+from django.shortcuts import render
+
+from django_weasyprint import WeasyTemplateResponse
+from django.forms.models import model_to_dict
+
+from ui.views.view_ import pretty_print_reqs, pretty_print_rules
+
+
+def view_program_pdf(request):
+    """ Renders a program to a PDF. """
+
+    id_to_view = request.GET.get('id', None)
+
+    # https://stackoverflow.com/questions/21925671/convert-django-model-object-to-dict-with-all-of-the-fields-intact
+    instance = model_to_dict(ProgramModel.objects.get(id=int(id_to_view)))
+
+    pretty_print_reqs(instance)
+    pretty_print_rules(instance)
+
+    context = {
+        "program": instance
+    }
+
+    if "raw" in request.GET:
+        return render(request, 'pdf_program.html', context=context)
+    else:
+        response = WeasyTemplateResponse(request=request, content_type='application/pdf',
+                                         filename=instance["name"] + ".pdf", attachment=False,
+                                         template="pdf_program.html", context=context)
+
+        return response.render()

--- a/cassdegrees/ui/views/view_.py
+++ b/cassdegrees/ui/views/view_.py
@@ -29,9 +29,14 @@ def pretty_print_rules(program):
         # For a subplan rule, GET the name of the subplan for display
         if rule["type"] == "subplan":
             subplans = {}
+            units = 0
             for id in rule["ids"]:
-                subplans[id] = SubplanModel.objects.get(id=int(id))
+                object = SubplanModel.objects.get(id=int(id))
+                units = object.units
+                subplans[id] = object
             rule["contents"] = subplans
+            rule["units"] = units
+
 
 
 def view_(request):

--- a/cassdegrees/ui/views/view_.py
+++ b/cassdegrees/ui/views/view_.py
@@ -1,6 +1,38 @@
 from django.shortcuts import render
 import requests
 
+from api.models import SubplanModel
+
+
+def pretty_print_reqs(program):
+    # It is convenient to generate the pretty list of each min/max rule
+    # here in python before passing it to the template.
+    for req in program["globalRequirements"]:
+        if req["type"] == "min" or req["type"] == "max":
+            pretty = ""
+            for field in req.keys():
+                if field[:7] == "courses":
+                    if req[field]:
+                        pretty += field[7:11] + "-level, "
+            pretty = pretty[:-2]
+
+            if len(pretty) > 18:
+                pretty = pretty[:-12] + " and" + pretty[-11:]
+            elif len(pretty) > 10:
+                pretty = pretty[:-11] + " and" + pretty[-11:]
+
+            req["prettyList"] = pretty
+
+
+def pretty_print_rules(program):
+    for rule in program["rules"]:
+        # For a subplan rule, GET the name of the subplan for display
+        if rule["type"] == "subplan":
+            subplans = {}
+            for id in rule["ids"]:
+                subplans[id] = SubplanModel.objects.get(id=int(id))
+            rule["contents"] = subplans
+
 
 def view_(request):
     """
@@ -26,32 +58,7 @@ def view_(request):
     elif "program" in url:
         program = requests.get(request.build_absolute_uri('/api/model/program/' + id_to_edit + '/?format=json')).json()
 
-        # It is convenient to generate the pretty list of each min/max rule
-        # here in python before passing it to the template.
-        for req in program["globalRequirements"]:
-            if req["type"] == "min" or req["type"] == "max":
-                pretty = ""
-                for field in req.keys():
-                    if field[:7] == "courses":
-                        if req[field]:
-                            pretty += field[7:11] + "-level, "
-                pretty = pretty[:-2]
-
-                if len(pretty) > 18:
-                    pretty = pretty[:-12] + " and" + pretty[-11:]
-                elif len(pretty) > 10:
-                    pretty = pretty[:-11] + " and" + pretty[-11:]
-
-                req["prettyList"] = pretty
-
-        for rule in program["rules"]:
-            # For a subplan rule, GET the name of the subplan for display
-            if rule["type"] == "subplan":
-                subplans = {}
-                for id in rule["ids"]:
-                    subplan = requests.get(
-                        request.build_absolute_uri('/api/model/subplan/' + str(id) + '/?format=json')).json()
-                    subplans[id] = subplan["name"]
-                rule["ids"] = subplans
+        pretty_print_reqs(program)
+        pretty_print_rules(program)
 
         return render(request, 'viewprogram.html', context={'data': program})

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ djangorestframework==3.9.2
 flake8==3.7.7
 psycopg2==2.7.7
 requests==2.21.0
+django-weasyprint==0.5.4


### PR DESCRIPTION
Closes #33.

This PR implements PDF rendering of programs into a format designed to be utilised by students. All rules and global requirements are implemented and displayed within this PR.

The main issue that came up during development was that of succinctness of the rule descriptions themselves. Noting that students do have access to Programs and Courses, full descriptions were not needed here. A few rules were modified to take advantage of this with short description boxes added.

Custom text units have had a checkbox added for if they need 6-unit courses rendered for them. Noting that not all custom text units will need this - e.g. exchange.

The choice of weasyprint can be found within the [decision log](https://docs.google.com/spreadsheets/d/12ar4XQoozRggSNLCwvhpQoXkVg5gJ_JHEPpT2dG7LBE/edit?usp=sharing).

Complete PDF example: [Bachelor of Arts.pdf](https://github.com/cass-degrees/CASS-Degrees-Code/files/3175932/Bachelor.of.Arts.pdf)
