### PR TITLE
Fixed issue with number inputs taking non-numbers (Bug #132)

### DIFF
--- a/cassdegrees/static/js/main.js
+++ b/cassdegrees/static/js/main.js
@@ -1,0 +1,13 @@
+/**
+ * This file contains all javascript functions which are used globally in all pages
+ * Linked to base.html
+ */
+
+/**
+ *
+ * @param checks the keys for the input box to make sure the user is entering numbers
+ * @returns only backspace and space + numbers
+ */
+function checkKeys(event) {
+    return event.keyCode === 8 || event.keyCode === 46 ? true : !isNaN(Number(event.key));
+}

--- a/cassdegrees/templates/base.html
+++ b/cassdegrees/templates/base.html
@@ -19,7 +19,6 @@
     <!--[if gt IE 7]><link href="//style.anu.edu.au/_anu/4/min/cass.ie8.min.css?1" rel="stylesheet" type="text/css" media="screen"/><![endif]-->
     
     <link rel="stylesheet" href="{% static 'css/style.css' %}">
-    <script src="{% static 'js/main.js' %}" type="application/javascript"></script>
 </head>
 <body>
     <!-- Heavily modified from CASS homepage root + ANU styling guide -->

--- a/cassdegrees/templates/base.html
+++ b/cassdegrees/templates/base.html
@@ -19,6 +19,7 @@
     <!--[if gt IE 7]><link href="//style.anu.edu.au/_anu/4/min/cass.ie8.min.css?1" rel="stylesheet" type="text/css" media="screen"/><![endif]-->
     
     <link rel="stylesheet" href="{% static 'css/style.css' %}">
+    <script src="{% static 'js/main.js' %}" type="application/javascript"></script>
 </head>
 <body>
     <!-- Heavily modified from CASS homepage root + ANU styling guide -->

--- a/cassdegrees/templates/createcourse.html
+++ b/cassdegrees/templates/createcourse.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load static %}
 {% load breadcrumbs %}
 
 {% block page-title %}{% if edit %}Edit{% else %}Create{% endif %} Course{% endblock %}
@@ -66,4 +67,5 @@
         </p>
     </form>
 
+    <script src="{% static 'js/main.js' %}" type="application/javascript"></script>
 {% endblock %}

--- a/cassdegrees/templates/createprogram.html
+++ b/cassdegrees/templates/createprogram.html
@@ -94,4 +94,6 @@
             }
         }
     </script>
+
+    <script src="{% static 'js/main.js' %}" type="application/javascript"></script>
 {% endblock %}

--- a/cassdegrees/templates/createsubplan.html
+++ b/cassdegrees/templates/createsubplan.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load static %}
 {% load breadcrumbs %}
 
 {% block page-title %}{% if edit %}Edit{% else %}Create{% endif %} Subplan{% endblock %}
@@ -52,4 +53,6 @@
         <input class="btn-uni-grad btn-large" type="submit" value="{% if edit %}Save{% else %}Create{% endif %}"
                onclick="if (handleRules()) document.getElementById('mainForm').submit()">
     </p>
+
+    <script src="{% static 'js/main.js' %}" type="application/javascript"></script>
 {% endblock %}

--- a/cassdegrees/templates/widgets/globalrequirements.html
+++ b/cassdegrees/templates/widgets/globalrequirements.html
@@ -16,7 +16,7 @@
                 <label>
                     Unit Count:
                 </label>
-                <input class="text" type="number" v-on:change="check_options" v-model="details.unit_count" min="0" step="6" max="1000" aria-required="true" required>
+                <input class="text" onkeydown="javascript: return event.keyCode === 8 || event.keyCode === 46 ? true : !isNaN(Number(event.key))" type="number" v-on:change="check_options" v-model="details.unit_count" min="0" step="6" max="1000" aria-required="true" required>
             </p>
 
             <div class="msg-error" v-if="invalid_units">Unit count must be > 0!</div>

--- a/cassdegrees/templates/widgets/globalrequirements.html
+++ b/cassdegrees/templates/widgets/globalrequirements.html
@@ -16,7 +16,7 @@
                 <label>
                     Unit Count:
                 </label>
-                <input class="text" onkeydown="javascript: return event.keyCode === 8 || event.keyCode === 46 ? true : !isNaN(Number(event.key))" type="number" v-on:change="check_options" v-model="details.unit_count" min="0" step="6" max="1000" aria-required="true" required>
+                <input class="text" onkeydown="javascript: return checkKeys(event)" type="number" v-on:change="check_options" v-model="details.unit_count" min="0" step="6" max="1000" aria-required="true" required>
             </p>
 
             <div class="msg-error" v-if="invalid_units">Unit count must be > 0!</div>

--- a/cassdegrees/templates/widgets/rules.html
+++ b/cassdegrees/templates/widgets/rules.html
@@ -35,7 +35,7 @@
             <label>
                 Students must select...
             </label>
-            <input class="text" type="number" v-on:change="check_options" v-model="details.unit_count" min="0" step="6" max="1000" aria-required="true" required>
+            <input class="text" onkeydown="javascript: return event.keyCode === 8 || event.keyCode === 46 ? true : !isNaN(Number(event.key))" type="number" v-on:change="check_options" v-model="details.unit_count" min="0" step="6" max="1000" aria-required="true" required>
             units
         </p>
 
@@ -64,7 +64,7 @@
             <label>
                 Students must complete...
             </label>
-            <input class="text" type="number" v-on:change="check_options" v-model="details.unit_count" min="0" step="6" max="1000" aria-required="true" required>
+            <input class="text" onkeydown="javascript: return event.keyCode === 8 || event.keyCode === 46 ? true : !isNaN(Number(event.key))" type="number" v-on:change="check_options" v-model="details.unit_count" min="0" step="6" max="1000" aria-required="true" required>
             units
         </p>
 
@@ -89,7 +89,7 @@
             <label>
                 Students must complete...
             </label>
-            <input class="text" type="number" v-on:change="check_options" v-model="details.unit_count" min="0" step="6" max="1000" aria-required="true" required>
+            <input class="text" onkeydown="javascript: return event.keyCode === 8 || event.keyCode === 46 ? true : !isNaN(Number(event.key))" type="number" v-on:change="check_options" v-model="details.unit_count" min="0" step="6" max="1000" aria-required="true" required>
             units
         </p>
 
@@ -122,7 +122,7 @@
 
         <p class="form-group">
             <label>Unit value for this item:</label>
-            <input class="text" type="number" min="0" max="1000" v-model="details.units" aria-required="true" required>
+            <input class="text" onkeydown="javascript: return event.keyCode === 8 || event.keyCode === 46 ? true : !isNaN(Number(event.key))" type="number" min="0" max="1000" v-model="details.units" aria-required="true" required>
         </p>
 
         <div class="msg-error" v-if="not_divisible">Units must be divisible by 6!</div>

--- a/cassdegrees/templates/widgets/rules.html
+++ b/cassdegrees/templates/widgets/rules.html
@@ -35,7 +35,7 @@
             <label>
                 Students must select...
             </label>
-            <input class="text" onkeydown="javascript: return event.keyCode === 8 || event.keyCode === 46 ? true : !isNaN(Number(event.key))" type="number" v-on:change="check_options" v-model="details.unit_count" min="0" step="6" max="1000" aria-required="true" required>
+            <input class="text" onkeydown="javascript: return checkKeys(event)" type="number" v-on:change="check_options" v-model="details.unit_count" min="0" step="6" max="1000" aria-required="true" required>
             units
         </p>
 
@@ -64,7 +64,7 @@
             <label>
                 Students must complete...
             </label>
-            <input class="text" onkeydown="javascript: return event.keyCode === 8 || event.keyCode === 46 ? true : !isNaN(Number(event.key))" type="number" v-on:change="check_options" v-model="details.unit_count" min="0" step="6" max="1000" aria-required="true" required>
+            <input class="text" onkeydown="javascript: return checkKeys(event)" type="number" v-on:change="check_options" v-model="details.unit_count" min="0" step="6" max="1000" aria-required="true" required>
             units
         </p>
 
@@ -89,7 +89,7 @@
             <label>
                 Students must complete...
             </label>
-            <input class="text" onkeydown="javascript: return event.keyCode === 8 || event.keyCode === 46 ? true : !isNaN(Number(event.key))" type="number" v-on:change="check_options" v-model="details.unit_count" min="0" step="6" max="1000" aria-required="true" required>
+            <input class="text" onkeydown="javascript: return checkKeys(event)" type="number" v-on:change="check_options" v-model="details.unit_count" min="0" step="6" max="1000" aria-required="true" required>
             units
         </p>
 
@@ -122,7 +122,7 @@
 
         <p class="form-group">
             <label>Unit value for this item:</label>
-            <input class="text" onkeydown="javascript: return event.keyCode === 8 || event.keyCode === 46 ? true : !isNaN(Number(event.key))" type="number" min="0" max="1000" v-model="details.units" aria-required="true" required>
+            <input class="text" onkeydown="javascript: return checkKeys(event)" type="number" min="0" max="1000" v-model="details.units" aria-required="true" required>
         </p>
 
         <div class="msg-error" v-if="not_divisible">Units must be divisible by 6!</div>

--- a/cassdegrees/templates/widgets/subplanrules.html
+++ b/cassdegrees/templates/widgets/subplanrules.html
@@ -15,7 +15,7 @@
             <label>
                 Students must select...
             </label>
-            <input class="text" type="number" v-on:change="check_options" v-model="details.unit_count" min="0" step="6" max="1000" aria-required="true" required>
+            <input class="text" onkeydown="javascript: return event.keyCode === 8 || event.keyCode === 46 ? true : !isNaN(Number(event.key))" type="number" v-on:change="check_options" v-model="details.unit_count" min="0" step="6" max="1000" aria-required="true" required>
             units
         </p>
 

--- a/cassdegrees/templates/widgets/subplanrules.html
+++ b/cassdegrees/templates/widgets/subplanrules.html
@@ -15,7 +15,7 @@
             <label>
                 Students must select...
             </label>
-            <input class="text" onkeydown="javascript: return event.keyCode === 8 || event.keyCode === 46 ? true : !isNaN(Number(event.key))" type="number" v-on:change="check_options" v-model="details.unit_count" min="0" step="6" max="1000" aria-required="true" required>
+            <input class="text" onkeydown="javascript: return checkKeys(event)" type="number" v-on:change="check_options" v-model="details.unit_count" min="0" step="6" max="1000" aria-required="true" required>
             units
         </p>
 

--- a/cassdegrees/ui/forms.py
+++ b/cassdegrees/ui/forms.py
@@ -32,9 +32,15 @@ class EditProgramFormSnippet(ModelForm):
                   'studentNotes')
         widgets = {
             'code': forms.TextInput(attrs={'class': "text tfull", 'placeholder': "e.g. BARTS"}),
-            'year': forms.NumberInput(attrs={'class': "text tfull", 'min': 2000, 'max': 3000}),
+            'year': forms.NumberInput(attrs={'class': "text tfull",
+                                             'onkeydown': "javascript: return event.keyCode === 8 || "
+                                                          "event.keyCode === 46 ? true : !isNaN(Number(event.key))",
+                                             'min': 2000, 'max': 3000}),
             'name': forms.TextInput(attrs={'class': "text tfull", 'placeholder': "e.g. Bachelor of Arts"}),
-            'units': forms.NumberInput(attrs={'class': "text tfull", 'step': 6, 'max': 512}),
+            'units': forms.NumberInput(attrs={'class': "text tfull",
+                                              'onkeydown': "javascript: return event.keyCode === 8 || "
+                                                           "event.keyCode === 46 ? true : !isNaN(Number(event.key))",
+                                              'step': 6, 'max': 512}),
             'staffNotes': forms.Textarea(attrs={
                 'class': "tfull",
                 'placeholder': "Notes for other CASS staff - these will not be displayed on the final template"}),

--- a/cassdegrees/ui/forms.py
+++ b/cassdegrees/ui/forms.py
@@ -89,7 +89,10 @@ class EditSubplanFormSnippet(ModelForm):
         fields = ('code', 'year', 'name', 'units', 'planType', 'rules', 'publish')
         widgets = {
             'code': forms.TextInput(attrs={'class': "text tfull", 'placeholder': "e.g. ARTH-MIN"}),
-            'year': forms.NumberInput(attrs={'class': "text tfull", 'min': 2000, 'max': 3000}),
+            'year': forms.NumberInput(attrs={'class': "text tfull",
+                                             'onkeydown': "javascript: return event.keyCode === 8 || "
+                                                          "event.keyCode === 46 ? true : !isNaN(Number(event.key))",
+                                             'min': 2000, 'max': 3000}),
             'name': forms.TextInput(attrs={'class': "text tfull", 'placeholder': "e.g. Art History Minor"}),
             'publish': forms.CheckboxInput()
             # See units above
@@ -140,10 +143,16 @@ class EditCourseFormSnippet(ModelForm):
         fields = ('code', 'year', 'name', 'units', 'offeredSem1', 'offeredSem2')
         widgets = {
             'code': forms.TextInput(attrs={'class': "text tfull", 'placeholder': "e.g. ARTH1006"}),
-            'year': forms.NumberInput(attrs={'class': "text tfull", 'type': "number"}),
+            'year': forms.NumberInput(attrs={'class': "text tfull",
+                                             'onkeydown': "javascript: return event.keyCode === 8 || "
+                                                          "event.keyCode === 46 ? true : !isNaN(Number(event.key))",
+                                             'type': "number"}),
             'name': forms.TextInput(attrs={'class': "text tfull",
                                            'placeholder': "e.g. Art and Design Histories: Form and Space"}),
-            'units': forms.NumberInput(attrs={'class': "text tfull", 'type': "number"}),
+            'units': forms.NumberInput(attrs={'class': "text tfull",
+                                              'onkeydown': "javascript: return event.keyCode === 8 || "
+                                                           "event.keyCode === 46 ? true : !isNaN(Number(event.key))",
+                                              'type': "number"}),
         }
         labels = {
             'offeredSem1': "Offered in Semester 1",

--- a/cassdegrees/ui/forms.py
+++ b/cassdegrees/ui/forms.py
@@ -33,13 +33,11 @@ class EditProgramFormSnippet(ModelForm):
         widgets = {
             'code': forms.TextInput(attrs={'class': "text tfull", 'placeholder': "e.g. BARTS"}),
             'year': forms.NumberInput(attrs={'class': "text tfull",
-                                             'onkeydown': "javascript: return event.keyCode === 8 || "
-                                                          "event.keyCode === 46 ? true : !isNaN(Number(event.key))",
+                                             'onkeydown': "javascript: return checkKeys(event)",
                                              'min': 2000, 'max': 3000}),
             'name': forms.TextInput(attrs={'class': "text tfull", 'placeholder': "e.g. Bachelor of Arts"}),
             'units': forms.NumberInput(attrs={'class': "text tfull",
-                                              'onkeydown': "javascript: return event.keyCode === 8 || "
-                                                           "event.keyCode === 46 ? true : !isNaN(Number(event.key))",
+                                              'onkeydown': "javascript: return checkKeys(event)",
                                               'step': 6, 'max': 512}),
             'staffNotes': forms.Textarea(attrs={
                 'class': "tfull",
@@ -90,8 +88,7 @@ class EditSubplanFormSnippet(ModelForm):
         widgets = {
             'code': forms.TextInput(attrs={'class': "text tfull", 'placeholder': "e.g. ARTH-MIN"}),
             'year': forms.NumberInput(attrs={'class': "text tfull",
-                                             'onkeydown': "javascript: return event.keyCode === 8 || "
-                                                          "event.keyCode === 46 ? true : !isNaN(Number(event.key))",
+                                             'onkeydown': "javascript: return checkKeys(event)",
                                              'min': 2000, 'max': 3000}),
             'name': forms.TextInput(attrs={'class': "text tfull", 'placeholder': "e.g. Art History Minor"}),
             'publish': forms.CheckboxInput()
@@ -144,14 +141,12 @@ class EditCourseFormSnippet(ModelForm):
         widgets = {
             'code': forms.TextInput(attrs={'class': "text tfull", 'placeholder': "e.g. ARTH1006"}),
             'year': forms.NumberInput(attrs={'class': "text tfull",
-                                             'onkeydown': "javascript: return event.keyCode === 8 || "
-                                                          "event.keyCode === 46 ? true : !isNaN(Number(event.key))",
+                                             'onkeydown': "javascript: return checkKeys(event)",
                                              'type': "number"}),
             'name': forms.TextInput(attrs={'class': "text tfull",
                                            'placeholder': "e.g. Art and Design Histories: Form and Space"}),
             'units': forms.NumberInput(attrs={'class': "text tfull",
-                                              'onkeydown': "javascript: return event.keyCode === 8 || "
-                                                           "event.keyCode === 46 ? true : !isNaN(Number(event.key))",
+                                              'onkeydown': "javascript: return checkKeys(event)",
                                               'type': "number"}),
         }
         labels = {


### PR DESCRIPTION
This patch closes #132.

Number input boxes now won't allow e, + , - in them and only takes numbers.
You can, however, bypass it by copy and paste it in, but this is very unlikely to happen...
For now, this addresses the main issue of the user pressing e, -, + by accident rather purposely breaking it/ feeding it bad data.