### PR TITLE
'Last Updated' Field to Course/Subplan/Program Models

### DIFF
--- a/cassdegrees/api/models.py
+++ b/cassdegrees/api/models.py
@@ -16,7 +16,7 @@ class CourseModel(models.Model):
     units = models.PositiveIntegerField()
     offeredSem1 = models.BooleanField()
     offeredSem2 = models.BooleanField()
-    lastUpdated = models.DateField(default=datetime.datetime.strptime('2019-03-10', '%Y-%m-%d'))
+    lastUpdated = models.DateField(default=datetime.datetime.today())
 
     class Meta:
         unique_together = (("code", "year"),)
@@ -28,7 +28,7 @@ class SubplanModel(models.Model):
     year = models.PositiveIntegerField()
     name = models.CharField(max_length=256)
     units = models.PositiveIntegerField()
-    lastUpdated = models.DateField(default=datetime.datetime.strptime('2019-03-10', '%Y-%m-%d'))
+    lastUpdated = models.DateField(default=datetime.datetime.today())
     rules = psql.JSONField(default=list)
     publish = models.BooleanField(default=False)
 
@@ -48,7 +48,7 @@ class ProgramModel(models.Model):
     year = models.PositiveIntegerField()
     name = models.CharField(max_length=256)
     units = models.PositiveIntegerField()
-    lastUpdated = models.DateField(default=datetime.datetime.strptime('2019-03-10', '%Y-%m-%d'))
+    lastUpdated = models.DateField(default=datetime.datetime.today())
     staffNotes = models.TextField(blank=True, default='')
     studentNotes = models.TextField(blank=True, default='')
 

--- a/cassdegrees/api/models.py
+++ b/cassdegrees/api/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 import django.contrib.postgres.fields as psql
+import datetime
 
 
 class SampleModel(models.Model):
@@ -15,6 +16,7 @@ class CourseModel(models.Model):
     units = models.PositiveIntegerField()
     offeredSem1 = models.BooleanField()
     offeredSem2 = models.BooleanField()
+    lastUpdated = models.DateField(default=datetime.datetime.strptime('2019-03-10', '%Y-%m-%d'))
 
     class Meta:
         unique_together = (("code", "year"),)
@@ -26,6 +28,7 @@ class SubplanModel(models.Model):
     year = models.PositiveIntegerField()
     name = models.CharField(max_length=256)
     units = models.PositiveIntegerField()
+    lastUpdated = models.DateField(default=datetime.datetime.strptime('2019-03-10', '%Y-%m-%d'))
     rules = psql.JSONField(default=list)
     publish = models.BooleanField(default=False)
 
@@ -45,6 +48,7 @@ class ProgramModel(models.Model):
     year = models.PositiveIntegerField()
     name = models.CharField(max_length=256)
     units = models.PositiveIntegerField()
+    lastUpdated = models.DateField(default=datetime.datetime.strptime('2019-03-10', '%Y-%m-%d'))
     staffNotes = models.TextField(blank=True, default='')
     studentNotes = models.TextField(blank=True, default='')
 

--- a/cassdegrees/api/models.py
+++ b/cassdegrees/api/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 import django.contrib.postgres.fields as psql
-import datetime
+from django.utils import timezone
 
 
 class SampleModel(models.Model):
@@ -16,7 +16,7 @@ class CourseModel(models.Model):
     units = models.PositiveIntegerField()
     offeredSem1 = models.BooleanField()
     offeredSem2 = models.BooleanField()
-    lastUpdated = models.DateField(default=datetime.datetime.today())
+    lastUpdated = models.DateField(default=timezone.now)
 
     class Meta:
         unique_together = (("code", "year"),)
@@ -28,7 +28,7 @@ class SubplanModel(models.Model):
     year = models.PositiveIntegerField()
     name = models.CharField(max_length=256)
     units = models.PositiveIntegerField()
-    lastUpdated = models.DateField(default=datetime.datetime.today())
+    lastUpdated = models.DateField(default=timezone.now)
     rules = psql.JSONField(default=list)
     publish = models.BooleanField(default=False)
 
@@ -48,7 +48,7 @@ class ProgramModel(models.Model):
     year = models.PositiveIntegerField()
     name = models.CharField(max_length=256)
     units = models.PositiveIntegerField()
-    lastUpdated = models.DateField(default=datetime.datetime.today())
+    lastUpdated = models.DateField(default=timezone.now)
     staffNotes = models.TextField(blank=True, default='')
     studentNotes = models.TextField(blank=True, default='')
 

--- a/cassdegrees/ui/forms.py
+++ b/cassdegrees/ui/forms.py
@@ -172,7 +172,7 @@ class EditCourseFormSnippet(ModelForm):
         model = CourseModel
         fields = ('code', 'year', 'name', 'units', 'offeredSem1', 'offeredSem2')
         widgets = {
-            'code': forms.TextInput(attrs={'class': "text tfull", 'placeholder': "e.g. ARTH1006, ARTH1100A"}),
+            'code': forms.TextInput(attrs={'class': "text tfull", 'placeholder': "e.g. ARTH1006, ARTH1100"}),
             'year': forms.NumberInput(attrs={'class': "text tfull",
                                              'onkeydown': "javascript: return checkKeys(event)",
                                              'type': "number"}),
@@ -180,7 +180,7 @@ class EditCourseFormSnippet(ModelForm):
                                            'placeholder': "e.g. Art and Design Histories: Form and Space"}),
             'units': forms.NumberInput(attrs={'class': "text tfull",
                                               'onkeydown': "javascript: return checkKeys(event)",
-                                              'type': "number"}),
+                                              'type': "number"})
         }
         labels = {
             'offeredSem1': "Offered in Semester 1",

--- a/cassdegrees/ui/views/courses.py
+++ b/cassdegrees/ui/views/courses.py
@@ -7,6 +7,8 @@ from django.shortcuts import render, redirect
 from ui.forms import EditCourseFormSnippet
 import json
 
+import datetime
+
 
 def create_course(request):
     duplicate = request.GET.get('duplicate', 'false')
@@ -31,6 +33,7 @@ def create_course(request):
         form = EditCourseFormSnippet(request.POST)
 
         if form.is_valid():
+            # instance.lastUpdated = datetime.date.today
             form.save()
             return redirect('/list/?view=Course&msg=Successfully Added Course!')
 
@@ -121,6 +124,8 @@ def edit_course(request):
         form = EditCourseFormSnippet(request.POST, instance=instance)
 
         if form.is_valid():
+            instance.lastUpdated = datetime.datetime.now().strftime('%Y-%m-%d')
+            instance.save(update_fields=['lastUpdated'])
             form.save()
             return redirect('/list/?view=Course&msg=Successfully Edited Course!')
 

--- a/cassdegrees/ui/views/courses.py
+++ b/cassdegrees/ui/views/courses.py
@@ -33,7 +33,6 @@ def create_course(request):
         form = EditCourseFormSnippet(request.POST)
 
         if form.is_valid():
-            # instance.lastUpdated = datetime.date.today
             form.save()
             return redirect('/list/?view=Course&msg=Successfully Added Course!')
 

--- a/cassdegrees/ui/views/courses.py
+++ b/cassdegrees/ui/views/courses.py
@@ -6,8 +6,7 @@ from django.shortcuts import render, redirect
 
 from ui.forms import EditCourseFormSnippet
 import json
-
-import datetime
+from django.utils import timezone
 
 
 def create_course(request):
@@ -123,7 +122,7 @@ def edit_course(request):
         form = EditCourseFormSnippet(request.POST, instance=instance)
 
         if form.is_valid():
-            instance.lastUpdated = datetime.datetime.now().strftime('%Y-%m-%d')
+            instance.lastUpdated = timezone.now().strftime('%Y-%m-%d')
             instance.save(update_fields=['lastUpdated'])
             form.save()
             return redirect('/list/?view=Course&msg=Successfully Edited Course!')

--- a/cassdegrees/ui/views/listings.py
+++ b/cassdegrees/ui/views/listings.py
@@ -15,9 +15,9 @@ def data_dict_as_displayable(data):
 
     # Columns that are needed
     desired_columns = {
-        'Program': ['id', 'code', 'year', 'name', 'units'],
-        'Subplan': ['id', 'code', 'year', 'name', 'planType'],
-        'Course': ['id', 'code', 'year', 'name', 'units']
+        'Program': ['id', 'code', 'year', 'name', 'units', 'lastUpdated'],
+        'Subplan': ['id', 'code', 'year', 'name', 'planType', 'lastUpdated'],
+        'Course': ['id', 'code', 'year', 'name', 'units', 'lastUpdated']
     }
 
     for key, value in data.items():

--- a/cassdegrees/ui/views/programs.py
+++ b/cassdegrees/ui/views/programs.py
@@ -4,8 +4,7 @@ from django.shortcuts import render, redirect, reverse
 
 from ui.forms import EditProgramFormSnippet
 from ui.views.subplans import create_subplan
-
-import datetime
+from django.utils import timezone
 
 
 def create_program(request):
@@ -102,7 +101,7 @@ def edit_program(request):
         form = EditProgramFormSnippet(request.POST, instance=instance)
 
         if form.is_valid():
-            instance.lastUpdated = datetime.datetime.now().strftime('%Y-%m-%d')
+            instance.lastUpdated = timezone.now().strftime('%Y-%m-%d')
             instance.save(update_fields=['lastUpdated'])
             form.save()
             return redirect('/list/?view=Program&msg=Successfully Edited Program!')

--- a/cassdegrees/ui/views/programs.py
+++ b/cassdegrees/ui/views/programs.py
@@ -5,6 +5,8 @@ from django.shortcuts import render, redirect, reverse
 from ui.forms import EditProgramFormSnippet
 from ui.views.subplans import create_subplan
 
+import datetime
+
 
 def create_program(request):
     duplicate = request.GET.get('duplicate', 'false')
@@ -100,6 +102,8 @@ def edit_program(request):
         form = EditProgramFormSnippet(request.POST, instance=instance)
 
         if form.is_valid():
+            instance.lastUpdated = datetime.datetime.now().strftime('%Y-%m-%d')
+            instance.save(update_fields=['lastUpdated'])
             form.save()
             return redirect('/list/?view=Program&msg=Successfully Edited Program!')
 

--- a/cassdegrees/ui/views/subplans.py
+++ b/cassdegrees/ui/views/subplans.py
@@ -7,6 +7,8 @@ from api.models import SubplanModel
 from api.views import search
 import json
 
+import datetime
+
 
 # Using sampleform template and #59 - basic program creation workflow as it's inspirations
 def create_subplan(request):
@@ -124,6 +126,8 @@ def edit_subplan(request):
         form = EditSubplanFormSnippet(request.POST, instance=instance)
 
         if form.is_valid():
+            instance.lastUpdated = datetime.datetime.now().strftime('%Y-%m-%d')
+            instance.save(update_fields=['lastUpdated'])
             form.save()
             return redirect('/list/?view=Subplan&msg=Successfully Edited Subplan!')
 

--- a/cassdegrees/ui/views/subplans.py
+++ b/cassdegrees/ui/views/subplans.py
@@ -6,8 +6,7 @@ from ui.forms import EditSubplanFormSnippet
 from api.models import SubplanModel
 from api.views import search
 import json
-
-import datetime
+from django.utils import timezone
 
 
 # Using sampleform template and #59 - basic program creation workflow as it's inspirations
@@ -126,7 +125,7 @@ def edit_subplan(request):
         form = EditSubplanFormSnippet(request.POST, instance=instance)
 
         if form.is_valid():
-            instance.lastUpdated = datetime.datetime.now().strftime('%Y-%m-%d')
+            instance.lastUpdated = timezone.now().strftime('%Y-%m-%d')
             instance.save(update_fields=['lastUpdated'])
             form.save()
             return redirect('/list/?view=Subplan&msg=Successfully Edited Subplan!')


### PR DESCRIPTION
This pr aims to accomplish #122.
I've added a new field called `lastUpdated` per model which has a default value to the current date (using the datetime library). When an instance of a course/subplan/program is edited, it updates the value of `lastUpdated` to the current date. This can be seen on the listings page. 

**Note:** 
- I wasn't sure whether to add a second field for the purpose of remembering when the instance was created so I've left it for now.
- I set the default date to March 10 2019 during my first migration, hence some rows has it as its date (this has allowed me to check if the date gets updated when a successful edit occurs).
![image](https://user-images.githubusercontent.com/24206502/57869762-10202a80-7849-11e9-8e42-893d3ece222a.png)
