### PR TITLE
Increase size of home button in breadcrumbs

### DIFF
--- a/cassdegrees/templates/base.html
+++ b/cassdegrees/templates/base.html
@@ -64,7 +64,7 @@
             <div id="content-main" class="margintop clearfix">
                 <div id="content-header" class="full nomargintop nomarginbottom">
                     <div id="breadcrumb" class="breadcrumbs">
-                        <a href="/"><img src="//style.anu.edu.au/_anu/images/icons/web/home.png" class="w16px absmiddle" alt="Home"></a>
+                        <a href="/"><img src="//style.anu.edu.au/_anu/images/icons/web/home.png" class="w24px absmiddle" alt="Home"></a>
                         {% block breadcrumb-trail %} No breadcrumb trail specified {% endblock %}
                     </div>
                     <h1 class="title" id="page-title">{% block subtitle %}No title defined{% endblock %}</h1>


### PR DESCRIPTION
One line PR. Increases size of home icon from 16px to 24px.

Closes #120.

![IncreasedHomeIcon](https://user-images.githubusercontent.com/1404334/58142053-f50a4c00-7c88-11e9-8e6f-cbeb7b1cc763.png)
