### PR TITLE
Prevent Course Code Change if Program/Subplan Requires It

### DIFF
--- a/cassdegrees/templates/createcourse.html
+++ b/cassdegrees/templates/createcourse.html
@@ -36,6 +36,14 @@
                         {{ field.label_tag }}
                     {% endif %}
                     {{ field }}
+                    {% if edit and 'code' in field.label_tag and dependencies|length > 0 %}
+                        <div class="instruction msg-info inline-error">
+                            You cannot edit the Code. Please check dependencies:
+                            {% for code, name in dependencies.items %}
+                                {{ code }} {{ name }}{% if not forloop.last %},{% endif %}
+                            {% endfor %}
+                        </div>
+                    {% endif %}
                 </p>
                 {% for error in field.errors %}
                      <div class="msg-error inline-error">{{ error }}</div>

--- a/cassdegrees/ui/forms.py
+++ b/cassdegrees/ui/forms.py
@@ -89,7 +89,6 @@ class EditProgramFormSnippet(ModelForm):
         return data
 
 
-
 class EditSubplanFormSnippet(ModelForm):
     # Automatically injected by default
     units = forms.IntegerField(widget=forms.HiddenInput(), required=False)

--- a/cassdegrees/ui/views/courses.py
+++ b/cassdegrees/ui/views/courses.py
@@ -123,9 +123,27 @@ def edit_course(request):
     # Find the program to specifically edit
     instance = CourseModel.objects.get(id=int(id))
 
+    dependencies = dict()
+
+    # Generate an internal request to search api made by Jack
+    gen_request = HttpRequest()
+
+    # Grab all the courses in the database
+    gen_request.GET = {'select': 'id,code,name,rules', 'from': 'program', 'rules': instance.code}
+    programs = json.loads(search(gen_request).content.decode())
+    gen_request.GET = {'select': 'id,code,name,rules', 'from': 'subplan', 'rules': instance.code}
+    subplans = json.loads(search(gen_request).content.decode())
+
+    # if there are programs/subplans that depend on the course code
+    if len(programs) + len(subplans) > 0:
+        for program in programs:
+            dependencies[program['code']] = program['name']
+        for subplan in subplans:
+            dependencies[subplan['code']] = subplan['name']
+
     if request.method == 'POST':
         form = EditCourseFormSnippet(request.POST, instance=instance)
-
+        form.fields['code'].disabled = len(programs) + len(subplans) > 0
         if form.is_valid():
             instance.lastUpdated = timezone.now().strftime('%Y-%m-%d')
             instance.save(update_fields=['lastUpdated'])
@@ -134,9 +152,11 @@ def edit_course(request):
 
     else:
         form = EditCourseFormSnippet(instance=instance)
+        form.fields['code'].disabled = len(programs) + len(subplans) > 0
 
     return render(request, 'createcourse.html', context={
         "edit": True,
         "form": form,
-        "courses": CourseModel.objects.values()
+        "courses": CourseModel.objects.values(),
+        "dependencies": dependencies
     })

--- a/cassdegrees/ui/views/courses.py
+++ b/cassdegrees/ui/views/courses.py
@@ -123,7 +123,7 @@ def edit_course(request):
     # Find the program to specifically edit
     instance = CourseModel.objects.get(id=int(id))
 
-    dependencies = dict()
+    dependencies = dict()  # programs/subplans that are dependent on this course instance {'code': 'name'}
 
     # Generate an internal request to search api made by Jack
     gen_request = HttpRequest()


### PR DESCRIPTION
Aims to complete #104. How I've tackled this issue is I check if a course code is being used in any subplans/programs. If it is, I disable the Course Code input box and display an info message. If no subplan/program depends on it, you're able to edit the course code as normal.

**When you're editing a course that is needed by a subplan/program:**
![image](https://user-images.githubusercontent.com/24206502/58403387-eb784e00-80a5-11e9-8d26-955a6630987c.png)
**When you're editing a course that is _not_ needed by a subplan/program:**
![image](https://user-images.githubusercontent.com/24206502/58403476-1b275600-80a6-11e9-9664-3c9f067830e3.png)
