### PR TITLE
Removed PDF button from subplans and courses

### DIFF
--- a/cassdegrees/templates/list.html
+++ b/cassdegrees/templates/list.html
@@ -87,7 +87,7 @@
                                             <a class="btn-uni-grad" href="/create/{% if title == 'Program' %}program{% elif title == 'Subplan' %}subplan{% elif title == 'Course' %}course{% endif %}/?id={{ item }}&duplicate=true">Duplicate</a>
                                             <a class="btn-uni-grad" href="/edit/{% if title == 'Program' %}program{% elif title == 'Subplan' %}subplan{% elif title == 'Course' %}course{% endif %}/?id={{ item }}">Edit</a>
                                             <a class="btn-uni-grad" href="/view/{% if title == 'Program' %}program{% elif title == 'Subplan' %}subplan{% elif title == 'Course' %}course{% endif %}/?id={{ item }}">View</a>
-                                            <a class="btn-uni-grad" href="/pdf/{% if title == 'Program' %}program{% elif title == 'Subplan' %}subplan{% elif title == 'Course' %}course{% endif %}/?id={{ item }}">PDF</a>
+                                            {% if title == 'Program' %}<a class="btn-uni-grad" href="/pdf/program?id={{ item }}">PDF</a>{% endif %}
                                         </td>
                                     {% endif %}
 


### PR DESCRIPTION
This PR fixes issue #171 by removing the PDF button from subplans and courses