### PR TITLE
Implement either/or for PDF program templates

### DIFF
--- a/cassdegrees/templates/pdf_base.html
+++ b/cassdegrees/templates/pdf_base.html
@@ -79,6 +79,10 @@
         .top-margin {
             padding-top: 0.1cm;
         }
+
+        .try-complete-box {
+            page-break-inside: avoid;
+        }
     </style>
 
 </head>

--- a/cassdegrees/templates/pdf_base.html
+++ b/cassdegrees/templates/pdf_base.html
@@ -66,6 +66,19 @@
         .small-text {
             font-size: 60%;
         }
+
+        .left-box {
+            border-left: 1px solid black;
+            padding-left: 0.25cm;
+        }
+
+        .bottom-margin {
+            padding-bottom: 0.1cm;
+        }
+
+        .top-margin {
+            padding-top: 0.1cm;
+        }
     </style>
 
 </head>

--- a/cassdegrees/templates/pdf_program.html
+++ b/cassdegrees/templates/pdf_program.html
@@ -1,6 +1,5 @@
 {% extends "pdf_base.html" %}
 {% load course_boxes %}
-{% load math %}
 
 {% block page-title %}{{ program.name }} ({{ program.year }}){% endblock %}
 
@@ -17,70 +16,7 @@
     <div class="columns-3 columns-no-gap">
 
         {% for rule in program.rules %}
-            <div class="box">
-                {% if rule.type == "subplan" %}
-                    <p>Completion of {{ rule.kind }} for {{ rule.units }} units:</p>
-                {% elif rule.type == "subject_area" %}
-                    {# https://stackoverflow.com/questions/4831306/need-to-convert-a-string-to-int-in-a-django-template #}
-                    {# add:"0" needed to cast units to int #}
-                    <p>Complete {{ rule.unit_count }} units from {% if rule.unit_count|add:"0" <= 6 %}a{% endif %}
-                        {{ rule.subject }} course{% if rule.unit_count|add:"0" > 6 %}s{% endif %}:</p>
-                {% elif rule.type == "year_level" %}
-                    <p>Complete {{ rule.unit_count }} units from {% if rule.unit_count|add:"0" <= 6 %}a{% endif %}
-                        {{ rule.year_level }}-level course{% if rule.unit_count|add:"0" > 6 %}s{% endif %}:</p>
-                {% elif rule.type == "course" %}
-                    {# Find out if all courses are required #}
-                    {% with courses_provided=rule.codes|length %}
-                        {% with courses_needed=rule.unit_count|divide:6 %}
-                            {% if courses_provided == courses_needed %}
-                                {# All courses specified are required - render all #}
-                                <p>Complete {{ rule.unit_count }} units from the following
-                                    {% if rule.unit_count|add:"0" <= 6 %}course{% else %}set of courses{% endif %}:</p>
-                            {% else %}
-                                {# Not all required courses - give descriptions #}
-                                <p>Complete {{ rule.unit_count }} units from a selection of:</p>
-                                {% for code in rule.codes %}
-                                    {{ code }}{% if not forloop.last %}, {% endif %}
-                                {% endfor %}
-                            {% endif %}
-                        {% endwith %}
-                    {% endwith %}
-
-                {% elif rule.type == "custom_text" %}
-                    <p>For {{ rule.units }} units:</p>
-                    <p>{{ rule.text }}</p>
-                {% else %}
-                <!-- TODO: courseRequirementTemplate -->
-                    ERROR: Unknown rule type "{{ rule.type }}"!
-                {% endif %}
-            </div>
-
-
-            {% if rule.type == "subplan" %}
-                {% course_box rule.units %}
-            {% elif rule.type == "subject_area" %}
-                {% course_box rule.unit_count %}
-            {% elif rule.type == "year_level" %}
-                {% course_box rule.unit_count %}
-            {% elif rule.type == "course" %}
-                {% with courses_provided=rule.codes|length %}
-                    {% with courses_needed=rule.unit_count|divide:6 %}
-                        {% if courses_provided == courses_needed %}
-                            {# All courses specified are required - render all #}
-                            {% course_box_with_values rule.unit_count rule.codes %}
-                        {% else %}
-                            {# Not all required courses - map them out as blanks #}
-                            {% course_box rule.unit_count %}
-                        {% endif %}
-                    {% endwith %}
-                {% endwith %}
-            {% elif rule.type == "custom_text" %}
-                {% if rule.show_course_boxes %}
-                    {% course_box rule.units %}
-                {% endif %}
-            {% endif %}
-
-            {% if forloop.last %}<div class="break-box"></div>{% endif %}
+            {% include "widgets/pdf_rules.html" %}
         {% endfor %}
 
         <div class="break-column"></div>

--- a/cassdegrees/templates/widgets/pdf_rules.html
+++ b/cassdegrees/templates/widgets/pdf_rules.html
@@ -1,8 +1,8 @@
 {% load course_boxes %}
 {% load math %}
 
-<!-- Renders a rule for a PDF program -->
-<div class="box">
+{# Renders rule a rule for a PDF program #}
+<div class="box try-complete-box">
     {% if rule.type == "subplan" %}
         <p>Completion of {{ rule.kind }} for {{ rule.units }} units:</p>
     {% elif rule.type == "subject_area" %}

--- a/cassdegrees/templates/widgets/pdf_rules.html
+++ b/cassdegrees/templates/widgets/pdf_rules.html
@@ -1,7 +1,7 @@
 {% load course_boxes %}
 {% load math %}
 
-<!-- Renders rule a rule for a PDF program -->
+<!-- Renders a rule for a PDF program -->
 <div class="box">
     {% if rule.type == "subplan" %}
         <p>Completion of {{ rule.kind }} for {{ rule.units }} units:</p>

--- a/cassdegrees/templates/widgets/pdf_rules.html
+++ b/cassdegrees/templates/widgets/pdf_rules.html
@@ -1,0 +1,78 @@
+{% load course_boxes %}
+{% load math %}
+
+<!-- Renders rule a rule for a PDF program -->
+<div class="box">
+    {% if rule.type == "subplan" %}
+        <p>Completion of {{ rule.kind }} for {{ rule.units }} units:</p>
+    {% elif rule.type == "subject_area" %}
+        {# https://stackoverflow.com/questions/4831306/need-to-convert-a-string-to-int-in-a-django-template #}
+        {# add:"0" needed to cast units to int #}
+        <p>Complete {{ rule.unit_count }} units from {% if rule.unit_count|add:"0" <= 6 %}a{% endif %}
+            {{ rule.subject }} course{% if rule.unit_count|add:"0" > 6 %}s{% endif %}:</p>
+    {% elif rule.type == "year_level" %}
+        <p>Complete {{ rule.unit_count }} units from {% if rule.unit_count|add:"0" <= 6 %}a{% endif %}
+            {{ rule.year_level }}-level course{% if rule.unit_count|add:"0" > 6 %}s{% endif %}:</p>
+    {% elif rule.type == "course" %}
+        {# Find out if all courses are required #}
+        {% with courses_provided=rule.codes|length %}
+            {% with courses_needed=rule.unit_count|divide:6 %}
+                {% if courses_provided == courses_needed %}
+                    {# All courses specified are required - render all #}
+                    <p>Complete {{ rule.unit_count }} units from the following
+                        {% if rule.unit_count|add:"0" <= 6 %}course{% else %}set of courses{% endif %}:</p>
+                {% else %}
+                    {# Not all required courses - give descriptions #}
+                    <p>Complete {{ rule.unit_count }} units from a selection of:</p>
+                    {% for code in rule.codes %}
+                        {{ code }}{% if not forloop.last %}, {% endif %}
+                    {% endfor %}
+                {% endif %}
+            {% endwith %}
+        {% endwith %}
+    {% elif rule.type == "either_or" %}
+        <p class="bottom-margin">Either:</p>
+
+        {% for group in rule.either_or %}
+            <div class="left-box">
+                {% for rule in group %}
+                    {% include "widgets/pdf_rules.html" %}
+                {% endfor %}
+            </div>
+
+            {% if not forloop.last %}<p class="bottom-margin top-margin">or...</p>{% endif %}
+        {% endfor %}
+    {% elif rule.type == "custom_text" %}
+        <p>For {{ rule.units }} units:</p>
+        <p>{{ rule.text }}</p>
+    {% else %}
+        ERROR: Unknown rule type "{{ rule.type }}"!
+    {% endif %}
+</div>
+
+
+{% if rule.type == "subplan" %}
+    {% course_box rule.units %}
+{% elif rule.type == "subject_area" %}
+    {% course_box rule.unit_count %}
+{% elif rule.type == "year_level" %}
+    {% course_box rule.unit_count %}
+{% elif rule.type == "course" %}
+    {% with courses_provided=rule.codes|length %}
+        {% with courses_needed=rule.unit_count|divide:6 %}
+            {% if courses_provided == courses_needed %}
+                {# All courses specified are required - render all #}
+                {% course_box_with_values rule.unit_count rule.codes %}
+            {% else %}
+                {# Not all required courses - map them out as blanks #}
+                {% course_box rule.unit_count %}
+            {% endif %}
+        {% endwith %}
+    {% endwith %}
+{% elif rule.type == "custom_text" %}
+    {% if rule.show_course_boxes %}
+        {% course_box rule.units %}
+    {% endif %}
+{% endif %}
+
+{% if forloop.last %}<div class="break-box"></div>{% endif %}


### PR DESCRIPTION
Closes #95 (see comment in there).

This PR implements the either/or rule for PDF templates:

![either-or-pdf](https://user-images.githubusercontent.com/1404334/58797541-9a3b0200-8643-11e9-9914-24a56392c463.png)

Rules for PDFs have been migrated to a recursive widget.
