### PR TITLE
Add help documentation for rules and global requirements

### DIFF
--- a/cassdegrees/static/css/style.css
+++ b/cassdegrees/static/css/style.css
@@ -205,3 +205,13 @@ select.text{
     color: #ffffff;
     background: #707070;
 }
+
+/* Vertically aligns text to the middle */
+.vertical-middle {
+    vertical-align: middle;
+}
+
+/* Indicates that an element is clickable */
+.clickable {
+    cursor: pointer;
+}

--- a/cassdegrees/static/js/globalrequirements.js
+++ b/cassdegrees/static/js/globalrequirements.js
@@ -78,7 +78,9 @@ Vue.component('global_requirement', {
     },
     data: function() {
         return {
-            component_names: GLOBAL_REQUIREMENT_NAMES
+            component_names: GLOBAL_REQUIREMENT_NAMES,
+            component_help: GLOBAL_REQUIREMENT_HELP,
+            show_help: false
         }
     },
     template: '#globalRequirementTemplate'
@@ -145,6 +147,16 @@ function handleProgram() {
 const GLOBAL_REQUIREMENT_NAMES = {
     'min': "Minimum Units from Year(s)",
     'max': "Maximum Units from Year(s)",
+};
+
+const GLOBAL_REQUIREMENT_HELP = {
+    'min': "Enforces for an entire degree that a minimum amount of units *must* come from a particular " +
+           "set of course levels - e.g. a minimum of 6 units of 1000-level courses over an entire program, " +
+           "and 12 from 2000-level. Multiple of these global requirements may exist (e.g. if different unit counts " +
+           "are needed).",
+    'max': "Enforces for an entire degree that a maximum amount of units from a particular set of course levels " +
+           "will exist - e.g. a maximum of 6 units of 1000-level courses over an entire program, and 12 from " +
+           "2000-level. Multiple of these global requirements may exist (e.g. if different unit counts are needed).",
 };
 
 var globalRequirementsApp = new Vue({

--- a/cassdegrees/static/js/rules.js
+++ b/cassdegrees/static/js/rules.js
@@ -14,6 +14,30 @@ const ALL_COMPONENT_NAMES = {
     'either_or': "Either Or"
 };
 
+// Help for all components
+const ALL_COMPONENT_HELP = {
+    'incompatibility': "A rule which notes that students must not have picked any of the set of courses specified.",
+    'program': 'A rule which enforces that only students from a particular course can take this option.',
+    'subplan': "A rule which gives students a choice from a particular set of majors, minors, specialisations or " +
+               "other subplans. The description here is used to describe the rule when displaying this rule to " +
+               "students.",
+    'year_level': 'A rule which specifies that students must complete a number of units from a particular year level.',
+    'subject_area': "A rule which specifies that students must complete a number of units from a particular field.",
+    'course': "A rule which specifies that students should pick a certain amount of units from a set of available " +
+              "courses.",
+    'course_requisite': "A rule which specifies that students should have taken a set of courses before taking this " +
+                        "one.",
+    'custom_text': "If other rules don't entirely fit the requirements of a rule, the custom text field allows " +
+                   "for the specification of other program content. Note that this isn't enforced in student-facing " +
+                   "tools.",
+    'custom_text_req': "If other rules don't entirely fit the requirements of a rule, the custom text field allows " +
+                       "for the specification of other program content. Note that this isn't enforced in student-facing " +
+                       "tools.",
+    'either_or': "A rule which allows for the specification of sets of different paths that students can take. Each " +
+                 "\"OR\" group is a collection of rules which must be completed if students were to pick that specific " +
+                 "group."
+};
+
 // Translation table between internal names for components and human readable ones.
 const COMPONENT_NAMES = {
     'subplan': "Subplan",
@@ -828,7 +852,9 @@ Vue.component('rule', {
     },
     data: function() {
         return {
-            component_names: ALL_COMPONENT_NAMES
+            component_names: ALL_COMPONENT_NAMES,
+            component_help: ALL_COMPONENT_HELP,
+            show_help: false
         }
     },
     methods:{

--- a/cassdegrees/templates/widgets/globalrequirements.html
+++ b/cassdegrees/templates/widgets/globalrequirements.html
@@ -104,10 +104,29 @@
             <p class="card-header-title">
                 {{ component_names[details.type] }}
             </p>
+            <img src="//style.anu.edu.au/_anu/images/icons/web/question.png" class="btn-snall no-left-margin vertical-middle clickable"
+                 alt="Help button" v-on:click="show_help = true" />
             <input type="button" v-on:click="$emit('remove')" class="btn-uni-grad btn-snall no-left-margin" value="Remove" />
         </header>
         <div class="box-solid">
             <div class="card-content" v-bind:is="'global_requirement_' + details.type" v-bind:details="details"></div>
+        </div>
+
+        <div class="modal" v-if="show_help">
+            <div class="modal-background" v-on:click="show_help = false"></div>
+            <div class="modal-card">
+                <div class="card">
+                    <header class="box-header">
+                        Help for {{ component_names[details.type] }}
+                    </header>
+                    <div class="box-solid box-has-footer">
+                        <p>{{ component_help[details.type] }}</p>
+                    </div>
+                    <footer class="box-solid">
+                        <button class="button" v-on:click="show_help = false">OK</button>
+                    </footer>
+                </div>
+            </div>
         </div>
     </div>
 </script>

--- a/cassdegrees/templates/widgets/rulescripts.html
+++ b/cassdegrees/templates/widgets/rulescripts.html
@@ -233,10 +233,29 @@
             <p class="card-header-title">
                 {{ component_names[details.type] }}
             </p>
+            <img src="//style.anu.edu.au/_anu/images/icons/web/question.png" class="btn-snall no-left-margin vertical-middle clickable"
+                 alt="Help button" v-on:click="show_help = true" />
             <input type="button" v-on:click="$emit('remove')" class="btn-uni-grad btn-snall no-left-margin" value="Remove" />
         </header>
         <div class="box-solid">
             <div class="card-content" v-bind:is="'rule_' + details.type" v-bind:details="details"></div>
+        </div>
+
+        <div class="modal" v-if="show_help">
+            <div class="modal-background" v-on:click="show_help = false"></div>
+            <div class="modal-card">
+                <div class="card">
+                    <header class="box-header">
+                        Help for {{ component_names[details.type] }}
+                    </header>
+                    <div class="box-solid box-has-footer">
+                        <p>{{ component_help[details.type] }}</p>
+                    </div>
+                    <footer class="box-solid">
+                        <button class="button" v-on:click="show_help = false">OK</button>
+                    </footer>
+                </div>
+            </div>
         </div>
     </div>
 </script>

--- a/cassdegrees/templates/widgets/subplanrules.html
+++ b/cassdegrees/templates/widgets/subplanrules.html
@@ -44,10 +44,28 @@
             <p class="card-header-title">
                 Course List
             </p>
+            <img src="//style.anu.edu.au/_anu/images/icons/web/question.png" class="btn-snall no-left-margin vertical-middle clickable"
+                 alt="Help button" v-on:click="show_help = true" />
             <input type="button" v-on:click="$emit('remove')" class="btn-uni-grad btn-snall no-left-margin" value="Remove" />
         </header>
         <div class="box-solid">
             <div class="card-content" v-bind:is="'rule_course'" v-bind:details="details"></div>
+        </div>
+        <div class="modal" v-if="show_help">
+            <div class="modal-background" v-on:click="show_help = false"></div>
+            <div class="modal-card">
+                <div class="card">
+                    <header class="box-header">
+                        Help for Course List
+                    </header>
+                    <div class="box-solid box-has-footer">
+                        <p>{{ component_help[details.type] }}</p>
+                    </div>
+                    <footer class="box-solid">
+                        <button class="button" v-on:click="show_help = false">OK</button>
+                    </footer>
+                </div>
+            </div>
         </div>
     </div>
 </script>


### PR DESCRIPTION
Closes https://github.com/cass-degrees/CASS-Degrees-Code/issues/125

This PR implements a help button for all rules and global requirements. This has been implemented for programs, subplans and courses.

A popup was chosen here to make it easier to read larger pieces of help documentation (for which e.g. a tooltip would not work)

Screenshot:

![screenshot-23_02_21_-_06_08_19](https://user-images.githubusercontent.com/1404334/62542002-79ad4500-b84a-11e9-9ca8-8cecec17f7f7.png)
