### PR TITLE
Disabled autocomplete on form inputs

### DIFF
--- a/cassdegrees/templates/createcourse.html
+++ b/cassdegrees/templates/createcourse.html
@@ -24,7 +24,7 @@
          <p class="msg-error">{{ error }}</p>
     {% endfor %}
 
-    <form class="anuform" id="mainForm" action="" method="post" onsubmit="return false;">
+    <form class="anuform" id="mainForm" action="" method="post" onsubmit="return false;" autocomplete="off">
         {% csrf_token %}
 
         <input type="hidden" id="redirect" name="redirect">

--- a/cassdegrees/templates/createprogram.html
+++ b/cassdegrees/templates/createprogram.html
@@ -24,7 +24,7 @@
          <p class="msg-error">{{ error }}</p>
     {% endfor %}
 
-    <form class="anuform" id="mainForm" action="" method="post" onsubmit="return false;">
+    <form class="anuform" id="mainForm" action="" method="post" onsubmit="return false;" autocomplete="off">
         {% csrf_token %}
 
         <input type="hidden" id="redirect" name="redirect">

--- a/cassdegrees/templates/createsubplan.html
+++ b/cassdegrees/templates/createsubplan.html
@@ -24,7 +24,7 @@
          <p class="msg-error">{{ error }}</p>
     {% endfor %}
 
-    <form class="anuform" id="mainForm" action="" method="post" onsubmit="return false;">
+    <form class="anuform" id="mainForm" action="" method="post" onsubmit="return false;" autocomplete="off">
         {% csrf_token %}
 
         <input type="hidden" id="redirect" name="redirect">


### PR DESCRIPTION
Closes #161 

This PR adds a tag to the template creation forms which prevents web browsers from showing autocomplete suggestions. UAT showed that autocomplete could be misleading for some users, and would not benefit the user workflow.

I had some trouble testing this as I do not experience any autocomplete suggestions on my environment (Chrome and Microsoft Edge). The change is small and should work in theory however. It would be good for people who experience autocomplete suggestions currently to validate whether this PR disables them.

