### PR TITLE
Extra Subplan Rules

### DIFF
--- a/cassdegrees/static/js/rules.js
+++ b/cassdegrees/static/js/rules.js
@@ -76,6 +76,12 @@ const REQUISITE_EITHER_OR_COMPONENT_NAMES = {
     'custom_text_req': "Custom (Text)"
 };
 
+const LIST_TYPES = {
+    'min': 'At least',
+    'exact': 'Exactly',
+    'max': 'No more than'
+};
+
 Vue.component('rule_incompatibility', {
     props: {
         "details": {
@@ -377,6 +383,11 @@ Vue.component('rule_course', {
                     value.codes = [""];
                 }
 
+                if (!value.hasOwnProperty("list_type")) {
+                    // possible values = LIST_TYPES
+                    value.list_type = "";
+                }
+
                 return true;
             }
         }
@@ -384,6 +395,7 @@ Vue.component('rule_course', {
     data: function() {
         return {
             "courses": [],
+            "list_types": [],
 
             // Display related warnings if true
             "non_unique_options": false,
@@ -403,7 +415,7 @@ Vue.component('rule_course', {
 
         request.addEventListener("load", function() {
             rule.courses = JSON.parse(request.response);
-
+            rule.list_types = LIST_TYPES;
             rule.check_options();
         });
         request.open("GET", "/api/search/?select=code,name&from=course");
@@ -500,7 +512,6 @@ Vue.component('rule_course_requisite', {
 
         request.addEventListener("load", function() {
             rule.courses = JSON.parse(request.response);
-
             rule.check_options();
         });
         request.open("GET", "/api/search/?select=code,name&from=course");

--- a/cassdegrees/templates/widgets/subplanrules.html
+++ b/cassdegrees/templates/widgets/subplanrules.html
@@ -15,12 +15,14 @@
             <label>
                 Students must complete:
             </label>
-            <select v-model="details.list_type" required>
-                <option v-for="(msg, type) in list_types" v-bind:value="type">{{ msg }}</option>
-            </select>
         </p>
 
-        <input class="text" onkeydown="javascript: return checkKeys(event)" type="number" v-on:change="check_options" v-model="details.unit_count" min="0" step="6" max="1000" aria-required="true" required> units
+        <select v-model="details.list_type" required>
+            <option v-for="(msg, type) in list_types" v-bind:value="type">{{ msg }}</option>
+        </select>
+
+{#       instyle css only temporary #}
+        <input style="margin-left: 0;" class="text" onkeydown="javascript: return checkKeys(event)" type="number" v-on:change="check_options" v-model="details.unit_count" min="0" step="6" max="1000" required> units
 
         <div class="msg-error" v-if="invalid_units">Unit count must be > 0!</div>
         <div class="msg-error" v-if="invalid_units_step">Unit count should be divisible by 6!</div>

--- a/cassdegrees/templates/widgets/subplanrules.html
+++ b/cassdegrees/templates/widgets/subplanrules.html
@@ -13,11 +13,14 @@
     <fieldset v-if="!redraw">
         <p class="form-group">
             <label>
-                Students must select...
+                Students must complete:
             </label>
-            <input class="text" onkeydown="javascript: return checkKeys(event)" type="number" v-on:change="check_options" v-model="details.unit_count" min="0" step="6" max="1000" aria-required="true" required>
-            units
+            <select v-model="details.list_type" required>
+                <option v-for="(msg, type) in list_types" v-bind:value="type">{{ msg }}</option>
+            </select>
         </p>
+
+        <input class="text" onkeydown="javascript: return checkKeys(event)" type="number" v-on:change="check_options" v-model="details.unit_count" min="0" step="6" max="1000" aria-required="true" required> units
 
         <div class="msg-error" v-if="invalid_units">Unit count must be > 0!</div>
         <div class="msg-error" v-if="invalid_units_step">Unit count should be divisible by 6!</div>

--- a/cassdegrees/templates/widgets/subplanrules.html
+++ b/cassdegrees/templates/widgets/subplanrules.html
@@ -21,7 +21,7 @@
             <option v-for="(msg, type) in list_types" v-bind:value="type">{{ msg }}</option>
         </select>
 
-{#       instyle css only temporary #}
+<!-- {#       instyle css only temporary #} -->
         <input style="margin-left: 0;" class="text" onkeydown="javascript: return checkKeys(event)" type="number" v-on:change="check_options" v-model="details.unit_count" min="0" step="6" max="1000" required> units
 
         <div class="msg-error" v-if="invalid_units">Unit count must be > 0!</div>


### PR DESCRIPTION
Closes #218 

There is now a new dropdown menu where the user can select min/max/exact for the rule. I had to use instyle css as a temp fix to overwrite anu styling (for some reason, could not do it through style.css).

**Adding a Course List Rule**
![image](https://user-images.githubusercontent.com/24206502/63406087-28957780-c42c-11e9-87fd-19e2e452c591.png)

**How It Is Saved**
**NOTE: `different list types = {'max', 'exact', 'min'}`**
`{
   "id":17,
   "code":"RULE-MAJ",
   "year":2020,
   "name":"Testing Extra Rules",
   "units":48,
   "planType":"MAJ",
   "rules":[
      {
         "type":"course",
         "codes":[
            "ARTH1007",
            "ARTH1000",
            "LMAO3000"
         ],
         "list_type":"max",
         "unit_count":"12"
      }
   ],
   "publish":true
}`

