### PR TITLE
Fixed UAT Bug #216 Unable tab number fields

### DIFF
--- a/cassdegrees/static/js/main.js
+++ b/cassdegrees/static/js/main.js
@@ -12,7 +12,7 @@
 const ADMIN_URL_PREFIX = "/admin/";
 
 function checkKeys(event) {
-    return event.keyCode === 8 || event.keyCode === 46 ? true : !isNaN(Number(event.key));
+    return event.keyCode === 9 || event.keyCode === 8 || event.keyCode === 46 ? true : !isNaN(Number(event.key));
 }
 
 /**


### PR DESCRIPTION
I figured out why we couldn't tab number fields. Issue (#216)
This was because our Javascript function to stop 'e' and '+' '-' used in number fields was also rejecting the tab keycode.

I've simply added it as an exception in out checkKeys function. 