### PR TITLE
Feature plan save and load

### DIFF
--- a/cassdegrees/cassdegrees/settings.py
+++ b/cassdegrees/cassdegrees/settings.py
@@ -120,7 +120,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'Australia/Sydney'
 
 USE_I18N = True
 

--- a/cassdegrees/static/css/style.css
+++ b/cassdegrees/static/css/style.css
@@ -53,6 +53,21 @@
     width: 100%;
 }
 
+.large-menu-item {
+    width:50%;
+}
+.small-menu-item {
+    width:25%;
+}
+.delete-color {
+    background-color:lightcoral;
+    color:#FFF;
+}
+.delete-color:hover {
+    background-color:indianred;
+    color:#FFF;
+}
+
 /* Adds carets to list sorting options */
 table th {}
 .sort:after{

--- a/cassdegrees/templates/student_create.html
+++ b/cassdegrees/templates/student_create.html
@@ -25,7 +25,7 @@
 
         <div class="list">
             {% for degree in programs %}
-                <a href="/edit/?id={{ degree.id }}" class="hide-link-underline">
+                <a href="/create/?id={{ degree.id }}" class="hide-link-underline">
                     <div class="course-details hide">
                         {{ degree.name }}
                         {{ degree.year }}

--- a/cassdegrees/templates/student_edit.html
+++ b/cassdegrees/templates/student_edit.html
@@ -12,21 +12,32 @@
 {% endblock %}
 
 {% block content %}
+    {% if render.msg != None %}
+        <p class="msg-success">{{ render.msg }}</p>
+    {% endif %}
+    {# linebreaksbr adds a <br> whenever there is a \n in a string #}
+    {% if render.error != None %}
+        <p class="msg-error">{{ render.error|linebreaksbr }}</p>
+    {% endif %}
+
     {# program is the full program object as selected by the user, superuser is if an authenticated #}
     {# user is logged in #}
-    <div class="box bdr-solid bdr-uni">
+    <form action="" method="post" class="box bdr-solid bdr-uni">
+        {% csrf_token %}
+        <input type="hidden" name="program_id" value="{{ plan.program_id }}" />
+
         <label for="plan-name">Name:</label>
-        <input id="plan-name" type="text" placeholder="e.g. {{ program.name }}" />
+        <input id="plan-name" name="plan_name" type="text" placeholder="e.g. {{ program.name }}" value="{{ plan.name }}"/>
         &nbsp;|&nbsp;
-        <span>Last Edited: 01/01/2000</span>
+        <span>Last Edited: {{ plan.date }}</span>
 
         <div class="float-right">
-            <input type="button" class="btn-uni-grad btn-small" value="Save...">
+            <input type="submit" class="btn-uni-grad btn-small" value="Save...">
             {% if superuser %}
                 <input type="button" class="btn-uni-grad btn-small" value="Save & Approve...">
             {% endif %}
         </div>
-    </div>
+    </form>
 
     {% for rule in program.rules %}
         {{ rule.type }}

--- a/cassdegrees/templates/student_index.html
+++ b/cassdegrees/templates/student_index.html
@@ -10,6 +10,14 @@
 {% endblock %}
 
 {% block content %}
+    {% if render.msg != None %}
+        <p class="msg-success">{{ render.msg }}</p>
+    {% endif %}
+    {# linebreaksbr adds a <br> whenever there is a \n in a string #}
+    {% if render.error != None %}
+        <p class="msg-error">{{ render.error|linebreaksbr }}</p>
+    {% endif %}
+
     <p>
         The CASS student planner tool is designed to help you plan out your degree, either
         at the beginning or throughout. This tool will check for common issues that you may
@@ -22,16 +30,21 @@
 
     <hr />
 
-    <!-- TODO: Relies on persistence (e.g. cookies) -->
     <div>
-        <a href="#" class="hide-link-underline">
-            <input class="btn-uni-grad btn-large" type="button"
-                   value="Continue previous plan: 'Bachelor of Arts', last updated 27th of April, 2019" />
-        </a>
-        &nbsp;
-        <a href="#">
-            <input type="button" class="btn-uni-grad btn-snall no-left-margin" value="Remove" />
-        </a>
+    {% for plan in plans %}
+        {% if plan.name %}
+        <div>
+            <a href="/edit/?plan={{ plan.name }}" class="hide-link-underline">
+                <input class="btn-uni-grad btn-large" type="button"
+                       value="Continue previous plan: '{{ plan.name }}', last updated {{ plan.date }}" />
+            </a>
+            &nbsp;
+            <a href="/delete/?plan={{ plan.name }}">
+                <input type="button" class="btn-uni-grad btn-snall no-left-margin" value="Remove" formaction="D"/>
+            </a>
+        </div>
+        {% endif %}
+    {% endfor %}
     </div>
 
 {% endblock %}

--- a/cassdegrees/templates/student_index.html
+++ b/cassdegrees/templates/student_index.html
@@ -33,15 +33,31 @@
     <div>
     {% for plan in plans %}
         {% if plan.name %}
-        <div>
-            <a href="/edit/?plan={{ plan.name }}" class="hide-link-underline">
-                <input class="btn-uni-grad btn-large" type="button"
-                       value="Continue previous plan: '{{ plan.name }}', last updated {{ plan.date }}" />
-            </a>
-            &nbsp;
-            <a href="/delete/?plan={{ plan.name }}">
-                <input type="button" class="btn-uni-grad btn-snall no-left-margin" value="Remove" formaction="D"/>
-            </a>
+        <div class="list w-full">
+            <div class="left w-two-third">
+                <a href="/edit/?plan={{ plan.name }}" class="hide-link-underline">
+                    <div class="card selectable-card">
+                        <div class="box-solid">
+                            <div class="card-content">
+                                <b>{{ plan.name }} </b><text class="right">{{ plan.date }}</text>
+                                <br />
+                                {{ plan.program }}
+                            </div>
+                        </div>
+                    </div>
+                </a>
+            </div>
+            <div class="w-full">
+                <a href="/delete/?plan={{ plan.name }}" class="hide-link-underline">
+                    <div class="card selectable-card">
+                        <div class="box-solid">
+                            <div class="card-content center">
+                                <p>Remove</p>
+                            </div>
+                        </div>
+                    </div>
+                </a>
+            </div>
         </div>
         {% endif %}
     {% endfor %}

--- a/cassdegrees/templates/student_index.html
+++ b/cassdegrees/templates/student_index.html
@@ -32,34 +32,80 @@
 
     <div>
     {% for plan in plans %}
-        {% if plan.name %}
-        <div class="list w-full">
-            <div class="left w-two-third">
+        {% if plan.name %}{% with i=forloop.counter0 %}
+        <div class="list w-full block-center">
+            {# Render the plan loading button #}
+            <div class="large-menu-item">
                 <a href="/edit/?plan={{ plan.name }}" class="hide-link-underline">
                     <div class="card selectable-card">
-                        <div class="box-solid">
-                            <div class="card-content">
-                                <b>{{ plan.name }} </b><text class="right">{{ plan.date }}</text>
-                                <br />
-                                {{ plan.program }}
-                            </div>
+                        <div class="box-solid card-content">
+                            <b>{{ plan.name }} </b><text class="right">{{ plan.date }}</text>
+                            <br />
+                            {{ plan.program }}
                         </div>
                     </div>
                 </a>
             </div>
-            <div class="w-full">
-                <a href="/delete/?plan={{ plan.name }}" class="hide-link-underline">
+            {# Render the plan duplicate button #}
+            <div id="{{ i }}Duplicate" class="small-menu-item">
+                <a href="#NotYetImplemented" class="hide-link-underline">
                     <div class="card selectable-card">
-                        <div class="box-solid">
-                            <div class="card-content center">
-                                <p>Remove</p>
-                            </div>
+                        <div class="box-solid card-content center noborder-left">
+                            <p>Duplicate</p>
                         </div>
                     </div>
                 </a>
             </div>
+            {# Render the plan delete button #}
+            <div id="{{ i }}Remove" class="small-menu-item">
+                <a href="javascript:void(0);" class="hide-link-underline">
+                    <div class="card selectable-card">
+                        <div class="box-solid card-content center noborder-left">
+                            <p>Remove</p>
+                        </div>
+                    </div>
+                </a>
+            </div>
+            {# Render the plan deletion confirmation button #}
+            <div hidden id="{{ i }}Confirm" class="small-menu-item">
+                <a href="/delete/?plan={{ plan.name }}" class="hide-link-underline">
+                    <div class="card">
+                        <div class="box-solid card-content center delete-color noborder-left">
+                            <p >Confirm</p>
+                        </div>
+                    </div>
+                </a>
+            </div>
+            {# Render the plan delete cancel button #}
+            <div hidden id="{{ i }}Cancel" class="small-menu-item">
+                <a href="javascript:void(0);" class="hide-link-underline">
+                    <div class="card selectable-card">
+                        <div class="box-solid card-content center noborder-left">
+                            <p id="{{ plan.name }}Test2">Cancel</p>
+                        </div>
+                    </div>
+                </a>
+            </div>
+            {# Script to make the buttons switch when certain buttons are clicked #}
+            <script type="text/javascript">
+                // Get the relevant elements
+                var dup{{ i }} = document.getElementById("{{ i }}Duplicate");
+                var rem{{ i }} = document.getElementById("{{ i }}Remove");
+                var can{{ i }} = document.getElementById("{{ i }}Cancel");
+                var con{{ i }} = document.getElementById("{{ i }}Confirm");
+
+                // Create a function to switch the confirm, delete, duplicate, and cancel buttons
+                fn{{ i }} = function() {
+                    rem{{ i }}.hidden = !rem{{ i }}.hidden;
+                    dup{{ i }}.hidden = !dup{{ i }}.hidden;
+                    can{{ i }}.hidden = !can{{ i }}.hidden;
+                    con{{ i }}.hidden = !con{{ i }}.hidden;
+                }
+                rem{{ i }}.onclick = fn{{ i }};
+                can{{ i }}.onclick = fn{{ i }};
+            </script>
         </div>
-        {% endif %}
+        {% endwith %}{% endif %}
     {% endfor %}
     </div>
 

--- a/cassdegrees/ui/urls.py
+++ b/cassdegrees/ui/urls.py
@@ -30,6 +30,7 @@ urlpatterns = [
     path('', student_index),
     path('create/', student_create),
     path('edit/', student_edit),
+    path('delete/', student_delete),
 
     path('admin/home/', index),
     path('admin/sampleform/', sampleform),

--- a/cassdegrees/ui/views/student.py
+++ b/cassdegrees/ui/views/student.py
@@ -93,7 +93,7 @@ def student_create(request):
     if id_to_view:
         # Create a new cookie in the default plan location containing compressed relevant plan details
         request.session['plan:'] = compress(
-            {'program_id': int(id_to_view), 'date': timezone.now().strftime('%d/%m/%Y')}
+            {'program_id': int(id_to_view), 'date': timezone.localtime().strftime('%d/%m/%Y %H:%M')}
         )
 
         # Redirect to the student edit page and add the '?plan=' url parameter
@@ -145,7 +145,7 @@ def student_edit(request):
             else:
                 new_plan = {key: request.POST[key] for key in request.POST.keys()
                             if key != 'csrfmiddlewaretoken' and key != 'plan_name'}
-                new_plan['date'] = timezone.now().strftime('%d/%m/%Y')
+                new_plan['date'] = timezone.localtime().strftime('%d/%m/%Y %H:%M')
                 request.session['plan:' + new_plan_name] = compress(new_plan)
 
                 try:
@@ -156,7 +156,7 @@ def student_edit(request):
         else:
             new_plan = {key: request.POST[key] for key in request.POST.keys()
                         if key != 'csrfmiddlewaretoken' and key != 'plan_name'}
-            new_plan['date'] = timezone.now().strftime('%d/%m/%Y')
+            new_plan['date'] = timezone.localtime().strftime('%d/%m/%Y %H:%M')
             request.session['plan:' + new_plan_name] = compress(new_plan)
         request.session['message'] = 'Successfully saved'
         return redirect('/edit/?plan=' + new_plan_name)

--- a/cassdegrees/ui/views/student.py
+++ b/cassdegrees/ui/views/student.py
@@ -1,29 +1,171 @@
 from api.models import ProgramModel
 from django.forms import model_to_dict
 from django.http import HttpResponseNotFound
-from django.shortcuts import render
+from django.shortcuts import render, redirect
+from django.utils import timezone
+
+import zlib
+import base64
+import json
+
+
+def compress(dct):
+    """ Takes a dictionary and returns a base64 encoding of the contained data
+
+    :param dct: The dictionary to compress
+    :return <str>:
+    """
+    return base64.b64encode(zlib.compress(bytes(json.dumps(dct), 'utf-8'), 9)).decode('utf-8')
+
+
+def decompress(string):
+    """ Takes a base64 string and returns a dict of the contained data
+
+    :param string: The base64 encoding of the compressed dictionary
+    :return <dict>:
+    """
+    return json.loads(zlib.decompress(base64.b64decode(string)))
+
+
+def load_messages(cookies):
+    """ Takes a dict of cookies and reads regular and error messages from them, deleting them from the original dict
+
+    :param cookies: The dictionary to read the cookies from
+    :return dict: A dictionary containing both messages that can be fed in to the render settings
+    """
+
+    render_settings = {}
+    error = cookies.get('error_message', None)
+    if error:
+        render_settings['error'] = error
+        try:
+            del cookies['error_message']
+        except KeyError:
+            pass
+    message = cookies.get('message', None)
+    if message:
+        render_settings['msg'] = message
+        try:
+            del cookies['message']
+        except KeyError:
+            pass
+
+    return render_settings
 
 
 # Static page for student landing
 def student_index(request):
+    # Load up the error and regular messages to render in the plan
+    render_settings = load_messages(request.session)
 
-    return render(request, 'student_index.html', context={})
+    # Generate a list of name-date tuples for all plans saved in the cookies
+    plans = [
+        {'name':plan[5:], 'date': decompress(val)['date']}
+        for plan, val in request.session.items() if plan[:5] == "plan:"
+    ]
+
+    return render(request, 'student_index.html', context={'plans': plans, 'render': render_settings})
+
+
+# Delete the requested plan
+def student_delete(request):
+    plan_name = request.GET.get('plan', None)
+
+    if plan_name is not None:
+        try:
+            del request.session['plan:'+plan_name]
+        except KeyError:
+            pass
+
+    return redirect(student_index)
 
 
 # Creation page. Also sends program metadata.
 def student_create(request):
+    id_to_view = request.GET.get('id', None)
 
-    return render(request, 'student_create.html', context={'programs': ProgramModel.objects.filter(publish=True)})
+    # Create a plan if an ID is specified
+    if id_to_view:
+        # Create a new cookie in the default plan location containing compressed relevant plan details
+        request.session['plan:'] = compress(
+            {'program_id': int(id_to_view), 'date': timezone.now().strftime('%d/%m/%Y')}
+        )
+
+        # Redirect to the student edit page and add the '?plan=' url parameter
+        response = redirect(student_edit)
+        response['Location'] += '?plan='
+        return response
+    # Render the creation homepage if an ID is not specified
+    else:
+        return render(request, 'student_create.html', context={'programs': ProgramModel.objects.filter(publish=True)})
 
 
 # Main edit page. Sends program metadata for specific course chosen.
 def student_edit(request):
-    id_to_view = request.GET.get('id', None)
+    plan_name = request.GET.get('plan', None)
 
-    if not id:
-        return HttpResponseNotFound("Specified ID not found")
+    # Load up the error and regular messages to render in the plan
+    render_settings = load_messages(request.session)
 
-    instance = model_to_dict(ProgramModel.objects.get(id=int(id_to_view)))
+    # If no plan name is specified, redirect them to the plan creation page
+    if plan_name is None:
+        request.session['error_message'] = 'No plan name given'
+        return redirect(student_index)
+    # If the user submits a POST request
+    if request.method == "POST":
+        new_plan_name = request.POST.get('plan_name', None)
 
-    return render(request, 'student_edit.html', context={'program': instance,
-                                                         'superuser': request.user.is_authenticated})
+        # If the plan name changed, delete the old one and create the new one
+        if new_plan_name != plan_name:
+            plans = [plan[5:] for plan in request.session.keys() if plan[:5] == "plan:"]
+            if new_plan_name in plans:
+                new_plan = {key: request.POST[key] for key in request.POST.keys()
+                            if key != 'csrfmiddlewaretoken' and key != 'plan_name'
+                }
+                render_settings['error'] = 'A plan already exists with that name. Please choose a different name.'
+                return render(request, 'student_edit.html', context={'plan': new_plan,
+                                                                     'program': {},
+                                                                     'render': render_settings,
+                                                                     'superuser': request.user.is_authenticated})
+            else:
+                new_plan = {key: request.POST[key] for key in request.POST.keys()
+                            if key != 'csrfmiddlewaretoken' and key != 'plan_name'
+                }
+                new_plan['date'] = timezone.now().strftime('%d/%m/%Y')
+                request.session['plan:'+new_plan_name] = compress(new_plan)
+
+                try:
+                    del request.session['plan:' + plan_name]
+                except KeyError:
+                    pass
+        # If the plan name stayed the same, update the old plan
+        else:
+            new_plan = {key: request.POST[key] for key in request.POST.keys()
+                        if key != 'csrfmiddlewaretoken' and key != 'plan_name'
+            }
+            new_plan['date'] = timezone.now().strftime('%d/%m/%Y')
+            request.session['plan:' + new_plan_name] = compress(new_plan)
+        request.session['message'] = 'Successfully saved'
+        return redirect('/edit/?plan='+new_plan_name)
+    # If the user submits a get request
+    else:
+        # Decompress and read the plan from the cookies
+        compressed_plan = request.session.get("plan:"+plan_name, '')
+        if compressed_plan:
+            plan = decompress(compressed_plan)
+            plan['name'] = plan_name
+
+            # Get the program that was specified in the plan
+            try:
+                instance = model_to_dict(ProgramModel.objects.get(id=plan['program_id']))
+            except ProgramModel.DoesNotExist:
+                render_settings['error'] = 'This program plan is not valid. Please create a new Program Plan'
+                instance = {}
+
+            return render(request, 'student_edit.html', context={'plan': plan,
+                                                                 'program': instance,
+                                                                 'render': render_settings,
+                                                                 'superuser': request.user.is_authenticated})
+        else:
+            request.session['error_message'] = 'Invalid plan name given'
+            return redirect(student_index)

--- a/cassdegrees/ui/views/student.py
+++ b/cassdegrees/ui/views/student.py
@@ -65,7 +65,7 @@ def student_index(request):
             plan = decompress(val)
             try:
                 instance = model_to_dict(ProgramModel.objects.get(id=plan['program_id']))
-                plans.append({'name':plan_name[5:], 'date': plan['date'], 'program': instance['name']})
+                plans.append({'name': plan_name[5:], 'date': plan['date'], 'program': instance['name']})
             except ProgramModel.DoesNotExist:
                 continue
 
@@ -78,7 +78,7 @@ def student_delete(request):
 
     if plan_name is not None:
         try:
-            del request.session['plan:'+plan_name]
+            del request.session['plan:' + plan_name]
         except KeyError:
             pass
 
@@ -125,8 +125,7 @@ def student_edit(request):
             plans = [plan[5:] for plan in request.session.keys() if plan[:5] == "plan:"]
             if new_plan_name in plans:
                 new_plan = {key: request.POST[key] for key in request.POST.keys()
-                            if key != 'csrfmiddlewaretoken' and key != 'plan_name'
-                }
+                            if key != 'csrfmiddlewaretoken' and key != 'plan_name'}
                 render_settings['error'] = 'A plan already exists with that name. Please choose a different name.'
                 return render(request, 'student_edit.html', context={'plan': new_plan,
                                                                      'program': {},
@@ -134,10 +133,9 @@ def student_edit(request):
                                                                      'superuser': request.user.is_authenticated})
             else:
                 new_plan = {key: request.POST[key] for key in request.POST.keys()
-                            if key != 'csrfmiddlewaretoken' and key != 'plan_name'
-                }
+                            if key != 'csrfmiddlewaretoken' and key != 'plan_name'}
                 new_plan['date'] = timezone.now().strftime('%d/%m/%Y')
-                request.session['plan:'+new_plan_name] = compress(new_plan)
+                request.session['plan:' + new_plan_name] = compress(new_plan)
 
                 try:
                     del request.session['plan:' + plan_name]
@@ -146,16 +144,15 @@ def student_edit(request):
         # If the plan name stayed the same, update the old plan
         else:
             new_plan = {key: request.POST[key] for key in request.POST.keys()
-                        if key != 'csrfmiddlewaretoken' and key != 'plan_name'
-            }
+                        if key != 'csrfmiddlewaretoken' and key != 'plan_name'}
             new_plan['date'] = timezone.now().strftime('%d/%m/%Y')
             request.session['plan:' + new_plan_name] = compress(new_plan)
         request.session['message'] = 'Successfully saved'
-        return redirect('/edit/?plan='+new_plan_name)
+        return redirect('/edit/?plan=' + new_plan_name)
     # If the user submits a get request
     else:
         # Decompress and read the plan from the cookies
-        compressed_plan = request.session.get("plan:"+plan_name, '')
+        compressed_plan = request.session.get("plan:" + plan_name, '')
         if compressed_plan:
             plan = decompress(compressed_plan)
             plan['name'] = plan_name

--- a/cassdegrees/ui/views/student.py
+++ b/cassdegrees/ui/views/student.py
@@ -58,11 +58,16 @@ def student_index(request):
     # Load up the error and regular messages to render in the plan
     render_settings = load_messages(request.session)
 
-    # Generate a list of name-date tuples for all plans saved in the cookies
-    plans = [
-        {'name':plan[5:], 'date': decompress(val)['date']}
-        for plan, val in request.session.items() if plan[:5] == "plan:"
-    ]
+    # Generate a dict containing the plan name, date, and program name for all plans saved in the cookies
+    plans = []
+    for plan_name, val in request.session.items():
+        if plan_name[:5] == "plan:":
+            plan = decompress(val)
+            try:
+                instance = model_to_dict(ProgramModel.objects.get(id=plan['program_id']))
+                plans.append({'name':plan_name[5:], 'date': plan['date'], 'program': instance['name']})
+            except ProgramModel.DoesNotExist:
+                continue
 
     return render(request, 'student_index.html', context={'plans': plans, 'render': render_settings})
 


### PR DESCRIPTION
This PR implements Issues #202, #183, #187, and #184. The primary new feature is plan saving and loading using the main menu system. This change also modifies the `student_edit.html` file by using a form and submit button rather than a link. 

The saving and loading uses `zlib` compression library, as it was experimentally found to give the best compression results for longer json strings. `bz2` and `lzma` were also tested.

**Adding New Plan Elements**
To add new details to the plan, one only needs to add an input element as with the following attributes inside the `form` element:
- `name="[Field Name]"`: The name that should be used to refer to the object
- `value="{{ plan.[Field Name] }}"`: Using that object to load existing plans

After doing this, the plan should automatically take the value inputted by the user when saving, and restore it when loading

![Screen Shot 2019-08-21 at 10 47 08 pm](https://user-images.githubusercontent.com/36946090/63433041-bb9ed380-c465-11e9-9939-440dd48ab27f.jpg)
