### PR TITLE
Make Bulk Upload Compatible with CASS' .xlsx Format

### DIFF
--- a/cassdegrees/cassdegrees/settings.py
+++ b/cassdegrees/cassdegrees/settings.py
@@ -140,3 +140,5 @@ STATICFILES_DIRS = [
 
 LOGIN_REDIRECT_URL = '/'
 
+# Default value of 1000 restricted the ability to delete courses en masse.
+DATA_UPLOAD_MAX_NUMBER_FIELDS = 2147483647

--- a/cassdegrees/ui/views/bulk_data_upload.py
+++ b/cassdegrees/ui/views/bulk_data_upload.py
@@ -90,15 +90,17 @@ def bulk_data_upload(request):
                     # where the file reader determines the year ranges and column positions.
                     if not year_range_found or not columns_set:
                         for cell in row:
-                            # Split the string in the first line of the excel sheet to get start and end year
+                            # Split the string in the first line of the excel sheet to get start and end years.
                             if not year_range_found:
                                 if cell.value is not None:
                                     stripped_title = cell.value.split()
 
-                                    start_year = int(stripped_title[-3])
-                                    end_year = int(stripped_title[-1])
+                                    # Only extract years if we found the right cell
+                                    if " ".join(stripped_title[0:5]) == "CASS 3 Year Teaching Plan:":
+                                        start_year = int(stripped_title[-3])
+                                        end_year = int(stripped_title[-1])
 
-                                    year_range_found = True
+                                        year_range_found = True
 
                             # Once the year range is set, then determine the column positions of the excel sheet.
                             elif not columns_set:
@@ -110,6 +112,12 @@ def bulk_data_upload(request):
                                 # If every column has been indexed, then mark columns_set as true.
                                 if col_counter + 1 == len(row):
                                     columns_set = True
+
+                        # If years are not determined in the first row, the excel file is not in the desirable format.
+                        if not year_range_found:
+                            any_error = True
+                            failed_to_upload.append("Unknown File Format")
+                            break
 
                     # Once the year range and the column positions are set,
                     # check the offerings specified in the 'Semester' column and process accordingly.

--- a/cassdegrees/ui/views/bulk_data_upload.py
+++ b/cassdegrees/ui/views/bulk_data_upload.py
@@ -20,10 +20,10 @@ from django.shortcuts import render
 # ARTI-SPEC%2016%Artificial Intelligence%24%SPEC
 # ...
 
-# 20/08/19 changes: Support added for excel sheets in the same rules as above (no % needed, but put each word between
-# the % sign in a new cell in that row.
+# Support is available for excel sheets in the same rules as above (no % needed, but put each word between
+# the % sign in a new cell in that row).
 
-# 21/08/19 changes: Support added for CASS teaching plan excel file.
+# Support is available for CASS' custom teaching plan excel file.
 
 
 @login_required

--- a/cassdegrees/ui/views/bulk_data_upload.py
+++ b/cassdegrees/ui/views/bulk_data_upload.py
@@ -1,5 +1,6 @@
 import csv
 from io import TextIOWrapper
+import pandas as pd
 
 from api.models import CourseModel, SubplanModel
 from django.contrib.auth.decorators import login_required
@@ -35,12 +36,7 @@ def bulk_data_upload(request):
         # Open file in text mode:
         # https://stackoverflow.com/questions/16243023/how-to-resolve-iterator-should-return-strings-not-bytes
         uploaded_file = TextIOWrapper(request.FILES['uploaded_file'], encoding=request.encoding)
-
-        # Reading the '%' using the csv import module came from:
-        # https://stackoverflow.com/questions/13992971/reading-and-parsing-a-tsv-file-then-manipulating-it-for-saving-as-csv-efficie
-
-        # % is used instead of comma since the course name may include commas (which would break this function)
-        uploaded_file = csv.reader(uploaded_file, delimiter='%')
+        print(uploaded_file.name[-4:])
 
         # First row contains the column type headings (code, name etc). We can't add them to the db.
         first_row_checked = False
@@ -51,6 +47,17 @@ def bulk_data_upload(request):
         any_success = False
         failed_to_upload = []
         correctly_uploaded = []
+
+        if uploaded_file.name[-4] == "xlsx":
+            # https://stackoverflow.com/questions/16888888/how-to-read-a-xlsx-file-using-the-pandas-library-in-ipython
+            uploaded_file = pd.read_excel(uploaded_file.name, sheet_name=None)
+            print(uploaded_file)
+        else:
+            # Reading the '%' using the csv import module came from:
+            # https://stackoverflow.com/questions/13992971/reading-and-parsing-a-tsv-file-then-manipulating-it-for-saving-as-csv-efficie
+
+            # % is used instead of comma since the course name may include commas (which would break this function)
+            uploaded_file = csv.reader(uploaded_file, delimiter='%')
 
         # Stores the index of the column containing the data type of each row,
         # so that the right data is stored in the right column

--- a/cassdegrees/ui/views/bulk_data_upload.py
+++ b/cassdegrees/ui/views/bulk_data_upload.py
@@ -78,6 +78,7 @@ def bulk_data_upload(request):
                 start_year = int()
                 end_year = int()
 
+                # Add columns that are matching the custom format designed in this script, detailed in line 10 - 26.
                 uploaded_file.append(["code", "year", "name", "units", "offeredSem1", "offeredSem2"])
                 for row in sheet.iter_rows():
 
@@ -85,8 +86,11 @@ def bulk_data_upload(request):
                     if columns_set:
                         sem_offer_value = row[col_index["Semesters"]].value
 
+                    # This is the initialisation phase,
+                    # where the file reader determines the year ranges and column positions.
                     if not year_range_found or not columns_set:
                         for cell in row:
+                            # Split the string in the first line of the excel sheet to get start and end year
                             if not year_range_found:
                                 if cell.value is not None:
                                     stripped_title = cell.value.split()
@@ -96,6 +100,7 @@ def bulk_data_upload(request):
 
                                     year_range_found = True
 
+                            # Once the year range is set, then determine the column positions of the excel sheet.
                             elif not columns_set:
                                 if cell.value is not None:
                                     # Find and store the index of all the column positions
@@ -106,16 +111,20 @@ def bulk_data_upload(request):
                                 if col_counter + 1 == len(row):
                                     columns_set = True
 
+                    # Once the year range and the column positions are set,
+                    # check the offerings specified in the 'Semester' column and process accordingly.
                     else:
+                        # Right now, courses with offering type 'other' and 'sessions' are not supported,
+                        # so add them to the list of 'failed' courses and move on to the next course.
                         if sem_offer_value == "Other" or sem_offer_value == "Offered only in sessions":
                             skipped_course = "{} - {} - Unknown/Unsupported course offering".format(
                                 row[col_index["Course Code"]].value,
                                 row[col_index["Course Title"]].value)
 
                             failed_to_upload.append(skipped_course)
-                            # failed_to_upload.append(row[col_index["Course Code"]].value)
                             any_error = True
                             continue
+
                         sem_offer_args = sem_offer_value.split()
 
                         for year in range(start_year, end_year + 1):
@@ -130,6 +139,7 @@ def bulk_data_upload(request):
                                 if year % 2 == 0:
                                     continue
 
+                            # Set the boolean values to true if the semester offerings say they are offered.
                             if sem_offer_args[-1] == "Semester" or \
                                     ("S1" in sem_offer_value and "S2" in sem_offer_value):
                                 s1_offer = True

--- a/cassdegrees/ui/views/bulk_data_upload.py
+++ b/cassdegrees/ui/views/bulk_data_upload.py
@@ -48,10 +48,10 @@ def bulk_data_upload(request):
         failed_to_upload = []
         correctly_uploaded = []
 
-        if uploaded_file.name[-4] == "xlsx":
+        if uploaded_file.name[-4:] == "xlsx":
             # https://stackoverflow.com/questions/16888888/how-to-read-a-xlsx-file-using-the-pandas-library-in-ipython
-            uploaded_file = pd.read_excel(uploaded_file.name, sheet_name=None)
-            print(uploaded_file)
+            uploaded_file = pd.read_excel(uploaded_file.name)
+            print(uploaded_file.columns)
         else:
             # Reading the '%' using the csv import module came from:
             # https://stackoverflow.com/questions/13992971/reading-and-parsing-a-tsv-file-then-manipulating-it-for-saving-as-csv-efficie

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ flake8==3.7.7
 psycopg2==2.7.7
 requests==2.21.0
 django-weasyprint==0.5.4
-pandas==0.25.0
-xlrd==1.2.0
+openpyxl==2.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ psycopg2==2.7.7
 requests==2.21.0
 django-weasyprint==0.5.4
 pandas==0.25.0
+xlrd==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ flake8==3.7.7
 psycopg2==2.7.7
 requests==2.21.0
 django-weasyprint==0.5.4
+pandas==0.25.0


### PR DESCRIPTION
Original Issue: https://github.com/cass-degrees/CASS-Degrees-Code/issues/217

Added support for Excel sheets, either in the custom format that the bulk uploader could already support, or in the format CASS uses.

To test this branch out, try the following file: https://drive.google.com/open?id=1EdQHhrNSd2QhO4c2A_su3x3K7hHQKQoI

Note that not all will be successfully added, but most will be.