### PR TITLE
Enable the rendering of student plans as PDFs

### DIFF
--- a/cassdegrees/static/css/style.css
+++ b/cassdegrees/static/css/style.css
@@ -349,3 +349,8 @@ select.text{
     position: sticky;
     top: 10px;
 }
+
+/* Automatically handle overflowing text */
+.auto-overflow {
+    overflow: auto;
+}

--- a/cassdegrees/static/js/student_edit.js
+++ b/cassdegrees/static/js/student_edit.js
@@ -27,6 +27,11 @@ function prepareSubmit(action) {
     document.getElementById("plan-courses").value = JSON.stringify(course_codes);
     document.getElementById("action_to_perform").value = action;
 
+    if (action === "pdf") {
+        // Ensure that the PDF opens in a new page
+        document.getElementById("main-form").setAttribute("target", "_blank");
+    }
+
     document.getElementById("main-form").submit();
 }
 

--- a/cassdegrees/templates/pdf_base.html
+++ b/cassdegrees/templates/pdf_base.html
@@ -47,7 +47,7 @@
         }
 
         .break-column {
-            break-after: right;
+            break-after: page;
         }
 
         .no-bottom-margin {

--- a/cassdegrees/templates/pdf_program.html
+++ b/cassdegrees/templates/pdf_program.html
@@ -9,7 +9,11 @@
         <br />
     </div>
 
-    <h1 class="no-bottom-margin">{{ program.name }} ({{ program.year }}, {{ program.units }} units)</h1>
+    {% if plan != None %}
+        <h1 class="no-bottom-margin">{{ plan.name }} ({{ program.name }}, {{ program.year }}, {{ program.units }} units)</h1>
+    {% else %}
+        <h1 class="no-bottom-margin">{{ program.name }} ({{ program.year }}, {{ program.units }} units)</h1>
+    {% endif %}
 
     <br />
 

--- a/cassdegrees/templates/student_edit.html
+++ b/cassdegrees/templates/student_edit.html
@@ -22,7 +22,7 @@
 
     {# program is the full program object as selected by the user, superuser is if an authenticated #}
     {# user is logged in #}
-    <form action="" id="main-form" method="post" class="box bdr-solid bdr-uni">
+    <form action="" id="main-form" method="post" class="box bdr-solid bdr-uni auto-overflow">
         {% csrf_token %}
 
         <input type="hidden" id="plan-courses" name="plan_courses" value="{{ plan.plan_courses }}" />

--- a/cassdegrees/templates/student_edit.html
+++ b/cassdegrees/templates/student_edit.html
@@ -37,6 +37,7 @@
 
         <div class="float-right">
             <input type="button" onclick="prepareSubmit('save')" class="btn-uni-grad btn-small" value="Save...">
+            <input type="button" onclick="prepareSubmit('pdf')" class="btn-uni-grad btn-small" value="Save as PDF...">
             <input type="button" onclick="prepareSubmit('export')" class="btn-uni-grad btn-small" value="Export...">
             {% if superuser %}
                 <input type="button" onclick="prepareSubmit('approve')" class="btn-uni-grad btn-small" value="Save & Approve...">

--- a/cassdegrees/templates/widgets/pdf_rules.html
+++ b/cassdegrees/templates/widgets/pdf_rules.html
@@ -1,8 +1,8 @@
-{% load student_course_boxes %}
+{% load course_boxes %}
 {% load math %}
 
-{# Renders rule a rule for a student plan #}
-<div class="card">
+{# Renders rule a rule for a PDF program #}
+<div class="box try-complete-box">
     {% if rule.type == "subplan" %}
         <p>Completion of {{ rule.kind }} for {{ rule.units }} units:</p>
     {% elif rule.type == "subject_area" %}
@@ -34,9 +34,9 @@
         <p class="bottom-margin">Either:</p>
 
         {% for group in rule.either_or %}
-            <div class="left-box" style="padding-left: 40px;">
+            <div class="left-box">
                 {% for rule in group %}
-                    {% include "widgets/student_rules.html" %}
+                    {% include "widgets/pdf_rules.html" %}
                 {% endfor %}
             </div>
 
@@ -50,31 +50,32 @@
     {% endif %}
 </div>
 
-<div style="padding-left: 20px;">
-    {% if rule.type == "subplan" %}
-        {# Assume all subplans have equal units - else it wouldn't make sense for a complete program #}
-        {% with subplan=subplans|index:rule.ids.0 %}
-            {% student_course_box subplan.units %}
+
+{% if rule.type == "subplan" %}
+    {# Assume all subplans have equal units - else it wouldn't make sense for a complete program #}
+    {% with subplan=subplans|index:rule.ids.0 %}
+        {% course_box subplan.units plan %}
+    {% endwith %}
+{% elif rule.type == "subject_area" %}
+    {% course_box rule.unit_count plan %}
+{% elif rule.type == "year_level" %}
+    {% course_box rule.unit_count plan %}
+{% elif rule.type == "course" %}
+    {% with courses_provided=rule.codes|length %}
+        {% with courses_needed=rule.unit_count|divide:6 %}
+            {% if courses_provided == courses_needed %}
+                {# All courses specified are required - render all #}
+                {% course_box_with_values rule.unit_count rule.codes plan %}
+            {% else %}
+                {# Not all required courses - map them out as blanks #}
+                {% course_box rule.unit_count plan %}
+            {% endif %}
         {% endwith %}
-    {% elif rule.type == "subject_area" %}
-        {% student_course_box rule.unit_count %}
-    {% elif rule.type == "year_level" %}
-        {% student_course_box rule.unit_count %}
-    {% elif rule.type == "course" %}
-        {% with courses_provided=rule.codes|length %}
-            {% with courses_needed=rule.unit_count|divide:6 %}
-                {% if courses_provided == courses_needed %}
-                    {# All courses specified are required - render all #}
-                    {% student_course_box_with_values rule.unit_count rule.codes %}
-                {% else %}
-                    {# Not all required courses - map them out as blanks #}
-                    {% student_course_box rule.unit_count %}
-                {% endif %}
-            {% endwith %}
-        {% endwith %}
-    {% elif rule.type == "custom_text" %}
-        {% if rule.show_course_boxes %}
-            {% student_course_box rule.units %}
-        {% endif %}
+    {% endwith %}
+{% elif rule.type == "custom_text" %}
+    {% if rule.show_course_boxes %}
+        {% course_box rule.units plan %}
     {% endif %}
-</div>
+{% endif %}
+
+{% if forloop.last %}<div class="break-box"></div>{% endif %}

--- a/cassdegrees/ui/templatetags/course_boxes.py
+++ b/cassdegrees/ui/templatetags/course_boxes.py
@@ -5,23 +5,46 @@ register = template.Library()
 
 
 @register.simple_tag(takes_context=True)
-def course_box(context, count):
+def course_box(context, count, plan):
     output = ""
     iters = int(int(count) / 6)
 
     for i in range(iters):
-        output += "<div class=\"box grey-text grey-box\">Course #" + str(i + 1) + ":</div>"
+        if plan:
+            course_name = plan['plan_courses'].pop(0)
+        else:
+            course_name = None
+
+        # Noting that pop() might also return None if a user hasn't selected a course yet:
+        if course_name:
+            output += "<div class=\"box grey-box\"><span class=\"grey-text\">Course #" + str(i + 1) + ":</span> " \
+                      + course_name + "</div>"
+        else:
+            output += "<div class=\"box grey-text grey-box\">Course #" + str(i + 1) + ":</div>"
 
     return Template(output).render(context)
 
 
 @register.simple_tag(takes_context=True)
-def course_box_with_values(context, count, courses):
+def course_box_with_values(context, count, courses, plan):
     output = ""
     iters = int(int(count) / 6)
 
     for i in range(iters):
+        if plan:
+            course_name = plan['plan_courses'].pop(0)
+        else:
+            course_name = None
+
+        if course_name is None:
+            course_name = courses[i]
+
         output += "<div class=\"box grey-box\"><span class=\"grey-text\">Course #" + str(i + 1) + ":</span> " \
-                  + courses[i] + "</div>"
+                  + course_name + "</div>"
 
     return Template(output).render(context)
+
+# https://stackoverflow.com/questions/4651172/reference-list-item-by-index-within-django-template/29664945#29664945
+@register.filter
+def index(List, i):
+    return List.filter(id=int(i))[0]

--- a/cassdegrees/ui/urls.py
+++ b/cassdegrees/ui/urls.py
@@ -32,6 +32,7 @@ urlpatterns = [
     path('', student_index),
     path('create/', student_create),
     path('edit/', student_edit),
+    path('pdf/', student_pdf),
     path('delete/', student_delete),
 
     path(staff_url_prefix, index),

--- a/cassdegrees/ui/views/pdf.py
+++ b/cassdegrees/ui/views/pdf.py
@@ -1,4 +1,4 @@
-from api.models import ProgramModel
+from api.models import ProgramModel, SubplanModel
 from django.shortcuts import render
 
 from django_weasyprint import WeasyTemplateResponse
@@ -18,8 +18,11 @@ def view_program_pdf(request):
     pretty_print_reqs(instance)
     pretty_print_rules(instance)
 
+    subplans = SubplanModel.objects.all()
+
     context = {
-        "program": instance
+        "program": instance,
+        'subplans': subplans
     }
 
     if "raw" in request.GET:


### PR DESCRIPTION
Closes #207.

This PR adds a button to the student homepage to render their plan as a PDF. The plan will be saved before the PDF is rendered. The pipeline is a modified one from staff's PDF rendering, with changes to (the render) environment and how course boxes are rendered.

Global requirements aren't validated yet as this is still to be implemented in the frontend. This will likely need to be stored in the main plan object when that is implemented for this to work.

![student-pdf](https://user-images.githubusercontent.com/1404334/63637544-d2fbdd80-c66c-11e9-804a-e21f8360c30d.png)
