### PR TITLE
Fixed "Page not found" error when clicking on subplans in Program viewer

### DIFF
--- a/cassdegrees/templates/viewprogram.html
+++ b/cassdegrees/templates/viewprogram.html
@@ -76,7 +76,7 @@
                         Completion of one subplan from the following list:
                         <ul>
                             {% for id, value in rule.contents.items %}
-                                <li><a class="btn-uni-grad" href="/view/subplan/?id={{ id }}" >{{ value.name }}</a></li>
+                                <li><a class="btn-uni-grad" href="/staff/view/subplan/?id={{ id }}" >{{ value.name }}</a></li>
                             {% endfor %}
                         </ul>
                     </p>


### PR DESCRIPTION
Original issue: #250 

This is a very simple fix so I will leave it for a few hours before merging it in.