### PR TITLE
Specify unit requirement type

### DIFF
--- a/cassdegrees/templates/viewsubplan.html
+++ b/cassdegrees/templates/viewsubplan.html
@@ -64,7 +64,8 @@
                     {% elif rule.list_type == "max" %}
                         No more than
                     {% endif %}
-                    {{ rule.unit_count }} units from completion of the following course(s):</i>
+                    {{ rule.unit_count }} units from completion of the following course(s):
+                </i>
                 <table class="tbl-cell-bdr">
                     <tr><th>Code</th><th>Title</th><th>Units</th></tr>
                         {% for course in rule.courses %}

--- a/cassdegrees/templates/viewsubplan.html
+++ b/cassdegrees/templates/viewsubplan.html
@@ -56,7 +56,15 @@
         {# Displays all of the required courses in a table #}
         {% for rule in data.rules %}
             <p>
-                <i>{{ rule.unit_count }} units from completion of the following course(s):</i>
+                <i>
+                    {% if rule.list_type == "min" %}
+                        At least
+                    {% elif rule.list_type == "exact" %}
+                        Exactly
+                    {% elif rule.list_type == "max" %}
+                        No more than
+                    {% endif %}
+                    {{ rule.unit_count }} units from completion of the following course(s):</i>
                 <table class="tbl-cell-bdr">
                     <tr><th>Code</th><th>Title</th><th>Units</th></tr>
                         {% for course in rule.courses %}


### PR DESCRIPTION
Original issue: #249 

Previously, details such as "at least" did not appear on subplan view page, which made things very confusing. Now, this has been fixed:

![image](https://user-images.githubusercontent.com/37033052/63702279-fd66ba00-c869-11e9-8de7-51bc2166a427.png)
