### PR TITLE
Add ability to remove first course in a rule if >1 course is defined

### DIFF
--- a/cassdegrees/templates/widgets/rulescripts.html
+++ b/cassdegrees/templates/widgets/rulescripts.html
@@ -93,7 +93,7 @@
             <select v-model="details.codes[index]" v-on:change="check_options" required>
                 <option v-for="course in courses" v-bind:value="course.code">{{ course.code }} {{ course.name }}</option>
             </select>
-            <input v-if="index != 0 || details.codes.length > 1" type="button" v-on:click="remove_course(index)" class="btn-uni-grad btn-snall no-left-margin" value="Remove" />
+            <input v-if="details.codes.length > 1" type="button" v-on:click="remove_course(index)" class="btn-uni-grad btn-snall no-left-margin" value="Remove" />
         </div>
 
         <input type="button" v-on:click="add_course()" class="btn-uni-grad btn-snall no-left-margin" value="Add new option" />

--- a/cassdegrees/templates/widgets/rulescripts.html
+++ b/cassdegrees/templates/widgets/rulescripts.html
@@ -113,7 +113,7 @@
             <select v-model="details.codes[index]" v-on:change="check_options" required>
                 <option v-for="course in courses" v-bind:value="course.code">{{ course.code }} {{ course.name }}</option>
             </select>
-            <input v-if="index != 0" type="button" v-on:click="remove_course(index)" class="btn-uni-grad btn-snall no-left-margin" value="Remove" />
+            <input v-if="details.codes.length > 1" type="button" v-on:click="remove_course(index)" class="btn-uni-grad btn-snall no-left-margin" value="Remove" />
         </div>
 
         <input type="button" v-on:click="add_course()" class="btn-uni-grad btn-snall no-left-margin" value="Add new option" />

--- a/cassdegrees/templates/widgets/rulescripts.html
+++ b/cassdegrees/templates/widgets/rulescripts.html
@@ -93,7 +93,7 @@
             <select v-model="details.codes[index]" v-on:change="check_options" required>
                 <option v-for="course in courses" v-bind:value="course.code">{{ course.code }} {{ course.name }}</option>
             </select>
-            <input v-if="index != 0" type="button" v-on:click="remove_course(index)" class="btn-uni-grad btn-snall no-left-margin" value="Remove" />
+            <input v-if="index != 0 || details.codes.length > 1" type="button" v-on:click="remove_course(index)" class="btn-uni-grad btn-snall no-left-margin" value="Remove" />
         </div>
 
         <input type="button" v-on:click="add_course()" class="btn-uni-grad btn-snall no-left-margin" value="Add new option" />


### PR DESCRIPTION
Closes #264.

This PR is a simple fix to allow for the first course in a course selection to be removed if there is more than one course in that list.

Screenshots:

![fixed-courses-1](https://user-images.githubusercontent.com/1404334/63762681-c668c680-c8b2-11e9-978d-dba42f60fce7.png)
![fixed-courses-2](https://user-images.githubusercontent.com/1404334/63762685-c799f380-c8b2-11e9-95ae-b1ad3f8bf27c.png)
