### PR TITLE
Limit deletion page message size to 5 items

### DIFF
--- a/cassdegrees/templates/deletecourses.html
+++ b/cassdegrees/templates/deletecourses.html
@@ -18,9 +18,13 @@
 
         <fieldset>
             <p>Are you sure you want to delete:</p>
-            {% for instance in instances %}
+            {% for instance in display_instances %}
                 <p class="marginleft">
-                    {{ instance.name }} ({{ instance.code }}) in {{ instance.year }}
+                    {% if instance.name == None %}
+                        {{ instance }}
+                    {% else %}
+                        {{ instance.name }} ({{ instance.code }}) in {{ instance.year }}
+                    {% endif %}
                 </p>
                 <input type="number" hidden value="{{ instance.id }}" name="id" />
             {% endfor %}

--- a/cassdegrees/templates/deletecourses.html
+++ b/cassdegrees/templates/deletecourses.html
@@ -13,12 +13,11 @@
 {% block subtitle %}Are You Sure?{% endblock %}
 
 {% block content %}
-    <form % class="anuform" action="" method="post">
+    <form class="anuform" action="" method="post">
         {% csrf_token %}
 
         <fieldset>
             <p>Are you sure you want to delete:</p>
-
             {% for instance in instances %}
                 <p class="marginleft">
                     {{ instance.name }} ({{ instance.code }}) in {{ instance.year }}

--- a/cassdegrees/templates/deleteprograms.html
+++ b/cassdegrees/templates/deleteprograms.html
@@ -18,9 +18,13 @@
 
         <fieldset>
             <p>Are you sure you want to delete:</p>
-            {% for instance in instances %}
+            {% for instance in display_instances %}
                 <p>
-                    {{ instance.name }} ({{ instance.code }}) in {{ instance.year }}
+                    {% if instance.name == None %}
+                        {{ instance }}
+                    {% else %}
+                        {{ instance.name }} ({{ instance.code }}) in {{ instance.year }}
+                    {% endif %}
                 </p>
                 <input type="number" hidden value="{{ instance.id }}" name="id" />
             {% endfor %}

--- a/cassdegrees/templates/deletesubplans.html
+++ b/cassdegrees/templates/deletesubplans.html
@@ -18,9 +18,13 @@
 
         <fieldset>
             <p>Are you sure you want to delete:</p>
-            {% for instance in instances %}
+            {% for instance in display_instances %}
                 <p>
-                    {{ instance.name }} ({{ instance.code }}) in {{ instance.year }}
+                    {% if instance.name == None %}
+                        {{ instance }}
+                    {% else %}
+                        {{ instance.name }} ({{ instance.code }}) in {{ instance.year }}
+                    {% endif %}
                 </p>
                 <input type="number" hidden value="{{ instance.id }}" name="id" />
             {% endfor %}

--- a/cassdegrees/ui/views/courses.py
+++ b/cassdegrees/ui/views/courses.py
@@ -121,7 +121,7 @@ def delete_course(request):
         # Only insert the "... and x more courses" if length is more than show_count.
         if num_instances > show_count:
             if num_instances == show_count + 1:
-                display_instances.append("... and {} more course".format(len(instances) - show_count))
+                display_instances.append("... and 1 more course")
             else:
                 display_instances.append("... and {} more courses".format(len(instances) - show_count))
 

--- a/cassdegrees/ui/views/courses.py
+++ b/cassdegrees/ui/views/courses.py
@@ -114,8 +114,20 @@ def delete_course(request):
 
         return redirect(list_course_url + '&msg=Successfully Deleted Course(s)!')
     else:
+        # To avoid the delete confirmation page from being too long, only show the first 5 courses.
+        show_count = 5
+        num_instances = len(instances)
+        display_instances = instances[:show_count]
+        # Only insert the "... and x more courses" if length is more than show_count.
+        if num_instances > show_count:
+            if num_instances == show_count + 1:
+                display_instances.append("... and {} more course".format(len(instances) - show_count))
+            else:
+                display_instances.append("... and {} more courses".format(len(instances) - show_count))
+
         return render(request, 'deletecourses.html', context={
-            "instances": instances
+            "instances": instances,
+            "display_instances": display_instances
         })
 
 

--- a/cassdegrees/ui/views/programs.py
+++ b/cassdegrees/ui/views/programs.py
@@ -93,7 +93,7 @@ def delete_program(request):
         # Only insert the "... and x more programs" if length is more than show_count.
         if num_instances > show_count:
             if num_instances == show_count + 1:
-                display_instances.append("... and {} more program".format(len(instances) - show_count))
+                display_instances.append("... and 1 more program")
             else:
                 display_instances.append("... and {} more programs".format(len(instances) - show_count))
 

--- a/cassdegrees/ui/views/programs.py
+++ b/cassdegrees/ui/views/programs.py
@@ -86,8 +86,20 @@ def delete_program(request):
 
         return redirect(list_program_url + '&msg=Successfully Deleted Program(s)!')
     else:
+        # To avoid the delete confirmation page from being too long, only show the first 5 programs.
+        show_count = 5
+        num_instances = len(instances)
+        display_instances = instances[:show_count]
+        # Only insert the "... and x more programs" if length is more than show_count.
+        if num_instances > show_count:
+            if num_instances == show_count + 1:
+                display_instances.append("... and {} more program".format(len(instances) - show_count))
+            else:
+                display_instances.append("... and {} more programs".format(len(instances) - show_count))
+
         return render(request, 'deleteprograms.html', context={
-            "instances": instances
+            "instances": instances,
+            "display_instances": display_instances
         })
 
 

--- a/cassdegrees/ui/views/subplans.py
+++ b/cassdegrees/ui/views/subplans.py
@@ -122,7 +122,7 @@ def delete_subplan(request):
         # Only insert the "... and x more subplans" if length is more than show_count.
         if num_instances > show_count:
             if num_instances == show_count + 1:
-                display_instances.append("... and {} more subplan".format(len(instances) - show_count))
+                display_instances.append("... and 1 more subplan")
             else:
                 display_instances.append("... and {} more subplans".format(len(instances) - show_count))
 

--- a/cassdegrees/ui/views/subplans.py
+++ b/cassdegrees/ui/views/subplans.py
@@ -115,8 +115,20 @@ def delete_subplan(request):
 
         return redirect(list_subplan_url + '&msg=Successfully Deleted Subplan(s)!')
     else:
+        # To avoid the delete confirmation page from being too long, only show the first 5 subplans.
+        show_count = 5
+        num_instances = len(instances)
+        display_instances = instances[:show_count]
+        # Only insert the "... and x more subplans" if length is more than show_count.
+        if num_instances > show_count:
+            if num_instances == show_count + 1:
+                display_instances.append("... and {} more subplan".format(len(instances) - show_count))
+            else:
+                display_instances.append("... and {} more subplans".format(len(instances) - show_count))
+
         return render(request, 'deletesubplans.html', context={
-            "instances": instances
+            "instances": instances,
+            "display_instances": display_instances
         })
 
 


### PR DESCRIPTION
Original Issue: #277 

The deletion page now only displays at most 5 courses to avoid an incredibly long page like as such:
![image](https://user-images.githubusercontent.com/37033052/63816215-c502d100-c97a-11e9-93b2-cec2e7296b2e.png)
