### PR TITLE
Add meta tag to dictate correct scaling

### DIFF
--- a/cassdegrees/templates/base.html
+++ b/cassdegrees/templates/base.html
@@ -6,6 +6,8 @@
     <meta charset="UTF-8">
     <title>{% block page-title %}No title defined{% endblock %} - CASS Program Planner</title>
 
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
     <!-- Adapted from CASS homepage root -->
     <link href="//style.anu.edu.au/_anu/4/images/logos/anu.ico" rel="shortcut icon" type="image/x-icon"/>
     <link href="//style.anu.edu.au/_anu/images/icons/web/anu-app-57.png" rel="apple-touch-icon" sizes="57x57"/>


### PR DESCRIPTION
This is a quick fix to improve scaling on mobile devices. This has no effect on PC devices.

Screenshot:
![Screenshot (28 Aug  2019 5_48_35 pm)](https://user-images.githubusercontent.com/1404334/63836171-93810a00-c968-11e9-9e78-091b09c68f4c.jpg)
