### PR TITLE
Remove First Item from Subplan Rule in Program Edit and Course Rule in Subplan Edit

### DIFF
--- a/cassdegrees/templates/widgets/rulescripts.html
+++ b/cassdegrees/templates/widgets/rulescripts.html
@@ -14,7 +14,7 @@
             <select v-model="details.incompatible_courses[index]" v-on:change="check_options" required>
                 <option v-for="course in courses" v-bind:value="course.code">{{ course.code }} {{ course.name }}</option>
             </select>
-            <input v-if="index != 0" type="button" v-on:click="remove_course(index)" class="btn-uni-grad btn-snall no-left-margin" value="Remove" />
+            <input v-if="details.incompatible_courses.length > 1" type="button" v-on:click="remove_course(index)" class="btn-uni-grad btn-snall no-left-margin" value="Remove" />
         </div>
 
         <input type="button" v-on:click="add_course()" class="btn-uni-grad btn-snall no-left-margin" value="Add new option" />
@@ -63,7 +63,7 @@
             <select v-model="details.ids[index]" v-on:change="check_options" required>
                 <option v-for="subplan in subplans" v-if="!program_year || subplan.year==program_year" v-bind:value="subplan.id">{{ subplan.name }} {{ subplan.year }} ({{ subplan.units }} units)</option>
             </select>
-            <input v-if="index != 0" type="button" v-on:click="remove_subplan(index)" class="btn-uni-grad btn-snall no-left-margin" value="Remove" />
+            <input v-if="details.ids.length > 1" type="button" v-on:click="remove_subplan(index)" class="btn-uni-grad btn-snall no-left-margin" value="Remove" />
         </div>
 
         <input type="button" v-on:click="add_subplan()" class="btn-uni-grad btn-snall no-left-margin" value="Add new option" />

--- a/cassdegrees/templates/widgets/subplanrules.html
+++ b/cassdegrees/templates/widgets/subplanrules.html
@@ -36,7 +36,7 @@
             <select v-model="details.codes[index]" v-on:change="check_options" required>
                 <option v-for="course in courses" v-bind:value="course.code">{{ course.code }} {{ course.name }}</option>
             </select>
-            <input v-if="index != 0" type="button" v-on:click="remove_course(index)" class="btn-uni-grad btn-snall no-left-margin" value="Remove" />
+            <input v-if="details.codes.length > 1" type="button" v-on:click="remove_course(index)" class="btn-uni-grad btn-snall no-left-margin" value="Remove" />
         </div>
 
         <input type="button" v-on:click="add_course()" class="btn-uni-grad btn-snall no-left-margin" value="Add new option" />


### PR DESCRIPTION
This extends #264 and closes #299.

A few rules did not support the ability to remove the first item from a given list, but this has been added now.

In subplan course rules:
![image](https://user-images.githubusercontent.com/37424867/64120366-5b058400-cddf-11e9-98c4-9f1ca2d29704.png)

In course incompatibility rules:
![image](https://user-images.githubusercontent.com/37424867/64120401-72447180-cddf-11e9-8261-243c44b8c435.png)

In program subplan rules:
![image](https://user-images.githubusercontent.com/37424867/64120443-8e481300-cddf-11e9-899a-77a018c467ef.png)
