### PR TITLE
General Elective Rule

### DIFF
--- a/cassdegrees/static/js/rules.js
+++ b/cassdegrees/static/js/rules.js
@@ -20,8 +20,6 @@ const ALL_COMPONENT_HELP = {
     'subplan': "A rule which gives students a choice from a particular set of majors, minors, specialisations or " +
                "other subplans. The description here is used to describe the rule when displaying this rule to " +
                "students.",
-    'year_level': 'A rule which specifies that students must complete a number of units from a particular year level.',
-    'subject_area': "A rule which specifies that students must complete a number of units from a particular field.",
     'course': "A rule which specifies that students should pick a certain amount of units from a set of available " +
               "courses.",
     'course_requisite': "A rule which specifies that students should have taken a set of courses before taking this " +
@@ -60,6 +58,7 @@ const EITHER_OR_COMPONENT_NAMES = {
 const REQUISITE_COMPONENT_NAMES = {
     'incompatibility': "Incompatibility",
     'program': 'Program',
+    'elective': "Elective",
     'course_requisite': "Course",
     'custom_text_req': "Custom (Text)",
     'either_or': "Either Or"
@@ -67,6 +66,7 @@ const REQUISITE_COMPONENT_NAMES = {
 
 const REQUISITE_EITHER_OR_COMPONENT_NAMES = {
     'program': 'Program',
+    'elective': "Elective",
     'course_requisite': "Course",
     'custom_text_req': "Custom (Text)"
 };

--- a/cassdegrees/static/js/rules.js
+++ b/cassdegrees/static/js/rules.js
@@ -11,6 +11,7 @@ const ALL_COMPONENT_NAMES = {
     'course_requisite': "Course",
     'custom_text': "Custom (Text)",
     'custom_text_req': "Custom (Text)",
+    'elective': "Elective Units",
     'either_or': "Either Or"
 };
 
@@ -33,6 +34,8 @@ const ALL_COMPONENT_HELP = {
     'custom_text_req': "If other rules don't entirely fit the requirements of a rule, the custom text field allows " +
                        "for the specification of other program content. Note that this isn't enforced in student-facing " +
                        "tools.",
+    'elective': "A rule which allows students to choose any courses offered by the ANU as electives to fill a set" +
+                " amount of units.",
     'either_or': "A rule which allows for the specification of sets of different paths that students can take. Each " +
                  "\"OR\" group is a collection of rules which must be completed if students were to pick that specific " +
                  "group."
@@ -45,6 +48,7 @@ const COMPONENT_NAMES = {
     'subject_area': "Subject-Area Units",
     'course': "Course",
     'custom_text': "Custom (Text)",
+    'elective': "Elective",
     'either_or': "Either Or"
 };
 
@@ -54,7 +58,8 @@ const EITHER_OR_COMPONENT_NAMES = {
     'year_level': 'Level-Specific Units',
     'subject_area': "Subject-Area Units",
     'course': "Course",
-    'custom_text': "Custom (Text)"
+    'custom_text': "Custom (Text)",
+    'elective': "Elective"
 };
 
 //
@@ -804,6 +809,39 @@ Vue.component('rule_custom_text_req', {
         }
     },
     template: '#customTextReqRuleTemplate'
+});
+
+Vue.component('rule_elective', {
+    props: {
+        "details": {
+            type: Object,
+
+            validator: function (value) {
+                // Ensure that the object has all the attributes we need
+                if (!value.hasOwnProperty("units")) {
+                    value.units = 0;
+                }
+
+                return true;
+            }
+        }
+    },
+    data: function() {
+        return {
+            "not_divisible": false,
+        }
+    },
+    created: function() {
+        this.check_options();
+    },
+    methods: {
+        check_options: function() {
+            this.not_divisible = this.details.units % 6 !== 0;
+
+            return !this.not_divisible;
+        }
+    },
+    template: '#electiveRuleTemplate'
 });
 
 Vue.component('rule_either_or', {

--- a/cassdegrees/static/js/rules.js
+++ b/cassdegrees/static/js/rules.js
@@ -5,8 +5,6 @@ const ALL_COMPONENT_NAMES = {
     'incompatibility': "Incompatibility",
     'program': 'Program',
     'subplan': "Subplan",
-    'year_level': 'Level-Specific Units',
-    'subject_area': "Subject-Area Units",
     'course': "Course",
     'course_requisite': "Course",
     'custom_text': "Custom (Text)",
@@ -44,8 +42,6 @@ const ALL_COMPONENT_HELP = {
 // Translation table between internal names for components and human readable ones.
 const COMPONENT_NAMES = {
     'subplan': "Subplan",
-    'year_level': 'Level-Specific Units',
-    'subject_area': "Subject-Area Units",
     'course': "Course",
     'custom_text': "Custom (Text)",
     'elective': "Elective",
@@ -55,8 +51,6 @@ const COMPONENT_NAMES = {
 // For either rule, list everything in the drop down menu except the "Either" option, or recursion will occur.
 const EITHER_OR_COMPONENT_NAMES = {
     'subplan': "Subplan",
-    'year_level': 'Level-Specific Units',
-    'subject_area': "Subject-Area Units",
     'course': "Course",
     'custom_text': "Custom (Text)",
     'elective': "Elective"
@@ -66,8 +60,6 @@ const EITHER_OR_COMPONENT_NAMES = {
 const REQUISITE_COMPONENT_NAMES = {
     'incompatibility': "Incompatibility",
     'program': 'Program',
-    'year_level': 'Level-Specific Units',
-    'subject_area': "Subject-Area Units",
     'course_requisite': "Course",
     'custom_text_req': "Custom (Text)",
     'either_or': "Either Or"
@@ -75,8 +67,6 @@ const REQUISITE_COMPONENT_NAMES = {
 
 const REQUISITE_EITHER_OR_COMPONENT_NAMES = {
     'program': 'Program',
-    'year_level': 'Level-Specific Units',
-    'subject_area': "Subject-Area Units",
     'course_requisite': "Course",
     'custom_text_req': "Custom (Text)"
 };
@@ -589,19 +579,23 @@ Vue.component('rule_course_requisite', {
     template: '#courseRequisiteTemplate'
 });
 
-Vue.component('rule_subject_area', {
+Vue.component('rule_elective', {
     props: {
         "details": {
             type: Object,
 
             validator: function (value) {
                 // Ensure that the object has all the attributes we need
-                if (!value.hasOwnProperty("subject")) {
-                    value.subject = "";
+                if (!value.hasOwnProperty("unit_count")) {
+                    value.unit_count = 0;
+                }
+
+                if (!value.hasOwnProperty("subject_area")) {
+                    value.subject_area = "all";
                 }
 
                 if (!value.hasOwnProperty("year_level")) {
-                    value.year_level = null;
+                    value.year_level = "all";
                 }
 
                 return true;
@@ -622,7 +616,6 @@ Vue.component('rule_subject_area', {
         }
     },
     created: function() {
-        // Javascript has the best indirection...
         var rule = this;
 
         var request = new XMLHttpRequest();
@@ -649,14 +642,16 @@ Vue.component('rule_subject_area', {
     methods: {
         check_options: function() {
             // Ensure all data has been filled in
-            this.is_blank = this.details.unit_count == null;
-            this.is_blank = this.is_blank || this.details.subject === "";
-            this.is_blank = this.is_blank || this.details.year_level == null;
+            this.is_blank = this.details.unit_count === "";
 
             // Ensure Unit Count is valid:
-            if (this.details.unit_count != null) {
-                this.invalid_units = this.details.unit_count <= 0;
+            if (this.details.unit_count !== "") {
+                this.invalid_units = this.details.unit_count < 0;
                 this.invalid_units_step = this.details.unit_count % 6 !== 0;
+            }
+            else{
+                this.invalid_units = false;
+                this.invalid_units_step = false;
             }
 
             return !this.invalid_units && !this.invalid_units_step && !this.is_blank;
@@ -670,68 +665,7 @@ Vue.component('rule_subject_area', {
             });
         }
     },
-    template: '#subjectAreaRuleTemplate'
-});
-
-Vue.component('rule_year_level', {
-    props: {
-        "details": {
-            type: Object,
-
-            validator: function (value) {
-                // Ensure that the object has all the attributes we need
-                if (!value.hasOwnProperty("year_level")) {
-                    value.year_level = null;
-                }
-
-                return true;
-            }
-        }
-    },
-    data: function() {
-        return {
-            "number_of_year_levels": 9,
-
-            // Display related warnings if true
-            "invalid_units": false,
-            "invalid_units_step": false,
-            "invalid_course_year_level": false,
-            "is_blank": false,
-
-            "redraw": false
-        }
-    },
-    created: function() {
-        this.check_options();
-    },
-    methods: {
-        check_options: function() {
-            // Ensure all data has been filled in
-            this.is_blank = this.details.unit_count == null;
-            this.is_blank = this.is_blank || this.details.year_level == null;
-
-            // Ensure Unit Count is valid:
-            if (this.details.unit_count != null) {
-                this.invalid_units = this.details.unit_count <= 0;
-                this.invalid_units_step = this.details.unit_count % 6 !== 0;
-            }
-            // Ensure Course Year Level Input is valid
-            if (this.details.year_level != null) {
-                this.invalid_course_year_level = this.details.year_level % 1000 !== 0;
-            }
-
-            return !this.invalid_units && !this.invalid_units_step && !this.invalid_course_year_level && !this.is_blank;
-        },
-        // https://michaelnthiessen.com/force-re-render/
-        do_redraw: function() {
-            this.redraw = true;
-
-            this.$nextTick(() => {
-                this.redraw = false;
-            });
-        }
-    },
-    template: '#yearSpecificRuleTemplate'
+    template: '#electiveRuleTemplate'
 });
 
 Vue.component('rule_custom_text', {
@@ -809,39 +743,6 @@ Vue.component('rule_custom_text_req', {
         }
     },
     template: '#customTextReqRuleTemplate'
-});
-
-Vue.component('rule_elective', {
-    props: {
-        "details": {
-            type: Object,
-
-            validator: function (value) {
-                // Ensure that the object has all the attributes we need
-                if (!value.hasOwnProperty("units")) {
-                    value.units = 0;
-                }
-
-                return true;
-            }
-        }
-    },
-    data: function() {
-        return {
-            "not_divisible": false,
-        }
-    },
-    created: function() {
-        this.check_options();
-    },
-    methods: {
-        check_options: function() {
-            this.not_divisible = this.details.units % 6 !== 0;
-
-            return !this.not_divisible;
-        }
-    },
-    template: '#electiveRuleTemplate'
 });
 
 Vue.component('rule_either_or', {

--- a/cassdegrees/templates/viewcourse.html
+++ b/cassdegrees/templates/viewcourse.html
@@ -63,20 +63,18 @@
                 {# Program Rule #}
                 {% elif rule.type == 'program' %}
                     <p>Students must be studying a {{ rule.program.name }}</p>
-                {# Year-level Rule #}
-                {% elif rule.type == 'year_level' %}
+                {# elective Rule #}
+                {% elif rule.type == 'elective' %}
                     <p>
-                        Students must have completed {{ rule.unit_count }} units from
-                        {{ rule.year_level }}-level courses
-                    </p>
-                {# Subject-area Rule #}
-                {% elif rule.type == 'subject_area' %}
-                    <p>
-                        Students must have completed {{ rule.unit_count }} units of
-                        {% if rule.year_level != 'Any year-level' %}
+                        Students must complete {{ rule.unit_count }} units of
+                        {% if rule.year_level != 'all' %}
                             {{ rule.year_level }}-level
                         {% endif %}
-                        {{ rule.subject }} courses
+                        {% if rule.subject_area == 'all' %}
+                            elective courses offered by ANU
+                        {% else %}
+                            {{ rule.subject_area }} courses
+                        {% endif %}
                     </p>
                 {# Course-requisite Rule #}
                 {% elif rule.type == 'course_requisite' %}

--- a/cassdegrees/templates/viewprogram.html
+++ b/cassdegrees/templates/viewprogram.html
@@ -105,6 +105,9 @@
                 {# Custom-text Rules #}
                 {% elif rule.type == "custom_text" %}
                     <p>{{ rule.units }} units from {{ rule.text }}</p>
+                {# Elective Rules #}
+                {% elif rule.type == "elective" %}
+                    <p>{{ rule.units }} units from the completion of elective courses offered by the ANU</p>
                 {# Either-or Rules #}
                 {% elif rule.type == 'either_or' %}
                     Either:
@@ -155,6 +158,9 @@
                                 {# Custom-text Or Rule #}
                                 {% elif sub_rule.type == "custom_text" %}
                                     <p>{{ sub_rule.units }} units from {{ sub_rule.text }}</p>
+                                {# Elective Or Rule #}
+                                {% elif sub_rule.type == "elective" %}
+                                    <p>{{ sub_rule.units }} units from the completion of elective courses offered by the ANU</p>
                                 {% endif %}
                             {% endfor %}
                         </div>

--- a/cassdegrees/templates/viewprogram.html
+++ b/cassdegrees/templates/viewprogram.html
@@ -90,17 +90,18 @@
                             {% endfor %}
                         </ul>
                     </p>
-                {# Year-level Rules #}
-                {% elif rule.type == 'year_level' %}
-                    <p>{{ rule.unit_count }} units from completion of {{ rule.year_level }}-level courses</p>
-                {# Subject-area Rules #}
-                {% elif rule.type == 'subject_area' %}
+                {# Elective Rules #}
+                {% elif rule.type == 'elective' %}
                     <p>
                         {{ rule.unit_count }} units from completion of
-                        {% if rule.year_level != 'Any year-level' %}
+                        {% if rule.year_level != 'all' %}
                             {{ rule.year_level }}-level
                         {% endif %}
-                        {{ rule.subject }} courses
+                        {% if rule.subject_area == 'all' %}
+                            elective courses offered by ANU
+                        {% else %}
+                            courses in the subject area {{ rule.subject_area }}
+                        {% endif %}
                     </p>
                 {# Custom-text Rules #}
                 {% elif rule.type == "custom_text" %}
@@ -140,27 +141,22 @@
                                             {% endfor %}
                                         </ul>
                                     </p>
-                                {# Year-level Or Rule #}
-                                {% elif sub_rule.type == 'year_level' %}
+                                {# Elective Or Rule #}
+                                {% elif rule.type == 'elective' %}
                                     <p>
-                                        {{ sub_rule.unit_count }} units from completion of
-                                        {{ sub_rule.year_level }}-level courses
-                                    </p>
-                                {# Subject-area Or Rule #}
-                                {% elif sub_rule.type == 'subject_area' %}
-                                    <p>
-                                        {{ sub_rule.unit_count }} units from completion of
-                                        {% if sub_rule.year_level != 'Any year-level' %}
-                                            {{ sub_rule.year_level }}-level
+                                        {{ rule.unit_count }} units from completion of
+                                        {% if rule.year_level != 'all' %}
+                                            {{ rule.year_level }}-level
                                         {% endif %}
-                                        {{ sub_rule.subject }} courses
+                                        {% if rule.subject_area == 'all' %}
+                                            elective courses offered by ANU
+                                        {% else %}
+                                            courses in the subject area {{ rule.subject_area }}
+                                        {% endif %}
                                     </p>
                                 {# Custom-text Or Rule #}
                                 {% elif sub_rule.type == "custom_text" %}
                                     <p>{{ sub_rule.units }} units from {{ sub_rule.text }}</p>
-                                {# Elective Or Rule #}
-                                {% elif sub_rule.type == "elective" %}
-                                    <p>{{ sub_rule.units }} units from the completion of elective courses offered by the ANU</p>
                                 {% endif %}
                             {% endfor %}
                         </div>

--- a/cassdegrees/templates/widgets/pdf_rules.html
+++ b/cassdegrees/templates/widgets/pdf_rules.html
@@ -18,11 +18,6 @@
             {% endif %}
             courses:
         </p>
-    {% elif rule.type == "subject_area" %}
-        {# https://stackoverflow.com/questions/4831306/need-to-convert-a-string-to-int-in-a-django-template #}
-        {# add:"0" needed to cast units to int #}
-        <p>Complete {{ rule.unit_count }} units from {% if rule.unit_count|add:"0" <= 6 %}a{% endif %}
-            {{ rule.subject }} course{% if rule.unit_count|add:"0" > 6 %}s{% endif %}:</p>
     {% elif rule.type == "year_level" %}
         <p>Complete {{ rule.unit_count }} units from {% if rule.unit_count|add:"0" <= 6 %}a{% endif %}
             {{ rule.year_level }}-level course{% if rule.unit_count|add:"0" > 6 %}s{% endif %}:</p>

--- a/cassdegrees/templates/widgets/pdf_rules.html
+++ b/cassdegrees/templates/widgets/pdf_rules.html
@@ -5,6 +5,19 @@
 <div class="box try-complete-box">
     {% if rule.type == "subplan" %}
         <p>Completion of {{ rule.kind }} for {{ rule.units }} units:</p>
+    {% elif rule.type == 'elective' %}
+        <p>
+            {{ rule.unit_count }} units from
+            {% if rule.year_level != 'all' %}
+                {{ rule.year_level }}-level
+            {% endif %}
+            {% if rule.subject_area != 'all' %}
+                {{ rule.subject_area }}
+            {% else %}
+                elective
+            {% endif %}
+            courses:
+        </p>
     {% elif rule.type == "subject_area" %}
         {# https://stackoverflow.com/questions/4831306/need-to-convert-a-string-to-int-in-a-django-template #}
         {# add:"0" needed to cast units to int #}
@@ -56,9 +69,7 @@
     {% with subplan=subplans|index:rule.ids.0 %}
         {% course_box subplan.units plan %}
     {% endwith %}
-{% elif rule.type == "subject_area" %}
-    {% course_box rule.unit_count plan %}
-{% elif rule.type == "year_level" %}
+{% elif rule.type == "elective" %}
     {% course_box rule.unit_count plan %}
 {% elif rule.type == "course" %}
     {% with courses_provided=rule.codes|length %}

--- a/cassdegrees/templates/widgets/rulescripts.html
+++ b/cassdegrees/templates/widgets/rulescripts.html
@@ -217,6 +217,19 @@
     </fieldset>
 </script>
 
+<script type="text/x-template" id="electiveRuleTemplate">
+    <fieldset>
+        <p>
+            Students must complete
+            <input style="margin-left: 0;" class="text" onkeydown="javascript: return checkKeys(event)" type="number" min="0" step="6" max="1000" v-model="details.units" aria-required="true" required>
+            units of elective courses. 
+        </p>
+
+        <div class="msg-error" v-if="not_divisible">Units must be divisible by 6!</div>
+
+    </fieldset>
+</script>
+
 <script type="text/x-template" id="customTextReqRuleTemplate">
     <fieldset>
         <p>

--- a/cassdegrees/templates/widgets/rulescripts.html
+++ b/cassdegrees/templates/widgets/rulescripts.html
@@ -125,69 +125,27 @@
     </fieldset>
 </script>
 
-<script type="text/x-template" id="subjectAreaRuleTemplate">
+<script type="text/x-template" id="electiveRuleTemplate">
     <fieldset v-if="!redraw">
-        <div class="msg-error" v-if="invalid_units">Unit count must be > 0!</div>
+        <div class="msg-error" v-if="invalid_units">Unit count must be non-negative!</div>
         <div class="msg-error" v-if="invalid_units_step">Unit count should be divisible by 6!</div>
         <div class="msg-error" v-if="is_blank">All options must be filled in!</div>
 
-        <p class="form-group">
-            <label>
-                Students must complete...
-            </label>
-            <input class="text" onkeydown="javascript: return checkKeys(event)" type="number" v-on:change="check_options" v-model="details.unit_count" min="0" step="6" max="1000" aria-required="true" required>
-            units
-        </p>
-
-
         <p>
-            from the following subject area:
-        </p>
-
-        <div>
-            <select v-model="details.subject" required>
-                <option v-for="subject_area in subject_areas" v-on:change="check_options" v-bind:value="subject_area">{{ subject_area }}</option>
-            </select>
-        </div>
-
-        <p>
-            within the following year-level:
-        </p>
-
-        <div>
-            <select v-model="details.year_level" v-on:change="check_options" required>
-                <option>Any year-level</option>
+            Students must complete
+            <input style="margin-left: 0;" class="text" v-on:change="check_options" onkeydown="javascript: return checkKeys(event)" type="number" min="0" step="6" max="1000" v-model="details.unit_count" aria-required="true" required>
+            units from
+            <select v-model="details.year_level" required>
+                <option value="all" selected>All</option>
                 <option v-for="year_level in number_of_year_levels" v-bind:value="year_level*1000">{{ year_level*1000 }}-level</option>
             </select>
-        </div>
-    </fieldset>
-</script>
-
-<script type="text/x-template" id="yearSpecificRuleTemplate">
-    <fieldset v-if="!redraw">
-        <div class="msg-error" v-if="invalid_units">Unit count must be > 0!</div>
-        <div class="msg-error" v-if="invalid_units_step">Unit count should be divisible by 6!</div>
-        <div class="msg-error" v-if="is_blank">All options must be filled in!</div>
-
-        <p class="form-group">
-            <label>
-                Students must complete...
-            </label>
-            <input class="text" onkeydown="javascript: return checkKeys(event)" type="number" v-on:change="check_options" v-model="details.unit_count" min="0" step="6" max="1000" aria-required="true" required>
-            units
-        </p>
-
-        <p>
-            from the following course year-level:
-        </p>
-
-        <div class="msg-error" v-if="invalid_course_year_level">Course Year-Level should be divisible by 1000!</div>
-
-        <div>
-            <select v-model="details.year_level" v-on:change="check_options" required>
-                <option v-for="year_level in number_of_year_levels" v-bind:value="year_level*1000">{{ year_level*1000 }}-level</option>
+            electives in
+            <select v-model="details.subject_area" required>
+                <option value="all" selected>Any</option>
+                <option v-for="subject_area in subject_areas" v-bind:value="subject_area">{{ subject_area }}</option>
             </select>
-        </div>
+            subject area.
+        </p>
     </fieldset>
 </script>
 
@@ -214,19 +172,6 @@
             <label>Show 6-unit course boxes in plans (e.g. PDF):</label>
             <input class="text" type="checkbox" v-model="details.show_course_boxes">
         </p>
-    </fieldset>
-</script>
-
-<script type="text/x-template" id="electiveRuleTemplate">
-    <fieldset>
-        <p>
-            Students must complete
-            <input style="margin-left: 0;" class="text" onkeydown="javascript: return checkKeys(event)" type="number" min="0" step="6" max="1000" v-model="details.units" aria-required="true" required>
-            units of elective courses. 
-        </p>
-
-        <div class="msg-error" v-if="not_divisible">Units must be divisible by 6!</div>
-
     </fieldset>
 </script>
 

--- a/cassdegrees/templates/widgets/student_rules.html
+++ b/cassdegrees/templates/widgets/student_rules.html
@@ -5,14 +5,16 @@
 <div class="card">
     {% if rule.type == "subplan" %}
         <p>Completion of {{ rule.kind }} for {{ rule.units }} units:</p>
-    {% elif rule.type == "subject_area" %}
-        {# https://stackoverflow.com/questions/4831306/need-to-convert-a-string-to-int-in-a-django-template #}
-        {# add:"0" needed to cast units to int #}
-        <p>Complete {{ rule.unit_count }} units from {% if rule.unit_count|add:"0" <= 6 %}a{% endif %}
-            {{ rule.subject }} course{% if rule.unit_count|add:"0" > 6 %}s{% endif %}:</p>
-    {% elif rule.type == "year_level" %}
-        <p>Complete {{ rule.unit_count }} units from {% if rule.unit_count|add:"0" <= 6 %}a{% endif %}
-            {{ rule.year_level }}-level course{% if rule.unit_count|add:"0" > 6 %}s{% endif %}:</p>
+    {% elif rule.type == "elective" %}
+        {{ rule.unit_count }} units from completion of
+        {% if rule.year_level != 'all' %}
+            {{ rule.year_level }}-level
+        {% endif %}
+        {% if rule.subject_area == 'all' %}
+            elective courses offered by ANU
+        {% else %}
+            courses in the subject area {{ rule.subject_area }}
+        {% endif %}
     {% elif rule.type == "course" %}
         {# Find out if all courses are required #}
         {% with courses_provided=rule.codes|length %}
@@ -30,8 +32,6 @@
                 {% endif %}
             {% endwith %}
         {% endwith %}
-    {% elif rule.type == "elective" %}
-        <p>{{ rule.units }} units from the completion of elective courses offered by the ANU</p>
     {% elif rule.type == "either_or" %}
         <p class="bottom-margin">Either:</p>
 
@@ -58,9 +58,7 @@
         {% with subplan=subplans|index:rule.ids.0 %}
             {% student_course_box subplan.units %}
         {%  endwith %}
-    {% elif rule.type == "subject_area" %}
-        {% student_course_box rule.unit_count %}
-    {% elif rule.type == "year_level" %}
+    {% elif rule.type == "elective" %}
         {% student_course_box rule.unit_count %}
     {% elif rule.type == "course" %}
         {% with courses_provided=rule.codes|length %}

--- a/cassdegrees/templates/widgets/student_rules.html
+++ b/cassdegrees/templates/widgets/student_rules.html
@@ -30,6 +30,8 @@
                 {% endif %}
             {% endwith %}
         {% endwith %}
+    {% elif rule.type == "elective" %}
+        <p>{{ rule.units }} units from the completion of elective courses offered by the ANU</p>
     {% elif rule.type == "either_or" %}
         <p class="bottom-margin">Either:</p>
 
@@ -76,5 +78,7 @@
         {% if rule.show_course_boxes %}
             {% student_course_box rule.units %}
         {% endif %}
+    {% elif rule.type == "elective" %}
+        {% student_course_box rule.units %}
     {% endif %}
 </div>


### PR DESCRIPTION
Closes #265.

Adds a new rule to replace the existing `year_level` and `subject_specific` elective rules as a general elective rule. Note that the numerous rules in the following screenshots were all created from the same primary rule (Program viewing was omitted for brevity's sake, but it works similarly to the student plan).

**Program Creation:**
> ![Edit Plan](https://user-images.githubusercontent.com/36946090/64174334-62d72e00-ce9c-11e9-952c-d55c690e4c63.jpg)

**PDF Viewing:**
> ![Pdf Plan](https://user-images.githubusercontent.com/36946090/64174335-636fc480-ce9c-11e9-9b52-2105e2b79984.jpg)

**Student Plan Editing:**
> ![Student Plan](https://user-images.githubusercontent.com/36946090/64174337-636fc480-ce9c-11e9-84d8-5938ae22120d.jpg)
