### PR TITLE
Fixed breadcrumbs on create list page

### DIFF
--- a/cassdegrees/templates/createlist.html
+++ b/cassdegrees/templates/createlist.html
@@ -7,8 +7,8 @@
 {% block subtitle %}{% if edit %}Edit{% else %}Create{% endif %} List{% endblock %}
 
 {% block breadcrumb-trail %}
-    {% breadcrumb '/admin/home' 'Admin Home' %}
-    {% breadcrumb '/admin/list/?view=Program' 'Programs/Subplans/Courses' %}
+    {% breadcrumb '/staff' 'Staff Home' %}
+    {% breadcrumb '/staff/list/?view=Program' 'Programs/Subplans/Courses' %}
     {% if edit %}
         {% finalcrumb 'Edit List' %}
     {% else %}


### PR DESCRIPTION
Simple bug fix to redirect the breadcrumbs on the create list page to staff url rather than admin.