### PR TITLE
Restyled Index Buttons to Wrap and Center Align When Resized.

### DIFF
--- a/cassdegrees/static/css/style.css
+++ b/cassdegrees/static/css/style.css
@@ -16,16 +16,17 @@
 .splash_menu_container {
     display: flex;
     padding-top: 20px;
-    flex-direction: row;
     justify-content: center;
     align-items: baseline;
+    flex-wrap: wrap;
 }
 
 .img_btn_container {
     display: flex;
     flex-direction: column;
     justify-content: center;
-    margin: 12px;
+    width: 160px;
+    margin: 10px;
 }
 
 .comments {

--- a/cassdegrees/templates/index.html
+++ b/cassdegrees/templates/index.html
@@ -15,7 +15,7 @@
 
     {# generate splash menu based on buttons defined in ui/views.py   #}
     {% for button in buttons %}
-        <a href="{{ button.url }}" class="homepage-button" style="width: {{ element_width }}">
+        <a href="{{ button.url }}" class="homepage-button">
             <div class="img_btn_container">
                 <div class="icon-btn">
                     <i class="{{ button.kind }}"></i>

--- a/cassdegrees/ui/views/index.py
+++ b/cassdegrees/ui/views/index.py
@@ -20,7 +20,4 @@ def index(request):
         {'url': staff_url_prefix + "bulk_upload/", 'kind': "fas fa-sign-in-alt", 'label': "Bulk Upload"}
     ]
 
-    # Dynamically calculate expected width for buttons
-    element_width = str(100 / len(buttons)) + "%"
-
-    return render(request, 'index.html', context={'buttons': buttons, 'element_width': element_width})
+    return render(request, 'index.html', context={'buttons': buttons})


### PR DESCRIPTION
Closes #306.

The buttons on the staff home page no longer overlap when resized, and instead wrap to the next line and neatly align themselves.

![image](https://user-images.githubusercontent.com/37424867/64171319-b6924900-ce95-11e9-8281-d0ec2cebf990.png)

![image](https://user-images.githubusercontent.com/37424867/64171354-cad64600-ce95-11e9-973d-13ba1b0d7b25.png)

![image](https://user-images.githubusercontent.com/37424867/64171386-e04b7000-ce95-11e9-8a0f-5f389b34c275.png)
