### PR TITLE
Fixed link for subplans within the 'either or' rule.

### DIFF
--- a/cassdegrees/templates/staff/view/viewprogram.html
+++ b/cassdegrees/templates/staff/view/viewprogram.html
@@ -129,7 +129,7 @@
                                         <ul>
                                             {% for id, value in sub_rule.contents.items %}
                                                 <li>
-                                                    <a class="btn-uni-grad" href="/view/subplan/?id={{ id }}" >
+                                                    <a class="btn-uni-grad" href="/staff/view/subplan/?id={{ id }}" >
                                                         {{ value.name }}
                                                     </a>
                                                 </li>


### PR DESCRIPTION
Original Issue: #297 

Fixed the 404 error when clicking on subplans that are within the 'either or' rule, which simply contained the wrong url.