### PR TITLE
Empty Dropdowns When No Course/Subplan/Program in Database

### DIFF
--- a/cassdegrees/static/js/staff/rules.js
+++ b/cassdegrees/static/js/staff/rules.js
@@ -85,12 +85,12 @@ const SUBPLAN_TYPES = {
 
 const INFO_MSGS = {
     'course': '<p>This Requisite requires Courses in the system. Please create Courses ' +
-        '<a href="/staff/create/course/">here</a> or bulk upload Courses ' +
-        '<a href="/staff/bulk_upload/">here</a> first before creating this Requisite.</p>',
+        '<a href="/staff/create/course/" target="_blank">here</a> or bulk upload Courses ' +
+        '<a href="/staff/bulk_upload/" target="_blank">here</a> first before creating this Requisite.</p>',
     'subplan': '<p>This Requisite requires Subplans in the system. Please create Subplans ' +
-        '<a href="/staff/create/subplan/">here</a> first before creating this Requisite.</p>',
+        '<a href="/staff/create/subplan/" target="_blank">here</a> first before creating this Requisite.</p>',
     'program': '<p>This Requisite requires Programs in the system. Please create Programs ' +
-        '<a href="/staff/create/program/">here</a> first before creating this Requisite.</p>'
+        '<a href="/staff/create/program/" target="_blank">here</a> first before creating this Requisite.</p>'
 };
 
 Vue.component('rule_incompatibility', {

--- a/cassdegrees/static/js/staff/rules.js
+++ b/cassdegrees/static/js/staff/rules.js
@@ -83,6 +83,16 @@ const SUBPLAN_TYPES = {
     'SPEC': 'Specialisations'
 };
 
+const INFO_MSGS = {
+    'course': '<p>This Requisite requires Courses in the system. Please create Courses ' +
+        '<a href="/staff/create/course/">here</a> or bulk upload Courses ' +
+        '<a href="/staff/bulk_upload/">here</a> first before creating this Requisite.</p>',
+    'subplan': '<p>This Requisite requires Subplans in the system. Please create Subplans ' +
+        '<a href="/staff/create/subplan/">here</a> first before creating this Requisite.</p>',
+    'program': '<p>This Requisite requires Programs in the system. Please create Programs ' +
+        '<a href="/staff/create/program/">here</a> first before creating this Requisite.</p>'
+};
+
 Vue.component('rule_incompatibility', {
     props: {
         "details": {
@@ -101,6 +111,7 @@ Vue.component('rule_incompatibility', {
     data: function() {
         return {
             "courses": [],
+            "info_msg": INFO_MSGS['course'],
 
             // Display related warnings if true
             "non_unique_options": false,
@@ -197,6 +208,7 @@ Vue.component('rule_program', {
     data: function() {
         return {
             "programs": [],
+            "info_msg": INFO_MSGS['program'],
 
             // Display related warnings if true
             "is_blank": false,
@@ -266,6 +278,7 @@ Vue.component('rule_subplan', {
             "filtered_subplans": [],
             "program_year": "",
             "subplan_types": [],
+            "info_msg": INFO_MSGS['subplan'],
 
             // Display related warnings if true
             "non_unique_options": false,
@@ -433,6 +446,7 @@ Vue.component('rule_course', {
         return {
             "courses": [],
             "list_types": [],
+            "info_msg": INFO_MSGS['course'],
 
             // Display related warnings if true
             "non_unique_options": false,
@@ -540,6 +554,7 @@ Vue.component('rule_course_requisite', {
     data: function() {
         return {
             "courses": [],
+            "info_msg": INFO_MSGS['course'],
 
             // Display related warnings if true
             "non_unique_options": false,
@@ -643,6 +658,7 @@ Vue.component('rule_elective', {
         return {
             "number_of_year_levels": 9,
             "subject_areas": [],
+            "info_msg": INFO_MSGS['course'],
 
             // Display related warnings if true
             "invalid_units": false,

--- a/cassdegrees/templates/widgets/staff/rulescripts.html
+++ b/cassdegrees/templates/widgets/staff/rulescripts.html
@@ -44,31 +44,43 @@
 
 <script type="text/x-template" id="subplanRuleTemplate">
     <fieldset v-if="!redraw">
-        <div class="msg-error" v-if="non_unique_options">Options must be unique!</div>
-        <div class="msg-error" v-if="inconsistent_units">Options have different unit values!</div>
-        <div class="msg-error" v-if="wrong_year_selected">Selected subplans must have same year as program!</div>
-        <div class="msg-error" v-if="is_blank">All options must be filled in!</div>
 
-        <p>
-            Students must pick
-            <input class="text" v-model="details.kind" v-on:change="check_options" aria-required="true" placeholder="e.g. Arts Major - brief description for students here"
-                   style="margin-left: 0; width: 400px" required>
-            from the following
-            <select v-model="details.subplan_type" v-on:change="change_filter" required>
-                <option v-for="(msg, type) in subplan_types" v-bind:value="type">{{ msg }}</option>
-            </select>:
-        </p>
+        <div v-if="subplans.length == 0">
+             <div class="msg-error" v-if="non_unique_options">Options must be unique!</div>
+            <div class="msg-error" v-if="inconsistent_units">Options have different unit values!</div>
+            <div class="msg-error" v-if="wrong_year_selected">Selected subplans must have same year as program!</div>
+            <div class="msg-error" v-if="is_blank">All options must be filled in!</div>
 
-        <p></p>
+            <p>
+                Students must pick
+                <input class="text" v-model="details.kind" v-on:change="check_options" aria-required="true" placeholder="e.g. Arts Major - brief description for students here"
+                       style="margin-left: 0; width: 400px" required>
+                from the following
+                <select v-model="details.subplan_type" v-on:change="change_filter" required>
+                    <option v-for="(msg, type) in subplan_types" v-bind:value="type">{{ msg }}</option>
+                </select>:
+            </p>
 
-        <div v-for="(id, index) in details.ids">
-            <select v-model="details.ids[index]" v-on:change="check_options" required>
-                <option v-for="subplan in filtered_subplans" v-bind:value="subplan.id">{{ subplan.name }} ({{ subplan.code }})</option>
-            </select>
-            <input v-if="details.ids.length > 1" type="button" v-on:click="remove_subplan(index)" class="btn-uni-grad btn-snall no-left-margin" value="Remove" />
+            <p></p>
+
+            <div v-for="(id, index) in details.ids">
+                <select v-model="details.ids[index]" v-on:change="check_options" required>
+                    <option v-for="subplan in filtered_subplans" v-bind:value="subplan.id">{{ subplan.name }} ({{ subplan.code }})</option>
+                </select>
+                <input v-if="details.ids.length > 1" type="button" v-on:click="remove_subplan(index)" class="btn-uni-grad btn-snall no-left-margin" value="Remove" />
+            </div>
+
+            <input type="button" v-on:click="add_subplan()" class="btn-uni-grad btn-snall no-left-margin" value="Add new option" />
         </div>
 
-        <input type="button" v-on:click="add_subplan()" class="btn-uni-grad btn-snall no-left-margin" value="Add new option" />
+        <div v-else>
+            <p>
+                There are currently no Subplans added to the system. Please create Subplans
+                <a href="#">here</a>
+                first before creating this rule.
+            </p>
+        </div>
+
     </fieldset>
 </script>
 
@@ -105,16 +117,16 @@
 
             <input type="button" v-on:click="add_course()" class="btn-uni-grad btn-snall no-left-margin" value="Add new option" />
         </div>
+
         <div v-else>
             <p>
                 There are currently no courses added to the system. Please create courses
                 <a href="#">here</a>
                 or bulk upload courses
                 <a href="#">here</a>
-                before creating this rule.
+                first before creating this rule.
             </p>
         </div>
-
 
     </fieldset>
 </script>

--- a/cassdegrees/templates/widgets/staff/rulescripts.html
+++ b/cassdegrees/templates/widgets/staff/rulescripts.html
@@ -22,9 +22,9 @@
          <div v-else>
              <p>
                 This Requisite requires Courses in the system. Please create Courses
-                <a href="#">here</a>
+                <a href="/staff/create/course/">here</a>
                 or bulk upload Courses
-                <a href="#">here</a>
+                <a href="/staff/bulk_upload/">here</a>
                 first before creating this Requisite.
             </p>
          </div>
@@ -52,7 +52,7 @@
         <div v-else>
             <p>
                 This Requisite requires Programs in the system. Please create Programs
-                <a href="#">here</a>
+                <a href="/staff/create/program/">here</a>
                 first before creating this Requisite.
             </p>
         </div>
@@ -94,7 +94,7 @@
         <div v-else>
             <p>
                 This Requisite requires Subplans in the system. Please create Subplans
-                <a href="#">here</a>
+                <a href="/staff/create/subplan/">here</a>
                 first before creating this Requisite.
             </p>
         </div>
@@ -138,9 +138,9 @@
         <div v-else>
             <p>
                 This Requisite requires Courses in the system. Please create Courses
-                <a href="#">here</a>
+                <a href="/staff/create/course/">here</a>
                 or bulk upload Courses
-                <a href="#">here</a>
+                <a href="/staff/bulk_upload/">here</a>
                 first before creating this Requisite.
             </p>
         </div>
@@ -171,9 +171,9 @@
         <div v-else>
             <p>
                 This Requisite requires Courses in the system. Please create Courses
-                <a href="#">here</a>
+                <a href="/staff/create/course/">here</a>
                 or bulk upload Courses
-                <a href="#">here</a>
+                <a href="/staff/bulk_upload/">here</a>
                 first before creating this Requisite.
             </p>
         </div>
@@ -207,9 +207,9 @@
         <div v-else>
             <p>
                 This Requisite requires Courses in the system. Please create Courses
-                <a href="#">here</a>
+                <a href="/staff/create/course/">here</a>
                 or bulk upload Courses
-                <a href="#">here</a>
+                <a href="/staff/bulk_upload/">here</a>
                 first before creating this Requisite.
             </p>
         </div>

--- a/cassdegrees/templates/widgets/staff/rulescripts.html
+++ b/cassdegrees/templates/widgets/staff/rulescripts.html
@@ -74,9 +74,9 @@
         </div>
         <div v-else>
             <p>
-                There are currently no Subplans added to the system. Please create Subplans
+                This Requisite requires Subplans in the system. Please create Subplans
                 <a href="#">here</a>
-                first before creating this rule.
+                first before creating this Requisite.
             </p>
         </div>
 
@@ -118,11 +118,11 @@
         </div>
         <div v-else>
             <p>
-                There are currently no courses added to the system. Please create courses
+                This Requisite requires Courses in the system. Please create Courses
                 <a href="#">here</a>
-                or bulk upload courses
+                or bulk upload Courses
                 <a href="#">here</a>
-                first before creating this rule.
+                first before creating this Requisite.
             </p>
         </div>
 
@@ -151,11 +151,11 @@
         </div>
         <div v-else>
             <p>
-                There are currently no courses added to the system. Please create courses
+                This Requisite requires Courses in the system. Please create Courses
                 <a href="#">here</a>
-                or bulk upload courses
+                or bulk upload Courses
                 <a href="#">here</a>
-                first before creating this rule.
+                first before creating this Requisite.
             </p>
         </div>
 

--- a/cassdegrees/templates/widgets/staff/rulescripts.html
+++ b/cassdegrees/templates/widgets/staff/rulescripts.html
@@ -1,41 +1,60 @@
 {% verbatim %}
 <script type="text/x-template" id="incompatibilityRuleTemplate">
      <fieldset v-if="!redraw">
-        <p class="form-group">
-            <label>
-                Students must not have completed/be currently enrolled in the following courses:
-            </label>
-        </p>
 
-        <div class="msg-error" v-if="non_unique_options">Options must be unique!</div>
-        <div class="msg-error" v-if="is_blank">All options must be filled in!</div>
+         <div v-if="courses.length != 0">
+             <p class="form-group">
+                 <label>Students must not have completed/be currently enrolled in the following courses:</label>
+             </p>
 
-        <div v-for="(code, index) in details.incompatible_courses">
-            <select v-model="details.incompatible_courses[index]" v-on:change="check_options" required>
-                <option v-for="course in courses" v-bind:value="course.code">{{ course.code }} {{ course.name }}</option>
-            </select>
-            <input v-if="details.incompatible_courses.length > 1" type="button" v-on:click="remove_course(index)" class="btn-uni-grad btn-snall no-left-margin" value="Remove" />
-        </div>
+             <div class="msg-error" v-if="non_unique_options">Options must be unique!</div>
+            <div class="msg-error" v-if="is_blank">All options must be filled in!</div>
 
-        <input type="button" v-on:click="add_course()" class="btn-uni-grad btn-snall no-left-margin" value="Add new option" />
+            <div v-for="(code, index) in details.incompatible_courses">
+                <select v-model="details.incompatible_courses[index]" v-on:change="check_options" required>
+                    <option v-for="course in courses" v-bind:value="course.code">{{ course.code }} {{ course.name }}</option>
+                </select>
+                <input v-if="details.incompatible_courses.length > 1" type="button" v-on:click="remove_course(index)" class="btn-uni-grad btn-snall no-left-margin" value="Remove" />
+            </div>
+
+            <input type="button" v-on:click="add_course()" class="btn-uni-grad btn-snall no-left-margin" value="Add new option" />
+         </div>
+         <div v-else>
+             <p>
+                This Requisite requires Courses in the system. Please create Courses
+                <a href="#">here</a>
+                or bulk upload Courses
+                <a href="#">here</a>
+                first before creating this Requisite.
+            </p>
+         </div>
+
     </fieldset>
 </script>
 
 
 <script type="text/x-template" id="programRuleTemplate">
     <fieldset v-if="!redraw">
-        <p class="form-group">
-            <label>
-                Students must be studying the following program:
-            </label>
-        </p>
 
-        <div class="msg-error" v-if="is_blank">All options must be filled in!</div>
+        <div v-if="programs.length != 0">
+            <p class="form-group">
+                <label>Students must be studying the following program:</label>
+            </p>
 
-         <div>
-            <select v-model="details.program" v-on:change="check_options" required>
-                <option v-for="program in programs" v-bind:value="program">{{ program.code }} {{ program.name }}</option>
-            </select>
+            <div class="msg-error" v-if="is_blank">All options must be filled in!</div>
+
+            <div>
+                <select v-model="details.program" v-on:change="check_options" required>
+                    <option v-for="program in programs" v-bind:value="program">{{ program.code }} {{ program.name }}</option>
+                </select>
+            </div>
+        </div>
+        <div v-else>
+            <p>
+                This Requisite requires Programs in the system. Please create Programs
+                <a href="#">here</a>
+                first before creating this Requisite.
+            </p>
         </div>
 
     </fieldset>

--- a/cassdegrees/templates/widgets/staff/rulescripts.html
+++ b/cassdegrees/templates/widgets/staff/rulescripts.html
@@ -19,15 +19,7 @@
 
             <input type="button" v-on:click="add_course()" class="btn-uni-grad btn-snall no-left-margin" value="Add new option" />
          </div>
-         <div v-else>
-             <p>
-                This Requisite requires Courses in the system. Please create Courses
-                <a href="/staff/create/course/">here</a>
-                or bulk upload Courses
-                <a href="/staff/bulk_upload/">here</a>
-                first before creating this Requisite.
-            </p>
-         </div>
+         <div v-else v-html="info_msg"></div>
 
     </fieldset>
 </script>
@@ -49,13 +41,7 @@
                 </select>
             </div>
         </div>
-        <div v-else>
-            <p>
-                This Requisite requires Programs in the system. Please create Programs
-                <a href="/staff/create/program/">here</a>
-                first before creating this Requisite.
-            </p>
-        </div>
+        <div v-else v-html="info_msg"></div>
 
     </fieldset>
 </script>
@@ -91,13 +77,7 @@
 
             <input type="button" v-on:click="add_subplan()" class="btn-uni-grad btn-snall no-left-margin" value="Add new option" />
         </div>
-        <div v-else>
-            <p>
-                This Requisite requires Subplans in the system. Please create Subplans
-                <a href="/staff/create/subplan/">here</a>
-                first before creating this Requisite.
-            </p>
-        </div>
+        <div v-else v-html="info_msg"></div>
 
     </fieldset>
 </script>
@@ -135,15 +115,7 @@
 
             <input type="button" v-on:click="add_course()" class="btn-uni-grad btn-snall no-left-margin" value="Add new option" />
         </div>
-        <div v-else>
-            <p>
-                This Requisite requires Courses in the system. Please create Courses
-                <a href="/staff/create/course/">here</a>
-                or bulk upload Courses
-                <a href="/staff/bulk_upload/">here</a>
-                first before creating this Requisite.
-            </p>
-        </div>
+        <div v-else v-html="info_msg"></div>
 
     </fieldset>
 </script>
@@ -168,15 +140,7 @@
 
             <input type="button" v-on:click="add_course()" class="btn-uni-grad btn-snall no-left-margin" value="Add new option" />
         </div>
-        <div v-else>
-            <p>
-                This Requisite requires Courses in the system. Please create Courses
-                <a href="/staff/create/course/">here</a>
-                or bulk upload Courses
-                <a href="/staff/bulk_upload/">here</a>
-                first before creating this Requisite.
-            </p>
-        </div>
+        <div v-else v-html="info_msg"></div>
 
     </fieldset>
 </script>
@@ -204,15 +168,7 @@
                 subject area.
             </p>
         </div>
-        <div v-else>
-            <p>
-                This Requisite requires Courses in the system. Please create Courses
-                <a href="/staff/create/course/">here</a>
-                or bulk upload Courses
-                <a href="/staff/bulk_upload/">here</a>
-                first before creating this Requisite.
-            </p>
-        </div>
+        <div v-else v-html="info_msg"></div>
 
     </fieldset>
 </script>

--- a/cassdegrees/templates/widgets/staff/rulescripts.html
+++ b/cassdegrees/templates/widgets/staff/rulescripts.html
@@ -72,7 +72,6 @@
 
             <input type="button" v-on:click="add_subplan()" class="btn-uni-grad btn-snall no-left-margin" value="Add new option" />
         </div>
-
         <div v-else>
             <p>
                 There are currently no Subplans added to the system. Please create Subplans
@@ -117,7 +116,6 @@
 
             <input type="button" v-on:click="add_course()" class="btn-uni-grad btn-snall no-left-margin" value="Add new option" />
         </div>
-
         <div v-else>
             <p>
                 There are currently no courses added to the system. Please create courses
@@ -133,21 +131,34 @@
 
 <script type="text/x-template" id="courseRequisiteTemplate">
     <fieldset v-if="!redraw">
-        <div class="msg-error" v-if="non_unique_options">Options must be unique!</div>
-        <div class="msg-error" v-if="is_blank">All options must be filled in!</div>
 
-        <p>
-            Students must have completed the following courses:
-        </p>
+        <div v-if="courses.length != 0">
+            <div class="msg-error" v-if="non_unique_options">Options must be unique!</div>
+            <div class="msg-error" v-if="is_blank">All options must be filled in!</div>
 
-        <div v-for="(code, index) in details.codes">
-            <select v-model="details.codes[index]" v-on:change="check_options" required>
-                <option v-for="course in courses" v-bind:value="course.code">{{ course.code }} {{ course.name }}</option>
-            </select>
-            <input v-if="details.codes.length > 1" type="button" v-on:click="remove_course(index)" class="btn-uni-grad btn-snall no-left-margin" value="Remove" />
+            <p>
+                Students must have completed the following courses:
+            </p>
+
+            <div v-for="(code, index) in details.codes">
+                <select v-model="details.codes[index]" v-on:change="check_options" required>
+                    <option v-for="course in courses" v-bind:value="course.code">{{ course.code }} {{ course.name }}</option>
+                </select>
+                <input v-if="details.codes.length > 1" type="button" v-on:click="remove_course(index)" class="btn-uni-grad btn-snall no-left-margin" value="Remove" />
+            </div>
+
+            <input type="button" v-on:click="add_course()" class="btn-uni-grad btn-snall no-left-margin" value="Add new option" />
+        </div>
+        <div v-else>
+            <p>
+                There are currently no courses added to the system. Please create courses
+                <a href="#">here</a>
+                or bulk upload courses
+                <a href="#">here</a>
+                first before creating this rule.
+            </p>
         </div>
 
-        <input type="button" v-on:click="add_course()" class="btn-uni-grad btn-snall no-left-margin" value="Add new option" />
     </fieldset>
 </script>
 

--- a/cassdegrees/templates/widgets/staff/rulescripts.html
+++ b/cassdegrees/templates/widgets/staff/rulescripts.html
@@ -164,25 +164,37 @@
 
 <script type="text/x-template" id="electiveRuleTemplate">
     <fieldset v-if="!redraw">
-        <div class="msg-error" v-if="invalid_units">Unit count must be non-negative!</div>
-        <div class="msg-error" v-if="invalid_units_step">Unit count should be divisible by 6!</div>
-        <div class="msg-error" v-if="is_blank">All options must be filled in!</div>
 
-        <p>
-            Students must complete
-            <input style="margin-left: 0;" class="text" v-on:change="check_options" onkeydown="javascript: return checkKeys(event)" type="number" min="0" step="6" max="1000" v-model="details.unit_count" aria-required="true" required>
-            units from
-            <select v-model="details.year_level" required>
-                <option value="all" selected>All</option>
-                <option v-for="year_level in number_of_year_levels" v-bind:value="year_level*1000">{{ year_level*1000 }}-level</option>
-            </select>
-            electives in
-            <select v-model="details.subject_area" required>
-                <option value="all" selected>Any</option>
-                <option v-for="subject_area in subject_areas" v-bind:value="subject_area">{{ subject_area }}</option>
-            </select>
-            subject area.
-        </p>
+        <div v-if="subject_areas.length != 0">
+            <div class="msg-error" v-if="invalid_units">Unit count must be non-negative!</div>
+            <div class="msg-error" v-if="invalid_units_step">Unit count should be divisible by 6!</div>
+            <div class="msg-error" v-if="is_blank">All options must be filled in!</div>
+            <p>
+                Students must complete
+                <input style="margin-left: 0;" class="text" v-on:change="check_options" onkeydown="javascript: return checkKeys(event)" type="number" min="0" step="6" max="1000" v-model="details.unit_count" aria-required="true" required>
+                units from
+                <select v-model="details.year_level" required>
+                    <option value="all" selected>All</option>
+                    <option v-for="year_level in number_of_year_levels" v-bind:value="year_level*1000">{{ year_level*1000 }}-level</option>
+                </select>
+                electives in
+                <select v-model="details.subject_area" required>
+                    <option value="all" selected>Any</option>
+                    <option v-for="subject_area in subject_areas" v-bind:value="subject_area">{{ subject_area }}</option>
+                </select>
+                subject area.
+            </p>
+        </div>
+        <div v-else>
+            <p>
+                This Requisite requires Courses in the system. Please create Courses
+                <a href="#">here</a>
+                or bulk upload Courses
+                <a href="#">here</a>
+                first before creating this Requisite.
+            </p>
+        </div>
+
     </fieldset>
 </script>
 

--- a/cassdegrees/templates/widgets/staff/rulescripts.html
+++ b/cassdegrees/templates/widgets/staff/rulescripts.html
@@ -74,36 +74,48 @@
 
 <script type="text/x-template" id="courseRequirementTemplate">
     <fieldset v-if="!redraw">
-        <p class="form-group">
-            <label>
-                Students must select...
-            </label>
-        </p>
 
-        <select v-model="details.list_type" v-on:change="check_options" required>
-            <option v-for="(msg, type) in list_types" v-bind:value="type">{{ msg }}</option>
-        </select>
+        <div v-if="courses.length != 0">
+            <p class="form-group">
+                <label>Students must select...</label>
+            </p>
+
+            <select v-model="details.list_type" v-on:change="check_options" required>
+                <option v-for="(msg, type) in list_types" v-bind:value="type">{{ msg }}</option>
+            </select>
 
 <!-- {#       instyle css only temporary #} -->
-        <input style="margin-left: 0;" class="text" onkeydown="javascript: return checkKeys(event)" type="number" v-on:change="check_options" v-model="details.unit_count" min="0" step="6" max="1000" required> units
+            <input style="margin-left: 0;" class="text" onkeydown="javascript: return checkKeys(event)" type="number" v-on:change="check_options" v-model="details.unit_count" min="0" step="6" max="1000" required> units
 
-        <div class="msg-error" v-if="invalid_units">Unit count must be greater than 0!</div>
-        <div class="msg-error" v-if="invalid_units_step">Unit count should be divisible by 6!</div>
-        <div class="msg-error" v-if="non_unique_options">Options must be unique!</div>
-        <div class="msg-error" v-if="is_blank">All options must be filled in!</div>
+            <div class="msg-error" v-if="invalid_units">Unit count must be greater than 0!</div>
+            <div class="msg-error" v-if="invalid_units_step">Unit count should be divisible by 6!</div>
+            <div class="msg-error" v-if="non_unique_options">Options must be unique!</div>
+            <div class="msg-error" v-if="is_blank">All options must be filled in!</div>
 
-        <p>
-            from the following courses:
-        </p>
+            <p>
+                from the following courses:
+            </p>
 
-        <div v-for="(code, index) in details.codes">
-            <select v-model="details.codes[index]" v-on:change="check_options" required>
-                <option v-for="course in courses" v-bind:value="course.code">{{ course.code }} {{ course.name }}</option>
-            </select>
-            <input v-if="details.codes.length > 1" type="button" v-on:click="remove_course(index)" class="btn-uni-grad btn-snall no-left-margin" value="Remove" />
+            <div v-for="(code, index) in details.codes">
+                <select v-model="details.codes[index]" v-on:change="check_options" required>
+                    <option v-for="course in courses" v-bind:value="course.code">{{ course.code }} {{ course.name }}</option>
+                </select>
+                <input v-if="details.codes.length > 1" type="button" v-on:click="remove_course(index)" class="btn-uni-grad btn-snall no-left-margin" value="Remove" />
+            </div>
+
+            <input type="button" v-on:click="add_course()" class="btn-uni-grad btn-snall no-left-margin" value="Add new option" />
+        </div>
+        <div v-else>
+            <p>
+                There are currently no courses added to the system. Please create courses
+                <a href="#">here</a>
+                or bulk upload courses
+                <a href="#">here</a>
+                before creating this rule.
+            </p>
         </div>
 
-        <input type="button" v-on:click="add_course()" class="btn-uni-grad btn-snall no-left-margin" value="Add new option" />
+
     </fieldset>
 </script>
 

--- a/cassdegrees/templates/widgets/staff/rulescripts.html
+++ b/cassdegrees/templates/widgets/staff/rulescripts.html
@@ -45,7 +45,7 @@
 <script type="text/x-template" id="subplanRuleTemplate">
     <fieldset v-if="!redraw">
 
-        <div v-if="subplans.length == 0">
+        <div v-if="subplans.length != 0">
              <div class="msg-error" v-if="non_unique_options">Options must be unique!</div>
             <div class="msg-error" v-if="inconsistent_units">Options have different unit values!</div>
             <div class="msg-error" v-if="wrong_year_selected">Selected subplans must have same year as program!</div>

--- a/cassdegrees/templates/widgets/staff/subplanrules.html
+++ b/cassdegrees/templates/widgets/staff/subplanrules.html
@@ -11,35 +11,46 @@
 {% verbatim %}
 <script type="text/x-template" id="courseRequirementTemplate">
     <fieldset v-if="!redraw">
-        <p class="form-group">
-            <label>
-                Students must complete:
-            </label>
-        </p>
 
-        <select v-model="details.list_type" v-on:change="check_options" required>
-            <option v-for="(msg, type) in list_types" v-bind:value="type">{{ msg }}</option>
-        </select>
+        <div v-if="courses.length != 0">
+            <p class="form-group">
+                <label>Students must complete:</label>
+            </p>
+
+            <select v-model="details.list_type" v-on:change="check_options" required>
+                <option v-for="(msg, type) in list_types" v-bind:value="type">{{ msg }}</option>
+            </select>
 
 <!-- {#       instyle css only temporary #} -->
-        <input style="margin-left: 0;" class="text" onkeydown="javascript: return checkKeys(event)" type="number" v-on:change="check_options" v-model="details.unit_count" min="0" step="6" max="1000" required> units
+            <input style="margin-left: 0;" class="text" onkeydown="javascript: return checkKeys(event)" type="number" v-on:change="check_options" v-model="details.unit_count" min="0" step="6" max="1000" required> units
 
-        <div class="msg-error" v-if="invalid_units">Unit count must be greater than 0!</div>
-        <div class="msg-error" v-if="invalid_units_step">Unit count should be divisible by 6!</div>
-        <div class="msg-error" v-if="non_unique_options">Options must be unique!</div>
+            <div class="msg-error" v-if="invalid_units">Unit count must be greater than 0!</div>
+            <div class="msg-error" v-if="invalid_units_step">Unit count should be divisible by 6!</div>
+            <div class="msg-error" v-if="non_unique_options">Options must be unique!</div>
 
-        <p>
-            from the following courses:
-        </p>
+            <p>
+                from the following courses:
+            </p>
 
-        <div v-for="(code, index) in details.codes">
-            <select v-model="details.codes[index]" v-on:change="check_options" required>
-                <option v-for="course in courses" v-bind:value="course.code">{{ course.code }} {{ course.name }}</option>
-            </select>
-            <input v-if="details.codes.length > 1" type="button" v-on:click="remove_course(index)" class="btn-uni-grad btn-snall no-left-margin" value="Remove" />
+            <div v-for="(code, index) in details.codes">
+                <select v-model="details.codes[index]" v-on:change="check_options" required>
+                    <option v-for="course in courses" v-bind:value="course.code">{{ course.code }} {{ course.name }}</option>
+                </select>
+                <input v-if="details.codes.length > 1" type="button" v-on:click="remove_course(index)" class="btn-uni-grad btn-snall no-left-margin" value="Remove" />
+            </div>
+
+            <input type="button" v-on:click="add_course()" class="btn-uni-grad btn-snall no-left-margin" value="Add new option" />
+        </div>
+        <div v-else>
+            <p>
+                This Requisite requires Courses in the system. Please create Courses
+                <a href="#">here</a>
+                or bulk upload Courses
+                <a href="#">here</a>
+                first before creating this Requisite.
+            </p>
         </div>
 
-        <input type="button" v-on:click="add_course()" class="btn-uni-grad btn-snall no-left-margin" value="Add new option" />
     </fieldset>
 </script>
 


### PR DESCRIPTION
closes #338.

When a user is trying to add a rule/requisite/incompatibility that depends on say, courses, if there are no courses in the database, a message will pop up notifying the user that they need to created courses first before they can create the rule/requisite/incompatibility they're planning to create. This was implemented with all the rules/requisites/incompatibilities in mind (using vue.js).
Eg.
**No Programs**
![image](https://user-images.githubusercontent.com/24206502/64868704-3634ca80-d683-11e9-8f43-0eb9f29e21ca.png)
**At least one Program**
![image](https://user-images.githubusercontent.com/24206502/64868786-5b293d80-d683-11e9-8a54-724ef6af7ca6.png)

