### PR TITLE
Implement confirmation box for saving non-public programs/subplans

### DIFF
--- a/cassdegrees/templates/staff/creation/createprogram.html
+++ b/cassdegrees/templates/staff/creation/createprogram.html
@@ -111,6 +111,13 @@
 
         function submit_form(form_action, redirect) {
             if (handleProgram() && handleRules()) {
+                // Ensure that the course has been agreed to to being non public on submission.
+                if (!document.getElementById("id_publish").checked &&
+                    !confirm("You haven't marked this program as public - this means this won't appear " +
+                        "to students or be selectable as a requirement elsewhere.\n\nAre you sure you want to continue?")) {
+                    return false;
+                }
+
                 document.getElementById('mainForm').action.value = form_action;
                 document.getElementById('redirect').value = redirect;
                 document.getElementById('mainForm').submit();

--- a/cassdegrees/templates/staff/creation/createsubplan.html
+++ b/cassdegrees/templates/staff/creation/createsubplan.html
@@ -78,6 +78,13 @@
 
         function submit_form(redirect) {
             if (handleRules()) {
+                // Ensure that the course has been agreed to to being non public on submission.
+                if (!document.getElementById("id_publish").checked &&
+                    !confirm("You haven't marked this subplan as public - this means this won't appear " +
+                        "to students or be selectable as a requirement elsewhere. Are you sure you want to continue?")) {
+                    return false;
+                }
+
                 document.getElementById('redirect').value = redirect;
                 document.getElementById('mainForm').submit();
             }


### PR DESCRIPTION
Closes #321.

This PR implements a simple confirmation box on the submission of programs/subplans to confirm the user's decision to save the respective plan as non-public. A browser confirmation was chosen as it is both blocking (the window is non-interactive otherwise) as well as mutable with built-in ways to manage that.

Screenshot (Firefox 71.0a1):
![public-notification](https://user-images.githubusercontent.com/1404334/64920385-a12af200-d7a6-11e9-9a11-702722564adb.png)
