### PR TITLE
Verify that plan links exist when setting up a popup

### DIFF
--- a/cassdegrees/static/js/student/edit.js
+++ b/cassdegrees/static/js/student/edit.js
@@ -55,6 +55,7 @@ function setupPopup() {
         return;
     }
 
+    // Plan link implies these:
     var copy = document.getElementById("copy_to_clipboard");
     var close = document.getElementById("close_modal");
 

--- a/cassdegrees/static/js/student/edit.js
+++ b/cassdegrees/static/js/student/edit.js
@@ -49,6 +49,12 @@ function searchQuery(query) {
 // Script to allow interactivity in the popup menu
 function setupPopup() {
     var plan_link = document.getElementById("plan_link");
+
+    // Ensure that plan links exist before trying to inject event handlers
+    if (plan_link === undefined) {
+        return;
+    }
+
     var copy = document.getElementById("copy_to_clipboard");
     var close = document.getElementById("close_modal");
 


### PR DESCRIPTION
Closes #304.

This adds a safety check to ensure that popups on the student facing system (e.g. for generating a sharing link) are set up correctly, and their handlers aren't injected if their respective elements don't exist.

This already appears to be masked by #298, but for sake of safety a type check has been added to ensure that this isn't an issue even if this does end up getting called during execution.