### PR TITLE
Fixed cancel button redirects

### DIFF
--- a/cassdegrees/templates/staff/creation/createcourse.html
+++ b/cassdegrees/templates/staff/creation/createcourse.html
@@ -63,7 +63,7 @@
 
     <p class="text-right">
         <input class="btn-uni-grad btn-large" type="button" value="Cancel"
-               onclick="{% if edit %}returnToList('Course'){% else %}goBack(){% endif %}">
+               onclick="{% if edit or 'list' in request.META.HTTP_REFERER %}returnToList('Course'){% else %}goBack(){% endif %}">
         {% if edit %}
             <input class="btn-uni-grad btn-large" type="submit" value="Save"
                onclick="submit_form(this.value, false)">

--- a/cassdegrees/templates/staff/creation/createlist.html
+++ b/cassdegrees/templates/staff/creation/createlist.html
@@ -65,7 +65,7 @@
         <input class="left btn-uni-grad btn-large" type="button" value="New Course"
                onclick="toggleCourseCreationPopup()">
         <input class="btn-uni-grad btn-large" type="button" value="Cancel"
-               onclick="{% if edit %}returnToList('Course'){% else %}goBack(){% endif %}">
+               onclick="{% if edit or 'list' in request.META.HTTP_REFERER %}returnToList('Course'){% else %}goBack(){% endif %}">
         {% if edit %}
             <input class="btn-uni-grad btn-large" type="submit" value="Save"
                    onclick="submit_form(this.value, false)">

--- a/cassdegrees/templates/staff/creation/createprogram.html
+++ b/cassdegrees/templates/staff/creation/createprogram.html
@@ -92,7 +92,7 @@
     </p>
     <p class="right text-right">
         <input class="btn-uni-grad btn-large" type="button" value="Cancel"
-               onclick="{% if edit %}returnToList('Program'){% else %}goBack(){% endif %}">
+               onclick="{% if edit or 'list' in request.META.HTTP_REFERER %}returnToList('Program'){% else %}goBack(){% endif %}">
         {% if edit %}
             <input class="btn-uni-grad btn-large" type="submit" value="Save"
                onclick="submit_form(this.value, false)">

--- a/cassdegrees/templates/staff/creation/createsubplan.html
+++ b/cassdegrees/templates/staff/creation/createsubplan.html
@@ -59,7 +59,7 @@
         <input class="left btn-uni-grad btn-large" type="button" value="New Course"
                onclick="toggleCourseCreationPopup()">
         <input class="btn-uni-grad btn-large" type="button" value="Cancel"
-               onclick="{% if edit %}returnToList('Subplan'){% else %}goBack(){% endif %}">
+               onclick="{% if edit or 'list' in request.META.HTTP_REFERER %}returnToList('Subplan'){% else %}goBack(){% endif %}">
         {% if edit %}
             <input class="btn-uni-grad btn-large" type="submit" value="Save"
                onclick="submit_form(false)">


### PR DESCRIPTION
Issue #342 

Cancel Button will now redirect to the relevant lists page if the user came from the lists page.
The button will still redirect to the main page if the user pressed the create buttons on the main page.

This was simply done by checking if the URL the user came from was the lists page. This means if the user types the URL or comes from somewhere else it will still default to the homepage if not the lists page.