### PR TITLE
OR Rule Unit Notification

### DIFF
--- a/cassdegrees/templates/widgets/staff/rules.html
+++ b/cassdegrees/templates/widgets/staff/rules.html
@@ -12,6 +12,12 @@
 {% verbatim %}
 <script type="text/x-template" id="eitherOrTemplate">
     <div v-if="!redraw">
+        <div class="msg-warn" v-if="large_unit_count">
+            You have created an OR rule that contains more than 48 units. Please check <i>Programs and Courses</i> to ensure
+            you have correctly implemented the rules, and try to reduce the number of units in each OR block if possible.
+        </div>
+        <br v-if="large_unit_count" />
+
         <div class="box bdr-solid bdr-uni" v-for="(item, i) in details.either_or" :key="i">
             <fieldset id="orRulesContainer">
                 <legend>Group {{ i + 1 }}</legend>

--- a/cassdegrees/templates/widgets/staff/rules.html
+++ b/cassdegrees/templates/widgets/staff/rules.html
@@ -13,7 +13,7 @@
 <script type="text/x-template" id="eitherOrTemplate">
     <div v-if="!redraw">
         <div class="msg-warn" v-if="large_unit_count">
-            You have created an OR rule that contains more than 48 units. Please check <i>Programs and Courses</i> to ensure
+            You have created an OR group that contains more than 48 units. Please check <i>Programs and Courses</i> to ensure
             you have correctly implemented the rules, and try to reduce the number of units in each OR block if possible.
         </div>
         <br v-if="large_unit_count" />

--- a/cassdegrees/templates/widgets/staff/rulescripts.html
+++ b/cassdegrees/templates/widgets/staff/rulescripts.html
@@ -95,7 +95,7 @@
             </select>
 
 <!-- {#       instyle css only temporary #} -->
-            <input style="margin-left: 0;" class="text" onkeydown="javascript: return checkKeys(event)" type="number" v-on:change="check_options" v-model="details.unit_count" min="0" step="6" max="1000" required> units
+            <input style="margin-left: 0;" class="text" onkeydown="javascript: return checkKeys(event)" type="number" v-on:change="update_units" v-model="details.unit_count" min="0" step="6" max="1000" required> units
 
             <div class="msg-error" v-if="invalid_units">Unit count must be greater than 0!</div>
             <div class="msg-error" v-if="invalid_units_step">Unit count should be divisible by 6!</div>
@@ -154,7 +154,7 @@
             <div class="msg-error" v-if="is_blank">All options must be filled in!</div>
             <p>
                 Students must complete
-                <input style="margin-left: 0;" class="text" v-on:change="check_options" onkeydown="javascript: return checkKeys(event)" type="number" min="0" step="6" max="1000" v-model="details.unit_count" aria-required="true" required>
+                <input style="margin-left: 0;" class="text" v-on:change="update_units" onkeydown="javascript: return checkKeys(event)" type="number" min="0" step="6" max="1000" v-model="details.unit_count" aria-required="true" required>
                 units from
                 <select v-model="details.year_level" required>
                     <option value="all" selected>All</option>
@@ -187,7 +187,7 @@
 
         <p class="form-group">
             <label>Unit value for this item:</label>
-            <input class="text" v-on:change="check_options" onkeydown="javascript: return checkKeys(event)" type="number" min="0" max="1000" v-model="details.units" aria-required="true" required>
+            <input class="text" v-on:change="update_units" onkeydown="javascript: return checkKeys(event)" type="number" min="0" max="1000" v-model="details.unit_count" aria-required="true" required>
         </p>
 
         <div class="msg-error" v-if="not_divisible">Units must be divisible by 6!</div>


### PR DESCRIPTION
This PR closes #293 

After reviewing the UAT video and making a BARTS program myself, I realised that the problems Andrew had when creating the program was that he added too many units in the OR rules. This meant he needed to add 8 different OR rules with 96 units, rather than only 3 or rules as can be seen in [BARTS P&C](https://programsandcourses.anu.edu.au/2019/program/BARTS). I decided it was better to keep the one-layered OR rules as if it gets any more complex then the user is probably implementing it wrong. 

Therefore, to try and fix this issue in future, if the user creates an OR rule that contains more than 48 units (1 major) a warning will appear suggesting they check P&C to follow the rules there. This PR also opens the door for verification further down the track.

![Screen Shot 2019-09-17 at 6 13 10 pm](https://user-images.githubusercontent.com/36946090/65024466-49dc7b80-d978-11e9-930a-56fdf3c7e62a.jpg)
