### PR TITLE
Unique Course Rule Identifiers

### DIFF
--- a/cassdegrees/static/js/staff/rules.js
+++ b/cassdegrees/static/js/staff/rules.js
@@ -506,7 +506,7 @@ Vue.component('rule_course', {
             if (!(rule.details.codes.length === 0)) {
                 for (let i = 0; i < rule.details.codes.length; i++){
                     for (let x = 0; x < rule.courses.length; x++){
-                        if (rule.courses[x].code === rule.details.codes[i]) {
+                        if (rule.courses[x].code === rule.details.codes[i]['code']) {
                             rule.courses.splice(x, 1).forEach(course => {
                                 rule.selected_courses.push(course)
                             });
@@ -597,7 +597,7 @@ Vue.component('rule_course', {
                     list.elements.forEach((course) => {
                         // add course code to details.codes if not already present
                         if (!this.details.codes.some(code => code === course.code)) {
-                            this.details.codes.push(course.code)
+                            this.details.codes.push({'code': resource.code, 'name': resource.name})
                         }
 
                         // if a course is added through a list, remove it from the temporary store of courses
@@ -620,12 +620,12 @@ Vue.component('rule_course', {
                     // Adds selected resources to array and prevents duplicates
                     if (!this.details.codes.some(code => code === resource.code)) {
                         this.selected_courses.push(resource)
-                        this.details.codes.push(resource.code)
+                        this.details.codes.push({'code': resource.code, 'name': resource.name});
                     }
                     // remove the selected course from the list of available courses to add
                     let resourceID = this.courses.indexOf(resource)
                     this.courses.splice(resourceID, 1)
-                })
+                });
             }
 
             // Clear options proxy to avoid selection tags from being displayed
@@ -643,7 +643,7 @@ Vue.component('rule_course', {
 
                 // find and remove code from details.codes
                 for (let i = 0; i < this.details.codes.length; i++){
-                    if (course.code === this.details.codes[i]){
+                    if (course.code === this.details.codes[i]['code']){
                         this.details.codes.splice(i, 1);
                         break;
                     }

--- a/cassdegrees/templates/staff/view/viewcourse.html
+++ b/cassdegrees/templates/staff/view/viewcourse.html
@@ -118,11 +118,11 @@
                         Incompatible with
                         {% for course in rule.incompatible_courses %}
                             {% if forloop.revcounter == 1 %}{# Last #}
-                                {{ course }}
+                                {{ course.code }}
                             {% elif forloop.revcounter == 2 %}{# Second-Last #}
-                                {{ course }} and
+                                {{ course.code }} and
                             {% else %}{# Otherwise #}
-                                {{ course }},
+                                {{ course.code }},
                             {% endif %}
                         {% endfor %}
                     </p>
@@ -148,11 +148,11 @@
                         Students must have completed
                         {% for course in rule.codes %}
                             {% if forloop.revcounter == 1 %}{# Last #}
-                                {{ course }}
+                                {{ course.code }}
                             {% elif forloop.revcounter == 2 %}{# Second-Last #}
-                                {{ course }} and
+                                {{ course.code }} and
                             {% else %}{# Otherwise #}
-                                {{ course }},
+                                {{ course.code }},
                             {% endif %}
                         {% endfor %}
                     </p>

--- a/cassdegrees/templates/widgets/pdf_rules.html
+++ b/cassdegrees/templates/widgets/pdf_rules.html
@@ -33,7 +33,7 @@
                     {# Not all required courses - give descriptions #}
                     <p>Complete {{ rule.unit_count }} units from a selection of:</p>
                     {% for code in rule.codes %}
-                        {{ code }}{% if not forloop.last %}, {% endif %}
+                        {{ code.code }}{% if not forloop.last %}, {% endif %}
                     {% endfor %}
                 {% endif %}
             {% endwith %}

--- a/cassdegrees/templates/widgets/staff/rulescripts.html
+++ b/cassdegrees/templates/widgets/staff/rulescripts.html
@@ -12,7 +12,9 @@
 
             <div v-for="(code, index) in details.incompatible_courses">
                 <select v-model="details.incompatible_courses[index]" v-on:change="check_options" required>
-                    <option v-for="course in courses" v-bind:value="course.code">{{ course.code }} {{ course.name }}</option>
+                    <option v-for="course in courses" v-bind:value="{'code': course.code, 'name': course.name}">
+                        {{ course.code }} {{ course.name }}
+                    </option>
                 </select>
                 <input v-if="details.incompatible_courses.length > 1" type="button" v-on:click="remove_course(index)" class="btn-uni-grad btn-snall no-left-margin" value="Remove" />
             </div>
@@ -108,7 +110,9 @@
 
             <div v-for="(code, index) in details.codes">
                 <select v-model="details.codes[index]" v-on:change="check_options" required>
-                    <option v-for="course in courses" v-bind:value="course.code">{{ course.code }} {{ course.name }}</option>
+                    <option v-for="course in courses" v-bind:value="{'code': course.code, 'name': course.name}">
+                        {{ course.code }} {{ course.name }}
+                    </option>
                 </select>
                 <input v-if="details.codes.length > 1" type="button" v-on:click="remove_course(index)" class="btn-uni-grad btn-snall no-left-margin" value="Remove" />
             </div>
@@ -133,7 +137,9 @@
 
             <div v-for="(code, index) in details.codes">
                 <select v-model="details.codes[index]" v-on:change="check_options" required>
-                    <option v-for="course in courses" v-bind:value="course.code">{{ course.code }} {{ course.name }}</option>
+                    <option v-for="course in courses" v-bind:value="{'code': course.code, 'name': course.name}">
+                        {{ course.code }} {{ course.name }}
+                    </option>
                 </select>
                 <input v-if="details.codes.length > 1" type="button" v-on:click="remove_course(index)" class="btn-uni-grad btn-snall no-left-margin" value="Remove" />
             </div>

--- a/cassdegrees/templates/widgets/staff/subplanrules.html
+++ b/cassdegrees/templates/widgets/staff/subplanrules.html
@@ -34,7 +34,9 @@
 
             <div v-for="(code, index) in details.codes">
                 <select v-model="details.codes[index]" v-on:change="check_options" required>
-                    <option v-for="course in courses" v-bind:value="course.code">{{ course.code }} {{ course.name }}</option>
+                    <option v-for="course in courses" v-bind:value="{'code': course.code, 'name': course.name}">
+                        {{ course.code }} {{ course.name }}
+                    </option>
                 </select>
                 <input v-if="details.codes.length > 1" type="button" v-on:click="remove_course(index)" class="btn-uni-grad btn-snall no-left-margin" value="Remove" />
             </div>

--- a/cassdegrees/ui/templatetags/course_boxes.py
+++ b/cassdegrees/ui/templatetags/course_boxes.py
@@ -37,7 +37,7 @@ def course_box_with_values(context, count, courses, plan):
             course_name = None
 
         if course_name is None:
-            course_name = courses[i]
+            course_name = courses[i]['code']
 
         output += "<div class=\"box grey-box\"><span class=\"grey-text\">Course #" + str(i + 1) + ":</span> " \
                   + course_name + "</div>"

--- a/cassdegrees/ui/templatetags/student_course_boxes.py
+++ b/cassdegrees/ui/templatetags/student_course_boxes.py
@@ -33,9 +33,9 @@ def student_course_box_with_values(context, count, courses):
 
     for i in range(iters):
         output += "<div class=\"card selectable-card\">" \
-                  "<div data-course-code=\"" + courses[i] + "\" class=\"box-solid course-drop dropzone\">" \
+                  "<div data-course-code=\"" + courses[i]['code'] + "\" class=\"box-solid course-drop dropzone\">" \
                   "<span class=\"grey-text\">Course #" + str(i + 1) + ":&nbsp;</span>" \
-                  "<span class=\"course-code\">" + courses[i] + "</span>" \
+                  "<span class=\"course-code\">" + courses[i]['code'] + "</span>" \
                   "</div>" \
                   "</div>"
 

--- a/cassdegrees/ui/views/staff/view.py
+++ b/cassdegrees/ui/views/staff/view.py
@@ -46,9 +46,12 @@ def pretty_print_rules(program):
                     gen_request = HttpRequest()
                     gen_request.GET = {'select': 'code,name,units', 'from': 'course'}
                     rule['courses'] = []
-                    for code in rule['codes']:
+                    for course in rule['codes']:
+                        code = course['code']
+                        name = course['name']
                         # Add a new field containing the courses that match the given code
                         gen_request.GET['code_exact'] = code
+                        gen_request.GET['name_exact'] = name
                         courses = json.loads(search(gen_request).content.decode())
                         rule['courses'] += courses
 
@@ -79,8 +82,11 @@ def view_section(request):
         for rule in subplan['rules']:
             # Add a new field containing the courses that match the given code
             rule['courses'] = []
-            for code in rule['codes']:
+            for course in rule['codes']:
+                code = course['code']
+                name = course['name']
                 gen_request.GET['code_exact'] = code
+                gen_request.GET['name_exact'] = name
                 courses = json.loads(search(gen_request).content.decode())
                 rule['courses'] += courses
 


### PR DESCRIPTION
Closes #266.

This PR actually ended up addressing a large issue to solve the minor view issue as described in the original issue.

The existing model only saves the course codes for a list of course requirements (or requisites or incompatibilities), which means that if there are two courses with the same code and different names (which our interface allows), then the courses will be conflated. 

If you create two courses with the same course code and different names and then attempt to select both rules in a course rule, you will find you can only select one. And when you view the program it will display both rules when only one was selected.

This PR 'simply' updates it to store the code and name of courses for such rules, and refactors the program to account for this. I've updated the pointers in PDF generation, view pages, other rules, and the student website, but it's possible I may have missed one.