### PR TITLE
Uat delete lists

### DIFF
--- a/cassdegrees/templates/staff/creation/createlist.html
+++ b/cassdegrees/templates/staff/creation/createlist.html
@@ -65,7 +65,7 @@
         <input class="left btn-uni-grad btn-large" type="button" value="New Course"
                onclick="toggleCourseCreationPopup()">
         <input class="btn-uni-grad btn-large" type="button" value="Cancel"
-               onclick="{% if edit or 'list' in request.META.HTTP_REFERER %}returnToList('Course'){% else %}goBack(){% endif %}">
+               onclick="{% if edit or 'list' in request.META.HTTP_REFERER %}returnToList('List'){% else %}goBack(){% endif %}">
         {% if edit %}
             <input class="btn-uni-grad btn-large" type="submit" value="Save"
                    onclick="submit_form(this.value, false)">

--- a/cassdegrees/templates/staff/delete/deletelists.html
+++ b/cassdegrees/templates/staff/delete/deletelists.html
@@ -1,0 +1,40 @@
+{% extends "base.html" %}
+{% load static %}
+{% load breadcrumbs %}
+
+{% block page-title %}Delete Course List{% endblock %}
+
+{% block breadcrumb-trail %}
+    {% breadcrumb '/staff/' 'Staff Home'%}
+    {% breadcrumb '/staff/list/?view=List' 'Programs/Subplans/Courses' %}
+    {% finalcrumb 'Delete List' %}
+{% endblock %}
+
+{% block subtitle %}Are you sure?{% endblock %}
+
+{% block content %}
+    <form class="anuform" action="" method="post">
+        {% csrf_token %}
+
+        <fieldset>
+            <p>Deleting these lists will mean they are no longer available to bulk add courses to templates.
+                It will not affect templates already containing these lists.</p>
+            <p>Are you sure you want to delete:</p>
+            {% for instance in instances %}
+                <p>
+                    {{ instance.name }} {{ instance.year }}
+                </p>
+                <input type="number" hidden value="{{ instance.id }}" name="id" />
+            {% endfor %}
+        </fieldset>
+
+        <input type="hidden" value="confirm" name="confirm" />
+
+        <p class="text-right">
+            <input class="btn-uni-grad btn-large" type="button" value="Cancel" onclick="returnToList('List')">
+            <input class="btn-uni-grad btn-large" type="submit" value="Delete">
+        </p>
+    </form>
+
+    <script src="{% static 'js/main.js' %}" type="application/javascript"></script>
+{% endblock %}

--- a/cassdegrees/ui/urls.py
+++ b/cassdegrees/ui/urls.py
@@ -43,6 +43,7 @@ urlpatterns = [
     path(staff_url_prefix + 'delete/courses/', delete_course),
     path(staff_url_prefix + 'delete/programs/', delete_program),
     path(staff_url_prefix + 'delete/subplans/', delete_subplan),
+    path(staff_url_prefix + 'delete/lists/', delete_list),
     path(staff_url_prefix + 'edit/course/', edit_course, name='edit_course'),
     path(staff_url_prefix + 'edit/program/', edit_program, name='edit_program'),
     path(staff_url_prefix + 'edit/subplan/', edit_subplan, name='edit_subplan'),

--- a/cassdegrees/ui/views/staff/lists.py
+++ b/cassdegrees/ui/views/staff/lists.py
@@ -60,7 +60,29 @@ def create_list(request):
     })
 
 
-# Todo: implement list deletion with associated business rules (if any)
+# Delete list(s) selected through the admin list page. Lists are mutable collections used to bulk add courses to plans.
+# As such, deleting or editing a list through the admin page will have no effect on existing plans containing that list
+@login_required
+def delete_list(request):
+    data = request.POST
+    instances = []
+
+    ids_to_delete = data.getlist('id')
+    if not ids_to_delete:
+        return redirect(list_course_group_url + '&error=Please select a List to delete!')
+    for id_to_delete in ids_to_delete:
+        instances.append(ListModel.objects.get(id=int(id_to_delete)))
+
+    if "confirm" in data:
+        for instance in instances:
+            instance.delete()
+
+        return redirect(list_course_group_url + '&msg=Successfully Deleted List(s)!')
+    else:
+        return render(request, 'staff/delete/deletelists.html', context={
+            "instances": instances
+        })
+
 
 
 @login_required

--- a/cassdegrees/ui/views/staff/lists.py
+++ b/cassdegrees/ui/views/staff/lists.py
@@ -112,7 +112,6 @@ def edit_list(request):
             # POST Requests only carry boolean values over as string
             # Only redirect the user to the list page if the user presses "Save and Exit".
             # Otherwise, simply display a success message on the same page.
-            # todo: implement list view for admin page then change url
             if request.POST.get('redirect') == 'true':
                 return redirect(list_course_group_url + '&msg=Successfully Edited List!')
             else:


### PR DESCRIPTION
Implementation of list deletion.

Expected functionality: allow a user to delete lists contained in the database. On deletion, these lists should no longer be available for selection.

Out of scope: deletion results in the deletion of the list from plans which may contain it. Lists are mutable collections of courses use to bulk add requirements to plans. Plans themselves do not contain a reference to the lists, and have their own local collections of courses.

![image](https://user-images.githubusercontent.com/10462891/65102431-60351680-da0e-11e9-9ca1-6789d04e8539.png)

![image](https://user-images.githubusercontent.com/10462891/65102438-6925e800-da0e-11e9-8d9e-499c664b0102.png)
