### PR TITLE
Checking filetype of uploaded file for bulk uploading

### DIFF
--- a/cassdegrees/ui/views/staff/bulk_data_upload.py
+++ b/cassdegrees/ui/views/staff/bulk_data_upload.py
@@ -24,6 +24,7 @@ from django.shortcuts import render
 # the % sign in a new cell in that row).
 
 # Support is available for CASS' custom teaching plan excel file.
+import os
 
 
 @login_required
@@ -41,6 +42,18 @@ def bulk_data_upload(request):
         # Open file in text mode:
         # https://stackoverflow.com/questions/16243023/how-to-resolve-iterator-should-return-strings-not-bytes
         raw_uploaded_file = request.FILES['uploaded_file']
+        file_type = os.path.splitext(str(raw_uploaded_file))[1]
+
+        # Put the supported file extensions in this list
+        supported_file_types = {"xlsx", "xls", "csv"}
+
+        if file_type not in supported_file_types:
+            context['user_msg'] = "Failed to upload file... " \
+                                  "File format '" + file_type + "' is not supported! <br>" \
+                                  "Please make sure the file extension and contents are correct."
+            context['err_type'] = "error"
+            return render(request, 'staff/bulkupload.html', context=context)
+
         uploaded_file = TextIOWrapper(raw_uploaded_file, encoding=request.encoding)
 
         # First row contains the column type headings (code, name etc). We can't add them to the db.

--- a/cassdegrees/ui/views/staff/bulk_data_upload.py
+++ b/cassdegrees/ui/views/staff/bulk_data_upload.py
@@ -45,7 +45,7 @@ def bulk_data_upload(request):
         file_type = os.path.splitext(str(raw_uploaded_file))[1]
 
         # Put the supported file extensions in this list
-        supported_file_types = {"xlsx", "xls", "csv"}
+        supported_file_types = [".xlsx", ".xls", ".csv"]
 
         if file_type not in supported_file_types:
             context['user_msg'] = "Failed to upload file... " \


### PR DESCRIPTION
Addressed the issue [Error When Bulk Uploading Invalid File Types] #370 

The issue was caused by TextIOWrapper function not accepting some encodings like images and videos.

Fixed this by checking the file extension before we parse the file into the wrapper. 
Since there is sanity checking later in the code, there isn't a need to verify the contents since its already done.

This was a simple fix to the issue. I am aware that if someone named an image file .xls or csv it could potentially still crash the wrapper - however, I don't believe CASS is this malicious so its not worth the effort as of now. 