### PR TITLE
Implement view page for lists and correct course_creation_form error …

### DIFF
--- a/cassdegrees/templates/staff/view/viewlist.html
+++ b/cassdegrees/templates/staff/view/viewlist.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+{% load static %}
+{% load breadcrumbs %}
+
+{% block page-title %}{{ data.name }} ({{ data.year }}){% endblock %}
+
+{% block subtitle %}{{ data.name }} ({{ data.year }}){% endblock %}
+
+{% block breadcrumb-trail %}
+    {% breadcrumb '/staff/' 'Staff Home'%}
+    {% breadcrumb '/staff/list/?view=Program' 'Programs/Subplans/Courses' %}
+    {% finalcrumb 'View List' %}
+{% endblock %}
+
+{% block content %}
+    <div>
+        <h3>Courses in list:</h3>
+        {# Displays all of the lists courses in a table #}
+
+        <table class="fullwidth tbl-cell-bdr">
+            <tr>
+                <th>Code</th>
+                <th>Title</th>
+            </tr>
+            {% for course in data.elements %}
+                <tr>
+                    <td>{{ course.code }}</td>
+                    <td>{{ course.name }}</td>
+                </tr>
+            {% endfor %}
+        </table>
+    </div>
+
+    <p class="text-left">Last Updated: {{ data.lastUpdated }}</p>
+
+{% endblock %}

--- a/cassdegrees/ui/urls.py
+++ b/cassdegrees/ui/urls.py
@@ -52,5 +52,6 @@ urlpatterns = [
     path(staff_url_prefix + 'view/program/', view_section),
     path(staff_url_prefix + 'view/subplan/', view_section),
     path(staff_url_prefix + 'view/course/', view_section),
+    path(staff_url_prefix + 'view/list/', view_section),
     path(staff_url_prefix + 'pdf/program/', view_program_pdf),
 ]

--- a/cassdegrees/ui/views/staff/lists.py
+++ b/cassdegrees/ui/views/staff/lists.py
@@ -26,6 +26,9 @@ def create_list(request):
     # Initialise instance with an empty string so that we don't get a "may be referenced before assignment" error below
     instance = ""
 
+    # Initiatlise form
+    course_creation_form = handle_course_subform()
+
     # If we are creating a list from a duplicate, we retrieve the instance with the given id
     # (should always come along with 'duplicate' variable) and return that data to the user.
     if duplicate:

--- a/cassdegrees/ui/views/staff/view.py
+++ b/cassdegrees/ui/views/staff/view.py
@@ -100,4 +100,3 @@ def view_section(request):
         cList = model_to_dict(ListModel.objects.get(id=int(id_to_edit)))
 
         return render(request, 'staff/view/viewlist.html', context={'data': cList})
-

--- a/cassdegrees/ui/views/staff/view.py
+++ b/cassdegrees/ui/views/staff/view.py
@@ -2,7 +2,7 @@ from django.shortcuts import render
 from django.forms.models import model_to_dict
 from django.http import HttpRequest
 
-from api.models import CourseModel, ProgramModel, SubplanModel
+from api.models import CourseModel, ProgramModel, SubplanModel, ListModel
 from api.views import search
 import json
 
@@ -93,3 +93,11 @@ def view_section(request):
         pretty_print_rules(program)
 
         return render(request, 'staff/view/viewprogram.html', context={'data': program})
+
+    # ListModel(id, name, year, elements, lastupdated)
+    elif "list" in url:
+        # ListModel.elements already contains the code and name of each unit in the list
+        cList = model_to_dict(ListModel.objects.get(id=int(id_to_edit)))
+
+        return render(request, 'staff/view/viewlist.html', context={'data': cList})
+


### PR DESCRIPTION
…in createList which was leading to crash on attempting to make list with same name and year.

Addresses #365 

View page implemented for lists.

Bug appeared to be a result of uninitialised course_creation_form short-circuiting the error message for uniqueness. All lists must have a unique name, year combination. Expected behaviour on violation is error message to user.

![image](https://user-images.githubusercontent.com/10462891/65364995-1ee47700-dc59-11e9-9ec7-14132b26dd63.png)
