### PR TITLE
Add verification for plan and subplan vue rules

### DIFF
--- a/cassdegrees/static/js/staff/rules.js
+++ b/cassdegrees/static/js/staff/rules.js
@@ -83,6 +83,12 @@ const SUBPLAN_TYPES = {
     'SPEC': 'Specialisations'
 };
 
+const SUBPLAN_UNITS = {
+    'MAJ':  48,
+    'MIN':  24,
+    'SPEC': 24
+};
+
 const INFO_MSGS = {
     'course': '<p>This Requisite requires Courses in the system. Please create Courses ' +
         '<a href="/staff/create/course/" target="_blank">here</a> or bulk upload Courses ' +
@@ -413,12 +419,11 @@ Vue.component('rule_subplan', {
             return !this.wrong_year_selected && !this.non_unique_options && !this.inconsistent_units &&  !this.is_blank;
         },
         count_units: function() {
-            switch (this.details.subplan_type) {
-                case "MAJ" : return {"exact": 48, "max": 0, "min": 0};
-                case "MIN" : return {"exact": 24, "max": 0, "min": 0};
-                case "SPEC": return {"exact": 24, "max": 0, "min": 0};
-                default:     return {"exact":  0, "max": 0, "min": 0};
-            }
+            var units = SUBPLAN_UNITS[this.details.subplan_type];
+            if (units)
+                return {"exact": units, "max": 0, "min": 0};
+            else
+                return {"exact":  0, "max": 0, "min": 0};
         },
         update_units: function() {
             // To be called whenever the unit count is updated. Will ask the OR rule to re-evaluate the unit count

--- a/cassdegrees/static/js/staff/rules.js
+++ b/cassdegrees/static/js/staff/rules.js
@@ -311,8 +311,8 @@ Vue.component('rule_subplan', {
         // Modifies the original 'id_year' element by telling it to refresh all components on all keystrokes
         document.getElementById('id_year').setAttribute("oninput", "redrawVueComponents()");
 
-        // Keep a copy of the OR Rule's "count_units" function (Or a blank function if unavailable)
-        this.parent_count_units_fn = this.$parent.get_or_rule_count_units_fn();
+        // Keep a copy of the OR Rule's "update_units" function (Or a blank function if unavailable)
+        this.parent_update_units_fn = this.$parent.get_or_rule_update_units_fn();
     },
     methods: {
         apply_subplan_filter: function(){
@@ -412,9 +412,17 @@ Vue.component('rule_subplan', {
 
             return !this.wrong_year_selected && !this.non_unique_options && !this.inconsistent_units &&  !this.is_blank;
         },
+        count_units: function() {
+            switch (this.details.subplan_type) {
+                case "MAJ" : return {"exact": 48, "max": 0, "min": 0};
+                case "MIN" : return {"exact": 24, "max": 0, "min": 0};
+                case "SPEC": return {"exact": 24, "max": 0, "min": 0};
+                default:     return {"exact":  0, "max": 0, "min": 0};
+            }
+        },
         update_units: function() {
             // To be called whenever the unit count is updated. Will ask the OR rule to re-evaluate the unit count
-            this.parent_count_units_fn();
+            this.parent_update_units_fn();
             this.check_options();
         },
         // https://michaelnthiessen.com/force-re-render/
@@ -521,8 +529,8 @@ Vue.component('rule_course', {
         request.send();
 
 
-        // Keep a copy of the Or Rule's "count_units" function (Or a blank function if unavailable)
-        this.parent_count_units_fn = this.$parent.get_or_rule_count_units_fn();
+        // Keep a copy of the Or Rule's "update_units" function (Or a blank function if unavailable)
+        this.parent_update_units_fn = this.$parent.get_or_rule_update_units_fn();
     },
 
     computed: {
@@ -670,10 +678,17 @@ Vue.component('rule_course', {
 
             return !this.invalid_units && !this.invalid_units_step && !this.is_blank;
         },
-
+        count_units: function() {
+            switch(this.details.list_type){
+                case "min":   return {"exact": 0, "max": 0, "min": parseInt(this.details.unit_count)};
+                case "max":   return {"exact": 0, "max": parseInt(this.details.unit_count), "min": 0};
+                case "exact": return {"exact": parseInt(this.details.unit_count), "max": 0, "min": 0};
+                default: return {"exact": 0, "max": 0, "min": 0};
+            }
+        },
         update_units: function() {
             // To be called whenever the unit count is updated. Will ask the OR rule to re-evaluate the unit count
-            this.parent_count_units_fn();
+            this.parent_update_units_fn();
             this.check_options();
         },
         // https://michaelnthiessen.com/force-re-render/
@@ -846,8 +861,8 @@ Vue.component('rule_elective', {
         request.open("GET", "/api/search/?select=code&from=course");
         request.send();
 
-        // Keep a copy of the Or Rule's "count_units" function (Or a blank function if unavailable)
-        this.parent_count_units_fn = this.$parent.get_or_rule_count_units_fn();
+        // Keep a copy of the Or Rule's "update_units" function (Or a blank function if unavailable)
+        this.parent_update_units_fn = this.$parent.get_or_rule_update_units_fn();
     },
     methods: {
         check_options: function() {
@@ -866,9 +881,12 @@ Vue.component('rule_elective', {
 
             return !this.invalid_units && !this.invalid_units_step && !this.is_blank;
         },
+        count_units: function() {
+            return {"exact": parseInt(this.details.unit_count), "max": 0, "min": 0};
+        },
         update_units: function() {
             // To be called whenever the unit count is updated. Will ask the OR rule to re-evaluate the unit count
-            this.parent_count_units_fn();
+            this.parent_update_units_fn();
             this.check_options();
         },
         // https://michaelnthiessen.com/force-re-render/
@@ -914,8 +932,8 @@ Vue.component('rule_custom_text', {
     },
     created: function() {
         this.check_options();
-        // Keep a copy of the Or Rule's "count_units" function (Or a blank function if unavailable)
-        this.parent_count_units_fn = this.$parent.get_or_rule_count_units_fn();
+        // Keep a copy of the Or Rule's "update_units" function (Or a blank function if unavailable)
+        this.parent_update_units_fn = this.$parent.get_or_rule_update_units_fn();
     },
     methods: {
         check_options: function() {
@@ -925,9 +943,12 @@ Vue.component('rule_custom_text', {
 
             return !this.not_divisible && !this.is_blank;
         },
+        count_units: function() {
+            return {"exact": parseInt(this.details.unit_count), "max": 0, "min": 0};
+        },
         update_units: function() {
             // To be called whenever the unit count is updated. Will ask the OR rule to re-evaluate the unit count
-            this.parent_count_units_fn();
+            this.parent_update_units_fn();
             this.check_options();
         },
     },
@@ -965,7 +986,7 @@ Vue.component('rule_custom_text_req', {
         },
         update_units: function() {
             // To be called whenever the unit count is updated. Will ask the OR rule to re-evaluate the unit count
-            this.parent_count_units_fn();
+            this.parent_update_units_fn();
             this.check_options();
         },
     },
@@ -1005,6 +1026,7 @@ Vue.component('rule_either_or', {
 
             // Show warnings if appropriate
             large_unit_count: false,
+            inconsistent_units: false,
 
             component_groups: { 'rules': EITHER_OR_COMPONENT_NAMES, 'requisites': REQUISITE_EITHER_OR_COMPONENT_NAMES},
             component_names: EITHER_OR_COMPONENT_NAMES,
@@ -1025,9 +1047,8 @@ Vue.component('rule_either_or', {
             });
         },
         remove: function(index, group) {
-            console.log(this.details.either_or[group]);
             this.details.either_or[group].splice(index, 1);
-            this.count_units();
+            this.update_units();
             this.do_redraw();
         },
         duplicate_rule: function(index, group) {
@@ -1037,7 +1058,7 @@ Vue.component('rule_either_or', {
         },
         remove_group: function(group) {
             this.details.either_or.splice(group, 1);
-            this.count_units();
+            this.update_units();
             this.do_redraw();
         },
         duplicate_group: function(group) {
@@ -1047,30 +1068,86 @@ Vue.component('rule_either_or', {
         },
         check_options: function() {
             var valid = true;
-            for (var index in this.$children){
-                valid = valid && this.$children[index].check_options();
+            for (var child of this.$children){
+                valid = valid && child.check_options();
+            }
+
+            // Count the number of units in each group, creating an error if there are any inconsistencies
+            this.inconsistent_units = false;
+            var units = null;
+            for(var or_group of this.details.either_or){
+                // Sum up the units of the or group
+                var group_units = {"exact": 0, "max": 0, "min": 0};
+                for (var details of or_group){
+                    var child_units = this.find_rule(details).count_units();
+                    for (var key in child_units)
+                        group_units[key] += child_units[key]
+                }
+
+                // If units has not been set yet, set it to the current OR group
+                if (units == null){
+                    units = group_units;
+                }
+                // If units has been set, verify they are compatible and shrink the possible unit bounds
+                else {
+                    // If the current unit count is incompatible with the OR rule count, notify of inconsistent units
+                    if (units.exact + units.min > group_units.exact + group_units.min + group_units.max){
+                        this.inconsistent_units = true;
+                        valid = false;
+                    }
+                    if (group_units.exact + group_units.min > units.exact + units.min + units.max){
+                        this.inconsistent_units = true;
+                        valid = false;
+                    }
+
+                    // Shrink the bounds of the OR rule units as much as possible
+                    var min =  Math.max(units.exact + units.min, group_units.exact + group_units.min);
+                    var max;
+                    if (units.exact + units.min + units.max > group_units.exact + group_units.min + group_units.max)
+                        max = group_units.exact + group_units.min + group_units.max - min;
+                    else
+                        max = units.exact + units.min + units.max - min;
+                    units = {'exactly': 0, 'min': min, 'max': max };
+
+                }
             }
 
             return valid;
         },
         count_units: function() {
+            // Get the unit count of the entire OR rule as the unit count of the first group
+            var units = {"exact": 0, "max": 0, "min": 0};
+            if (this.details.either_or.length !== 0){
+                for (var details of this.details.either_or[0]) {
+                    var child_units = this.find_rule(details).count_units();
+                    for (var key in child_units)
+                        units[key] += child_units[key]
+                }
+            }
+
+            return units;
+        },
+        find_rule: function(rule_details) {
+            // Takes a rule details object and finds the child node with a matching set of rules
+            for(var child of this.$children)
+                if (child.details === rule_details)
+                    return child;
+            return null;
+        },
+        update_units: function() {
+            // "check_options" is run as an updated unit count affects the error messages in this rule
+            this.check_options();
+
             // Will go through each rule and determine how many units it specifies, showing a warning if over 48
             for(var or_group of this.details.either_or){
-                var units = 0;
-                for(var rule of or_group) {
-                    if (rule.hasOwnProperty("subplan_type")) {
-                        switch (rule.subplan_type) {
-                            case "MAJ" : units += 48; break;
-                            case "MIN" : units += 24; break;
-                            case "SPEC": units += 24; break;
-                        }
-                    }
-                    else if (rule.hasOwnProperty("unit_count")) {
-                        units += parseInt(rule.unit_count);
-                    }
+                var group_units = {"exact": 0, "max": 0, "min": 0};
+                for (var details of or_group){
+                    var child_units = this.find_rule(details).count_units();
+                    for (var key in child_units)
+                        group_units[key] += child_units[key]
                 }
 
-                if (units > 48) {
+                if (group_units.exact + group_units.min > 48) {
                     this.large_unit_count = true;
                     return;
                 }
@@ -1147,13 +1224,22 @@ Vue.component('rule', {
 
             return valid;
         },
-        get_or_rule_count_units_fn: function() {
+        count_units: function() {
+            var units = {"exact": 0, "max": 0, "min": 0};
+            for (var child of this.$children){
+                var child_units = child.count_units();
+                for (var key in child_units)
+                    units[key] += child_units[key];
+            }
+            return units;
+        },
+        get_or_rule_update_units_fn: function() {
             // Looks through the parent nodes until it finds the OR rule, returning its "count_units" function
             // If no OR rule is found, an empty function is returned
             var parent_or = this.$parent;
             while(parent_or !== undefined){
                 if (parent_or.constructor.options.name === 'rule_either_or'){
-                    return parent_or.count_units;
+                    return parent_or.update_units;
                 }
                 parent_or = parent_or.$parent;
             }
@@ -1209,6 +1295,15 @@ Vue.component('rule_container', {
 
             return valid;
         },
+        count_units: function() {
+            var units = {"exact": 0, "max": 0, "min": 0};
+            for (var child of this.$children){
+                var child_units = child.count_units();
+                for (var key in child_units)
+                    units[key] += child_units[key];
+            }
+            return units;
+        },
         // https://michaelnthiessen.com/force-re-render/
         do_redraw: function() {
             this.redraw = true;
@@ -1249,6 +1344,20 @@ if (reqs.length > 0) {
     if (parsed != null) {
         app.rules = parsed;
     }
+}
+
+
+function isValidUnitCount(value) {
+    // Go through each child and sum up all of the units
+    var units = {"exact": 0, "max": 0, "min": 0};
+    for (var child of app.$children){
+        var child_units = child.count_units();
+        for (var key in child_units)
+            units[key] += child_units[key];
+    }
+
+    // Return true if the specified value is within the unit count bounds
+    return units.exact + units.min <= value && value <= units.exact + units.min + units.max;
 }
 
 

--- a/cassdegrees/templates/staff/creation/createprogram.html
+++ b/cassdegrees/templates/staff/creation/createprogram.html
@@ -127,6 +127,13 @@
                         "to students or be selectable as a requirement elsewhere.\n\nAre you sure you want to continue?")) {
                     return false;
                 }
+                // If the user has chosen to publish a plan but the unit count is inconsistent, verify with the user
+                if (document.getElementById("id_publish").checked &&
+                    !isValidUnitCount(parseInt(document.getElementById("id_units").value)) &&
+                    !confirm("You have created a plan that contains a different number of units than you have " +
+                        "specified.\n\nAre you sure you want to continue? (Not Recommended)")) {
+                    return false;
+                }
 
                 document.getElementById('mainForm').action.value = form_action;
                 document.getElementById('redirect').value = redirect;

--- a/cassdegrees/templates/staff/creation/createprogram.html
+++ b/cassdegrees/templates/staff/creation/createprogram.html
@@ -131,7 +131,7 @@
                 if (document.getElementById("id_publish").checked &&
                     !isValidUnitCount(parseInt(document.getElementById("id_units").value)) &&
                     !confirm("You have created a plan that contains a different number of units than you have " +
-                        "specified.\n\nAre you sure you want to continue? (Not Recommended)")) {
+                        "specified for the entire plan.\n\nAre you sure you want to continue? (Not Recommended)")) {
                     return false;
                 }
 

--- a/cassdegrees/templates/staff/creation/createsubplan.html
+++ b/cassdegrees/templates/staff/creation/createsubplan.html
@@ -94,6 +94,25 @@
                         "to students or be selectable as a requirement elsewhere. Are you sure you want to continue?")) {
                     return false;
                 }
+                // If the user has chosen to publish a subplan but the unit count is inconsistent, verify with the user
+                if (document.getElementById("id_publish").checked) {
+                    var planType = document.getElementById("id_planType").value;
+                    if (planType === "MAJ" && !isValidUnitCount(48) &&
+                        !confirm("You have created a major that does not contain 48 units.\n\n" +
+                            "Are you sure you want to continue? (Not Recommended)")){
+                        return false;
+                    }
+                    if (planType === "MIN" && !isValidUnitCount(24) &&
+                        !confirm("You have created a minor that does not contain 24 units.\n\n" +
+                            "Are you sure you want to continue? (Not Recommended)")){
+                        return false;
+                    }
+                    if (planType === "SPEC" && !isValidUnitCount(24) &&
+                        !confirm("You have created a specialisation that does not contain 24 units.\n\n" +
+                            "Are you sure you want to continue? (Not Recommended)")){
+                        return false;
+                    }
+                }
 
                 document.getElementById('redirect').value = redirect;
                 document.getElementById('mainForm').submit();

--- a/cassdegrees/templates/staff/creation/createsubplan.html
+++ b/cassdegrees/templates/staff/creation/createsubplan.html
@@ -94,22 +94,13 @@
                         "to students or be selectable as a requirement elsewhere. Are you sure you want to continue?")) {
                     return false;
                 }
+
                 // If the user has chosen to publish a subplan but the unit count is inconsistent, verify with the user
                 if (document.getElementById("id_publish").checked) {
                     var planType = document.getElementById("id_planType").value;
-                    if (planType === "MAJ" && !isValidUnitCount(48) &&
-                        !confirm("You have created a major that does not contain 48 units.\n\n" +
-                            "Are you sure you want to continue? (Not Recommended)")){
-                        return false;
-                    }
-                    if (planType === "MIN" && !isValidUnitCount(24) &&
-                        !confirm("You have created a minor that does not contain 24 units.\n\n" +
-                            "Are you sure you want to continue? (Not Recommended)")){
-                        return false;
-                    }
-                    if (planType === "SPEC" && !isValidUnitCount(24) &&
-                        !confirm("You have created a specialisation that does not contain 24 units.\n\n" +
-                            "Are you sure you want to continue? (Not Recommended)")){
+                    if (planType && !isValidUnitCount( SUBPLAN_UNITS[planType] ) &&
+                        !confirm("You have created a subplan that does not contain " + SUBPLAN_UNITS[planType] +
+                            " units.\n\nAre you sure you want to continue? (Not Recommended)")){
                         return false;
                     }
                 }

--- a/cassdegrees/templates/widgets/staff/rules.html
+++ b/cassdegrees/templates/widgets/staff/rules.html
@@ -17,6 +17,9 @@
             You have created an OR group that contains more than 48 units. Please check <i>Programs and Courses</i> to ensure
             you have correctly implemented the rules, and try to reduce the number of units in each OR block if possible.
         </div>
+        <div class="msg-error" v-if="inconsistent_units">
+            The number of units in each group is inconsistent. Please ensure an equal number of units.
+        </div>
         <br v-if="large_unit_count" />
 
         <div class="box bdr-solid bdr-uni" v-for="(item, i) in details.either_or" :key="i">

--- a/cassdegrees/templates/widgets/staff/rules.html
+++ b/cassdegrees/templates/widgets/staff/rules.html
@@ -18,7 +18,7 @@
             you have correctly implemented the rules, and try to reduce the number of units in each OR block if possible.
         </div>
         <div class="msg-error" v-if="inconsistent_units">
-            The number of units in each group is inconsistent. Please ensure an equal number of units.
+            The number of units in each group is inconsistent. Please ensure that each group has an equivalent number of units.
         </div>
         <br v-if="large_unit_count" />
 


### PR DESCRIPTION
Closes #380

This PR will add unit verification in program plans and subplans. Furthermore, OR rules will now throw an error if there is an inconsistent number of units in each group. This functionality also supports `At Least`, `Exactly` and `No More Than` rules by bounding the unit count as the plan is evaluated.

**Error Message for Subplan Rules:**
<img width="1115" alt="Subplan MSG" src="https://user-images.githubusercontent.com/36946090/65399889-8ab61380-de02-11e9-92d1-93c690a375a1.png">

**OR Rule Error Message:**
<img width="781" alt="OR MSG" src="https://user-images.githubusercontent.com/36946090/65399890-8ab61380-de02-11e9-839b-ac7c0f69189b.png">
