### PR TITLE
Add global requirements rule to subplans

### DIFF
--- a/cassdegrees/api/models.py
+++ b/cassdegrees/api/models.py
@@ -65,6 +65,7 @@ class SubplanModel(models.Model):
 
     subplanChoices = (("MAJ", "Major"), ("MIN", "Minor"), ("SPEC", "Specialisation"))
 
+    globalRequirements = psql.JSONField(default=list)
     rules = psql.JSONField(default=list)
 
     planType = models.CharField(max_length=4, choices=subplanChoices)

--- a/cassdegrees/api/serializers.py
+++ b/cassdegrees/api/serializers.py
@@ -31,7 +31,7 @@ class CourseSerializer(serializers.HyperlinkedModelSerializer):
 class SubplanSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = SubplanModel
-        fields = ('id', 'code', 'year', 'name', 'units', 'planType', 'rules', 'publish')
+        fields = ('id', 'code', 'year', 'name', 'units', 'planType', 'globalRequirements', 'rules', 'publish')
 
 
 class ProgramSerializer(serializers.HyperlinkedModelSerializer):

--- a/cassdegrees/templates/staff/creation/createsubplan.html
+++ b/cassdegrees/templates/staff/creation/createsubplan.html
@@ -62,6 +62,7 @@
     <!-- We still need a form for regular styling, though these will be serialized manually because of their list-like
          structure -->
     <form class="anuform">
+        {% include "widgets/staff/globalrequirements.html" %}
         {% include "widgets/staff/subplanrules.html" %}
     </form>
 
@@ -87,7 +88,7 @@
         }
 
         function submit_form(redirect) {
-            if (handleRules()) {
+            if (handleProgram() && handleRules()) {
                 // Ensure that the course has been agreed to to being non public on submission.
                 if (!document.getElementById("id_publish").checked &&
                     !confirm("You haven't marked this subplan as public - this means this won't appear " +

--- a/cassdegrees/templates/staff/view/viewsubplan.html
+++ b/cassdegrees/templates/staff/view/viewsubplan.html
@@ -50,8 +50,30 @@
             {% elif data.planType == "SPEC" %}
                 Specialisation
             {% endif %}
-            requires completion of {{ data.units }} units, which must include:
+            requires completion of {{ data.units }} units, of which:
         </p>
+
+        {% for rule in data.globalRequirements %}
+            {% if rule.type == "general" %}
+                <p style="margin-left: 40px">
+                    A
+                    {% if rule.minmax == "min" %}
+                        minimum of {{ rule.unit_count }} units must
+                    {% elif rule.minmax == "max" %}
+                        maximum of {{ rule.unit_count }} units may
+                    {% endif %}
+                    come from completion of {{ rule.prettyList }}
+                    {% if rule.subject_area == "any" %}
+                        courses.
+                    {% else %}
+                        courses from the subject area {{ rule.subject_area }}.
+                    {% endif %}
+                    {% if rule.customRequirements != "" %}
+                        {{ rule.customRequirements }}
+                    {% endif %}
+                </p>
+            {% endif %}
+        {% endfor %}
 
         {# Displays all of the required courses in a table #}
         {% for rule in data.rules %}

--- a/cassdegrees/templates/widgets/pdf_rules.html
+++ b/cassdegrees/templates/widgets/pdf_rules.html
@@ -51,7 +51,7 @@
             {% if not forloop.last %}<p class="bottom-margin top-margin">or...</p>{% endif %}
         {% endfor %}
     {% elif rule.type == "custom_text" %}
-        <p>For {{ rule.units }} units:</p>
+        <p>For {{ rule.unit_count }} units:</p>
         <p>{{ rule.text }}</p>
     {% else %}
         ERROR: Unknown rule type "{{ rule.type }}"!
@@ -80,7 +80,7 @@
     {% endwith %}
 {% elif rule.type == "custom_text" %}
     {% if rule.show_course_boxes %}
-        {% course_box rule.units plan %}
+        {% course_box rule.unit_count plan %}
     {% endif %}
 {% endif %}
 

--- a/cassdegrees/ui/forms.py
+++ b/cassdegrees/ui/forms.py
@@ -184,11 +184,12 @@ class EditProgramFormSnippet(ModelForm):
 class EditSubplanFormSnippet(ModelForm):
     # Automatically injected by default
     units = forms.IntegerField(widget=forms.HiddenInput(), required=False)
+    globalRequirements = JSONField(field_id='globalRequirements', required=False)
     rules = JSONField(field_id='rules', required=False)
 
     class Meta:
         model = SubplanModel
-        fields = ('code', 'year', 'name', 'units', 'planType', 'rules', 'publish')
+        fields = ('code', 'year', 'name', 'units', 'planType', 'globalRequirements', 'rules', 'publish')
         widgets = {
             'code': forms.TextInput(attrs={'class': "text tfull", 'placeholder': "e.g. ARTH-MIN"}),
             'year': forms.NumberInput(attrs={'class': "text eighth-width",

--- a/cassdegrees/ui/views/staff/view.py
+++ b/cassdegrees/ui/views/staff/view.py
@@ -76,6 +76,8 @@ def view_section(request):
         gen_request.GET = {'select': 'code,name,units', 'from': 'course'}
 
         subplan = model_to_dict(SubplanModel.objects.get(id=int(id_to_edit)))
+        pretty_print_reqs(subplan)
+
         for rule in subplan['rules']:
             # Add a new field containing the courses that match the given code
             rule['courses'] = []


### PR DESCRIPTION
Closes #347, Closes #383

This PR adds the standard global requirements rule to subplans. It also fixes a bug where PDFs would not be rendered if the `Custom (Text)` rule was added.

NOTE: Requires calls to `manage.py makemigrations` and `manage.py migrate`