### PR TITLE
Changed display text and added a help field for advice.

### DIFF
--- a/cassdegrees/static/js/staff/rules.js
+++ b/cassdegrees/static/js/staff/rules.js
@@ -279,6 +279,7 @@ Vue.component('rule_subplan', {
             "program_year": "",
             "subplan_types": [],
             "info_msg": INFO_MSGS['subplan'],
+            "show_help": false,
 
             // Display related warnings if true
             "non_unique_options": false,

--- a/cassdegrees/templates/widgets/staff/rulescripts.html
+++ b/cassdegrees/templates/widgets/staff/rulescripts.html
@@ -97,6 +97,10 @@
                             you may simply wish to specify that students must pick "one Arts Major", or you could add
                             additional criteria by saying students must pick "one Arts Major which has a different
                             name to their chosen Minor".
+                            <br>
+                            <br>
+                            This description will be shown to students on exported PDFs and on the CASS Program Planner
+                            site as instructions when picking their subplan.
                         </p>
                     </div>
                     <footer class="box-solid">

--- a/cassdegrees/templates/widgets/staff/rulescripts.html
+++ b/cassdegrees/templates/widgets/staff/rulescripts.html
@@ -60,9 +60,12 @@
 
             <p>
                 Students must pick
-                <input class="text" v-model="details.kind" v-on:change="check_options" aria-required="true" placeholder="e.g. Arts Major - brief description for students here"
+                <input class="text" v-model="details.kind" v-on:change="check_options" aria-required="true"
+                       placeholder="e.g. 'one Arts Major' or 'one Minor'"
                        style="margin-left: 0; width: 400px" required>
-                from the following
+                <img src="//style.anu.edu.au/_anu/images/icons/web/question.png" class="btn-snall no-left-margin vertical-middle clickable"
+                 alt="Help button" v-on:click="show_help = true" />
+                from the following list
                 <select v-model="details.subplan_type" v-on:change="change_filter" required>
                     <option v-for="(msg, type) in subplan_types" v-bind:value="type">{{ msg }}</option>
                 </select>:
@@ -80,6 +83,28 @@
             <input type="button" v-on:click="add_subplan()" class="btn-uni-grad btn-snall no-left-margin" value="Add new option" />
         </div>
         <div v-else v-html="info_msg"></div>
+
+        <div class="modal" v-if="show_help">
+            <div class="modal-background" v-on:click="show_help = false"></div>
+            <div class="modal-card">
+                <div class="card">
+                    <header class="box-header">
+                        Help for Subplan Description Field
+                    </header>
+                    <div class="box-solid box-has-footer">
+                        <p>
+                            This description field can be used to add more context to a subplan requirement. For example,
+                            you may simply wish to specify that students must pick "one Arts Major", or you could add
+                            additional criteria by saying students must pick "one Arts Major which has a different
+                            name to their chosen Minor".
+                        </p>
+                    </div>
+                    <footer class="box-solid">
+                        <button class="button" v-on:click="show_help = false">OK</button>
+                    </footer>
+                </div>
+            </div>
+        </div>
 
     </fieldset>
 </script>


### PR DESCRIPTION
Closes #348.

This PR rewords the placeholder text in the description field for program subplan rules. It now gives two simple examples of how the field is expected to be used in most cases.

A further help pop-up was added which aims to give a better understanding of how the field can be used for for more detailed rules, for example in the Bachelor of Arts. 

![image](https://user-images.githubusercontent.com/37424867/65418073-f28a4f80-de3e-11e9-9b7e-926bb796ffa6.png)
