### PR TITLE
Fix hovering checkboxes by pushing modals above the rest of the page

### DIFF
--- a/cassdegrees/static/css/style.css
+++ b/cassdegrees/static/css/style.css
@@ -144,6 +144,8 @@ select.text{
     left: 0;
     width: 100%;
     height: 100%;
+    /* Above checkboxes (with a ~5 z-index) */
+    z-index: 10;
 }
 
 .modal-background {


### PR DESCRIPTION
Closes #344.

This PR is a quick fix to fix checkboxes which hover over modals. Due to how checkboxes were implemented, they needed relative positioning with custom z-indexes. Modals also have custom layout logic, but we never specified a z depth which meant that checkboxes could potentially get displayed over them. This PR just specifies a value for this.

![fix-checkboxes](https://user-images.githubusercontent.com/1404334/65427642-47f43b80-de02-11e9-96b3-626c002d0b94.png)
