### PR TITLE
Updated messages to make publish clearer to the user

### DIFF
--- a/cassdegrees/templates/staff/creation/createprogram.html
+++ b/cassdegrees/templates/staff/creation/createprogram.html
@@ -53,6 +53,9 @@
                         {% endif %}
                         {{ field }}
                     </p>
+                    {% if field.name == "publish" %}
+                        <p class="text-center">Please tick the checkbox above as 'published' if you want this to be searchable as a requirement and by students</p>
+                    {% endif %}
                     {% for error in field.errors %}
                          <div class="msg-error inline-error">{{ error }}</div>
                     {% endfor %}
@@ -118,8 +121,8 @@
             if (handleProgram() && handleRules()) {
                 // Ensure that the course has been agreed to to being non public on submission.
                 if (!document.getElementById("id_publish").checked &&
-                    !confirm("You haven't marked this program as public - this means this won't appear " +
-                        "to students or be selectable as a requirement elsewhere.\n\nAre you sure you want to continue?")) {
+                    !confirm("You haven't marked this program as 'published' - this means this won't appear " +
+                        "to students or be selectable as a requirement elsewhere.\r\n\r\nAre you sure you want to continue?")) {
                     return false;
                 }
 

--- a/cassdegrees/templates/staff/creation/createsubplan.html
+++ b/cassdegrees/templates/staff/creation/createsubplan.html
@@ -52,6 +52,9 @@
                     {% endif %}
                     {{ field }}
                 </p>
+                {% if field.name == "publish" %}
+                    <p class="text-center">Please tick the checkbox above as 'published' if you want this to be searchable as a requirement by programs and students</p>
+                {% endif %}
                 {% for error in field.errors %}
                      <div class="msg-error inline-error">{{ error }}</div>
                 {% endfor %}
@@ -90,8 +93,8 @@
             if (handleRules()) {
                 // Ensure that the course has been agreed to to being non public on submission.
                 if (!document.getElementById("id_publish").checked &&
-                    !confirm("You haven't marked this subplan as public - this means this won't appear " +
-                        "to students or be selectable as a requirement elsewhere. Are you sure you want to continue?")) {
+                    !confirm("You haven't marked this subplan as 'published' - this means this won't appear " +
+                        "to students or be selectable as a requirement elsewhere.\r\n\r\nAre you sure you want to continue?")) {
                     return false;
                 }
 


### PR DESCRIPTION
Addresses issues raised by UAT's constantly; specifically (#374 , #345, #316)

Created a tooltip below the publish checkbox, explaining what it means
![image](https://user-images.githubusercontent.com/44992275/65428594-ff676d00-de57-11e9-9078-b3305ba725dc.png)

Updated the wording in the alert notifications
![image](https://user-images.githubusercontent.com/44992275/65428700-29b92a80-de58-11e9-99ef-97e73793d273.png)

I also think we should look into better-looking alert boxes as default ones tend to be ignored as they look like generic popups.

Happy to take suggestions for better wording etc.

Should probably commit this before the UAT on Tuesday...
