### PR TITLE
Fix custom text rule checkbox rendering

### DIFF
--- a/cassdegrees/static/css/style.css
+++ b/cassdegrees/static/css/style.css
@@ -483,3 +483,9 @@ select.text{
 .pretty .state label {
     overflow: hidden;
 }
+
+/* Forces a checkbox to appear larger on the page */
+.large-checkbox {
+    margin: 5px;
+    font-size: 25px;
+}

--- a/cassdegrees/static/css/style.css
+++ b/cassdegrees/static/css/style.css
@@ -484,6 +484,14 @@ select.text{
     overflow: hidden;
 }
 
+/* A centered checkbox */
+.pretty.centered {
+    display: block;
+    margin-right: auto;
+    width: calc(1em + 2px);
+    margin-left: auto;
+}
+
 /* Forces a checkbox to appear larger on the page */
 .large-checkbox {
     margin: 5px;

--- a/cassdegrees/templates/widgets/staff/globalrequirements.html
+++ b/cassdegrees/templates/widgets/staff/globalrequirements.html
@@ -72,7 +72,7 @@
                         <!-- Because of the Vue container, these need custom styling pre-applied. They still
                              otherwise work fine, however. -->
                         <td>
-                             <div class="pretty p-icon">
+                             <div class="pretty centered p-icon">
                                 <input type="checkbox" class="custom-checkbox" v-model="details.courses1000Level" v-on:change="check_options">
                                 <div class="state p-primary">
                                   <i class="icon fa fa-check"></i>
@@ -81,7 +81,7 @@
                              </div>
                         </td>
                         <td>
-                             <div class="pretty p-icon">
+                             <div class="pretty centered p-icon">
                                 <input type="checkbox" class="custom-checkbox" v-model="details.courses2000Level" v-on:change="check_options">
                                 <div class="state p-primary">
                                   <i class="icon fa fa-check"></i>
@@ -90,7 +90,7 @@
                              </div>
                         </td>
                         <td>
-                             <div class="pretty p-icon">
+                             <div class="pretty centered p-icon">
                                 <input type="checkbox" class="custom-checkbox" v-model="details.courses3000Level" v-on:change="check_options">
                                 <div class="state p-primary">
                                   <i class="icon fa fa-check"></i>
@@ -99,7 +99,7 @@
                              </div>
                         </td>
                         <td>
-                             <div class="pretty p-icon">
+                             <div class="pretty centered p-icon">
                                 <input type="checkbox" class="custom-checkbox" v-model="details.courses4000Level" v-on:change="check_options">
                                 <div class="state p-primary">
                                   <i class="icon fa fa-check"></i>
@@ -108,7 +108,7 @@
                              </div>
                         </td>
                         <td>
-                             <div class="pretty p-icon">
+                             <div class="pretty centered p-icon">
                                 <input type="checkbox" class="custom-checkbox" v-model="details.courses5000Level" v-on:change="check_options">
                                 <div class="state p-primary">
                                   <i class="icon fa fa-check"></i>
@@ -117,7 +117,7 @@
                              </div>
                         </td>
                         <td>
-                             <div class="pretty p-icon">
+                             <div class="pretty centered p-icon">
                                 <input type="checkbox" class="custom-checkbox" v-model="details.courses6000Level" v-on:change="check_options">
                                 <div class="state p-primary">
                                   <i class="icon fa fa-check"></i>
@@ -126,7 +126,7 @@
                              </div>
                         </td>
                         <td>
-                             <div class="pretty p-icon">
+                             <div class="pretty centered p-icon">
                                 <input type="checkbox" class="custom-checkbox" v-model="details.courses7000Level" v-on:change="check_options">
                                 <div class="state p-primary">
                                   <i class="icon fa fa-check"></i>
@@ -135,7 +135,7 @@
                              </div>
                         </td>
                         <td>
-                             <div class="pretty p-icon">
+                             <div class="pretty centered p-icon">
                                 <input type="checkbox" class="custom-checkbox" v-model="details.courses8000Level" v-on:change="check_options">
                                 <div class="state p-primary">
                                   <i class="icon fa fa-check"></i>
@@ -144,7 +144,7 @@
                              </div>
                         </td>
                         <td>
-                             <div class="pretty p-icon">
+                             <div class="pretty centered p-icon">
                                 <input type="checkbox" class="custom-checkbox" v-model="details.courses9000Level" v-on:change="check_options">
                                 <div class="state p-primary">
                                   <i class="icon fa fa-check"></i>

--- a/cassdegrees/templates/widgets/staff/rulescripts.html
+++ b/cassdegrees/templates/widgets/staff/rulescripts.html
@@ -202,7 +202,13 @@
 
         <p class="form-group">
             <label>Show 6-unit course boxes in plans (e.g. PDF):</label>
-            <input class="text" type="checkbox" v-model="details.show_course_boxes">
+            <div class="pretty p-icon large-checkbox">
+                <input type="checkbox" class="custom-checkbox" v-model="details.show_course_boxes">
+                <div class="state p-primary">
+                    <i class="icon fa fa-check"></i>
+                    <label>&nbsp;</label>
+                </div>
+            </div>
         </p>
     </fieldset>
 </script>


### PR DESCRIPTION
Closes #361

This PR fixes the rendering of checkboxes on custom text rules. This was because the JavaScript replacement code didn't detect the checkboxes displayed in Vue's virtual DOM and subsequently displayed the old UI element instead.

![screenshot-11_51_26_-_24_09_19](https://user-images.githubusercontent.com/1404334/65475117-e23d9900-de6d-11e9-9cbe-6a447e8606f2.png)
