### PR TITLE
Autofill Year for Subplan Created from Program

### DIFF
--- a/cassdegrees/templates/staff/creation/createsubplan.html
+++ b/cassdegrees/templates/staff/creation/createsubplan.html
@@ -82,6 +82,10 @@
     {% include "widgets/staff/coursecreatepopup.html" %}
 
     <script>
+        window.addEventListener("load", function(){
+            document.getElementById('mainForm').year.value = "{{ year }}"
+        });
+
         function submit_course_form(){
             handleRules();
             document.getElementById('mainForm').submit();

--- a/cassdegrees/ui/views/staff/programs.py
+++ b/cassdegrees/ui/views/staff/programs.py
@@ -38,7 +38,7 @@ def create_program(request):
         if request.POST['action'] == 'New Subplan':
             request.session['cached_program_form_data'] = request.POST
             request.session['cached_program_form_source'] = request.path
-            return redirect(staff_url_prefix + 'create/subplan/')
+            return redirect(staff_url_prefix + 'create/subplan/?program_year=' + request.POST['year'])
 
         form = EditProgramFormSnippet(request.POST)
 
@@ -115,7 +115,7 @@ def edit_program(request):
         if request.POST['action'] == 'New Subplan':
             request.session['cached_program_form_data'] = request.POST
             request.session['cached_program_form_source'] = request.build_absolute_uri()
-            return redirect(staff_url_prefix + 'create/subplan/')
+            return redirect(staff_url_prefix + 'create/subplan/?program_year=' + request.POST['year'])
 
         form = EditProgramFormSnippet(request.POST, instance=instance)
 

--- a/cassdegrees/ui/views/staff/subplans.py
+++ b/cassdegrees/ui/views/staff/subplans.py
@@ -23,6 +23,9 @@ def create_subplan(request):
         duplicate = True
     elif duplicate == 'false':
         duplicate = False
+    year = request.GET.get('program_year')
+    if not year:
+        year = ""
 
     # Initialise instance with an empty string so that we don't get a "may be referenced before assignment" error below
     instance = ""
@@ -62,7 +65,8 @@ def create_subplan(request):
 
     return render(request, 'staff/creation/createsubplan.html', context={
         "form": form,
-        "course_creation": course_creation_form
+        "course_creation": course_creation_form,
+        "year": year
     })
 
 
@@ -133,6 +137,9 @@ def edit_subplan(request):
     id = request.GET.get('id')
     if not id:
         return HttpResponseNotFound("Specified ID not found")
+    year = request.GET.get('program_year')
+    if not year:
+        year = ""
 
     # Find the program to specifically edit
     instance = SubplanModel.objects.get(id=int(id))
@@ -170,5 +177,6 @@ def edit_subplan(request):
         'render': {'msg': message},
         "edit": True,
         "form": form,
-        "course_creation": course_creation_form
+        "course_creation": course_creation_form,
+        "year": year
     })


### PR DESCRIPTION
Closes #371.

This simple PR automatically fills the year of a subplan created from the New Subplan button in a program using the year of that program. This negates users accidentally creating subplans with mismatched years that cannot be seen from the program they wanted to add to.