### PR TITLE
Made delete messages consistent

### DIFF
--- a/cassdegrees/templates/staff/delete/deletecourses.html
+++ b/cassdegrees/templates/staff/delete/deletecourses.html
@@ -21,10 +21,13 @@
         {% csrf_token %}
 
         <fieldset>
-            <p>Are you sure you want to delete:</p>
-
+            {% if instances|length == 1 %}
+                <p>Are you sure you want to delete the following course:</p>
+            {% else %}
+                <p>Are you sure you want to delete the following courses:</p>
+            {% endif %}
             {% for instance in instances %}
-                <p class="marginleft">
+                <p>
                     {{ instance.name }} ({{ instance.code }})
                 </p>
                 <input type="number" hidden value="{{ instance.id }}" name="id" />

--- a/cassdegrees/templates/staff/delete/deletelists.html
+++ b/cassdegrees/templates/staff/delete/deletelists.html
@@ -19,7 +19,11 @@
         <fieldset>
             <p>Deleting these lists will mean they are no longer available to bulk add courses to templates.
                 It will not affect templates already containing these lists.</p>
-            <p>Are you sure you want to delete:</p>
+            {% if instances|length == 1 %}
+                <p>Are you sure you want to delete the following list:</p>
+            {% else %}
+                <p>Are you sure you want to delete the following lists:</p>
+            {% endif %}
             {% for instance in instances %}
                 <p>
                     {{ instance.name }} {{ instance.year }}

--- a/cassdegrees/templates/staff/delete/deleteprograms.html
+++ b/cassdegrees/templates/staff/delete/deleteprograms.html
@@ -17,7 +17,11 @@
         {% csrf_token %}
 
         <fieldset>
-            <p>Are you sure you want to delete:</p>
+            {% if instances|length == 1 %}
+                <p>Are you sure you want to delete the following program:</p>
+            {% else %}
+                <p>Are you sure you want to delete the following programs:</p>
+            {% endif %}
             {% for instance in instances %}
                 <p>
                     {{ instance.name }} ({{ instance.code }}) in {{ instance.year }}

--- a/cassdegrees/templates/staff/delete/deletesubplans.html
+++ b/cassdegrees/templates/staff/delete/deletesubplans.html
@@ -17,7 +17,11 @@
         {% csrf_token %}
 
         <fieldset>
-            <p>Are you sure you want to delete:</p>
+            {% if instances|length == 1 %}
+                <p>Are you sure you want to delete the following subplan:</p>
+            {% else %}
+                <p>Are you sure you want to delete the following subplans:</p>
+            {% endif %}
             {% for instance in instances %}
                 <p>
                     {{ instance.name }} ({{ instance.code }}) in {{ instance.year }}


### PR DESCRIPTION
Sorry I forgot about issue #356 

I've made all of the delete page messages consistent now. 
They also change if there are 1 or more for plural cases.

Single
![image](https://user-images.githubusercontent.com/44992275/65520458-f2677e00-df2a-11e9-9a07-bf0356d191d9.png)

Pural
![image](https://user-images.githubusercontent.com/44992275/65520535-10cd7980-df2b-11e9-8e53-0c1171e0dd34.png)

Please let me know if there are any issues/nitpicky things.