### PR TITLE
Fix caching issues

### DIFF
--- a/cassdegrees/templates/base.html
+++ b/cassdegrees/templates/base.html
@@ -1,5 +1,6 @@
 {# Follows from https://docs.djangoproject.com/en/2.1/ref/templates/language/ #}
 {% load static %}
+{% load cache_control %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -24,7 +25,7 @@
     <link rel="stylesheet" href="{% static 'css/flexboxgrid.min.css' %}">
     <link rel="stylesheet" href="{% static 'css/pretty-checkbox.min.css' %}">
     <link rel="stylesheet" href="{% static 'css/anu-style-override.css' %}">
-    <link rel="stylesheet" href="{% static 'css/style.css' %}">
+    <link rel="stylesheet" href="{% static_no_cache 'css/style.css' %}">
 </head>
 <body>
     <!-- Heavily modified from CASS homepage root + ANU styling guide -->

--- a/cassdegrees/templates/pdf_base.html
+++ b/cassdegrees/templates/pdf_base.html
@@ -1,4 +1,3 @@
-{% load static %}
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/cassdegrees/templates/staff/creation/createcourse.html
+++ b/cassdegrees/templates/staff/creation/createcourse.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load static %}
+{% load cache_control %}
 {% load breadcrumbs %}
 
 {% block page-title %}{% if edit %}Edit{% else %}Create{% endif %} Course{% endblock %}
@@ -96,5 +97,5 @@
         }
     </script>
 
-    <script src="{% static 'js/main.js' %}" type="application/javascript"></script>
+    <script src="{% static_no_cache 'js/main.js' %}" type="application/javascript"></script>
 {% endblock %}

--- a/cassdegrees/templates/staff/creation/createlist.html
+++ b/cassdegrees/templates/staff/creation/createlist.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load static %}
+{% load cache_control %}
 {% load breadcrumbs %}
 
 {% block page-title %}{% if edit %}Edit{% else %}Create{% endif %} List{% endblock %}
@@ -90,6 +91,6 @@
         }
     </script>
 
-    <script src="{% static 'js/main.js' %}" type="application/javascript"></script>
+    <script src="{% static_no_cache 'js/main.js' %}" type="application/javascript"></script>
 
 {% endblock %}

--- a/cassdegrees/templates/staff/creation/createprogram.html
+++ b/cassdegrees/templates/staff/creation/createprogram.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load static %}
+{% load cache_control %}
 {% load breadcrumbs %}
 
 {% block page-title %}{% if edit %}Edit{% else %}Create{% endif %} Program Template{% endblock %}
@@ -154,5 +155,5 @@
         }
     </script>
 
-    <script src="{% static 'js/main.js' %}" type="application/javascript"></script>
+    <script src="{% static_no_cache 'js/main.js' %}" type="application/javascript"></script>
 {% endblock %}

--- a/cassdegrees/templates/staff/creation/createsubplan.html
+++ b/cassdegrees/templates/staff/creation/createsubplan.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load static %}
+{% load cache_control %}
 {% load breadcrumbs %}
 
 {% block page-title %}{% if edit %}Edit{% else %}Create{% endif %} Subplan{% endblock %}
@@ -121,5 +122,5 @@
         }
     </script>
 
-    <script src="{% static 'js/main.js' %}" type="application/javascript"></script>
+    <script src="{% static_no_cache 'js/main.js' %}" type="application/javascript"></script>
 {% endblock %}

--- a/cassdegrees/templates/staff/delete/deletecourses.html
+++ b/cassdegrees/templates/staff/delete/deletecourses.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load static %}
+{% load cache_control %}
 {% load breadcrumbs %}
 
 {% block page-title %}Delete Courses{% endblock %}
@@ -42,5 +43,5 @@
         </p>
     </form>
 
-    <script src="{% static 'js/main.js' %}" type="application/javascript"></script>
+    <script src="{% static_no_cache 'js/main.js' %}" type="application/javascript"></script>
 {% endblock %}

--- a/cassdegrees/templates/staff/delete/deletelists.html
+++ b/cassdegrees/templates/staff/delete/deletelists.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load static %}
+{% load cache_control %}
 {% load breadcrumbs %}
 
 {% block page-title %}Delete Course List{% endblock %}
@@ -40,5 +41,5 @@
         </p>
     </form>
 
-    <script src="{% static 'js/main.js' %}" type="application/javascript"></script>
+    <script src="{% static_no_cache 'js/main.js' %}" type="application/javascript"></script>
 {% endblock %}

--- a/cassdegrees/templates/staff/delete/deleteprograms.html
+++ b/cassdegrees/templates/staff/delete/deleteprograms.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load static %}
+{% load cache_control %}
 {% load breadcrumbs %}
 
 {% block page-title %}Delete Program Templates{% endblock %}
@@ -38,5 +39,5 @@
         </p>
     </form>
 
-    <script src="{% static 'js/main.js' %}" type="application/javascript"></script>
+    <script src="{% static_no_cache 'js/main.js' %}" type="application/javascript"></script>
 {% endblock %}

--- a/cassdegrees/templates/staff/delete/deletesubplans.html
+++ b/cassdegrees/templates/staff/delete/deletesubplans.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load static %}
+{% load cache_control %}
 {% load breadcrumbs %}
 
 {% block page-title %}Delete Subplans{% endblock %}
@@ -38,5 +39,5 @@
         </p>
     </form>
 
-    <script src="{% static 'js/main.js' %}" type="application/javascript"></script>
+    <script src="{% static_no_cache 'js/main.js' %}" type="application/javascript"></script>
 {% endblock %}

--- a/cassdegrees/templates/student/create.html
+++ b/cassdegrees/templates/student/create.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load static %}
+{% load cache_control %}
 {% load breadcrumbs %}
 
 {% block page-title %}Create New Plan{% endblock %}
@@ -93,5 +94,5 @@
     </div>
 
     <script src="{% static 'js/vendor/list.js' %}" type="application/javascript"></script>
-    <script src="{% static 'js/student/create.js' %}" type="application/javascript"></script>
+    <script src="{% static_no_cache 'js/student/create.js' %}" type="application/javascript"></script>
 {% endblock %}

--- a/cassdegrees/templates/student/edit.html
+++ b/cassdegrees/templates/student/edit.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load static %}
+{% load cache_control %}
 {% load breadcrumbs %}
 
 {% block page-title %}Edit Plan ({{ program.name }} - {{ program.year }}){% endblock %}
@@ -137,7 +138,7 @@
     <script src="{% static 'js/vendor/list.js' %}" type="application/javascript"></script>
     <script src="{% static 'js/vendor/fuse.js' %}" type="application/javascript"></script>
     <script src="{% static 'js/vendor/interact.js' %}" type="application/javascript"></script>
-    <script src="{% static 'js/student/edit.js' %}" type="application/javascript"></script>
+    <script src="{% static_no_cache 'js/student/edit.js' %}" type="application/javascript"></script>
     {% if render.popup %}
     <script type="application/javascript">setupPopup()</script>
     {% endif %}

--- a/cassdegrees/templates/widgets/rules/blank.html
+++ b/cassdegrees/templates/widgets/rules/blank.html
@@ -1,8 +1,8 @@
-{% load static %}
+{% load cache_control %}
 
 {% verbatim %}
 
 
 {% endverbatim %}
 
-<script type="text/javascript" src="{% static "js/staff/rules/" %}"></script>
+<script type="text/javascript" src="{% static_no_cache "js/staff/rules/" %}"></script>

--- a/cassdegrees/templates/widgets/rules/course_elective.html
+++ b/cassdegrees/templates/widgets/rules/course_elective.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% load cache_control %}
 
 {% verbatim %}
 <script type="text/x-template" id="electiveRuleTemplate">
@@ -30,4 +30,4 @@
 </script>
 {% endverbatim %}
 
-<script type="text/javascript" src="{% static "js/staff/rules/course_elective.js" %}"></script>
+<script type="text/javascript" src="{% static_no_cache "js/staff/rules/course_elective.js" %}"></script>

--- a/cassdegrees/templates/widgets/rules/course_requisite.html
+++ b/cassdegrees/templates/widgets/rules/course_requisite.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% load cache_control %}
 
 {% verbatim %}
 <script type="text/x-template" id="courseRequisiteTemplate">
@@ -29,4 +29,4 @@
 </script>
 {% endverbatim %}
 
-<script type="text/javascript" src="{% static "js/staff/rules/course_requisite.js" %}"></script>
+<script type="text/javascript" src="{% static_no_cache "js/staff/rules/course_requisite.js" %}"></script>

--- a/cassdegrees/templates/widgets/rules/course_selection.html
+++ b/cassdegrees/templates/widgets/rules/course_selection.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% load cache_control %}
 
 {% verbatim %}
 <script type="text/x-template" id="course-list-template">
@@ -96,4 +96,4 @@
 </script>
 {% endverbatim %}
 
-<script type="text/javascript" src="{% static "js/staff/rules/course_selection.js" %}"></script>
+<script type="text/javascript" src="{% static_no_cache "js/staff/rules/course_selection.js" %}"></script>

--- a/cassdegrees/templates/widgets/rules/custom_text.html
+++ b/cassdegrees/templates/widgets/rules/custom_text.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% load cache_control %}
 
 {% verbatim %}
 <script type="text/x-template" id="customTextRuleTemplate">
@@ -34,4 +34,4 @@
 </script>
 {% endverbatim %}
 
-<script type="text/javascript" src="{% static "js/staff/rules/custom_text.js" %}"></script>
+<script type="text/javascript" src="{% static_no_cache "js/staff/rules/custom_text.js" %}"></script>

--- a/cassdegrees/templates/widgets/rules/custom_text_requirement.html
+++ b/cassdegrees/templates/widgets/rules/custom_text_requirement.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% load cache_control %}
 
 {% verbatim %}
 <script type="text/x-template" id="customTextReqRuleTemplate">
@@ -17,4 +17,4 @@
 </script>
 {% endverbatim %}
 
-<script type="text/javascript" src="{% static "js/staff/rules/custom_text_requirement.js" %}"></script>
+<script type="text/javascript" src="{% static_no_cache "js/staff/rules/custom_text_requirement.js" %}"></script>

--- a/cassdegrees/templates/widgets/rules/either_or.html
+++ b/cassdegrees/templates/widgets/rules/either_or.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% load cache_control %}
 
 {% verbatim %}
 <script type="text/x-template" id="eitherOrTemplate">
@@ -59,5 +59,5 @@
 </script>
 {% endverbatim %}
 
-<script type="text/javascript" src="{% static "js/staff/rules/either_or.js" %}"></script>
+<script type="text/javascript" src="{% static_no_cache "js/staff/rules/either_or.js" %}"></script>
 

--- a/cassdegrees/templates/widgets/rules/enrolled_program.html
+++ b/cassdegrees/templates/widgets/rules/enrolled_program.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% load cache_control %}
 
 {% verbatim %}
 <script type="text/x-template" id="programRuleTemplate">
@@ -23,4 +23,4 @@
 </script>
 {% endverbatim %}
 
-<script type="text/javascript" src="{% static "js/staff/rules/enrolled_program.js" %}"></script>
+<script type="text/javascript" src="{% static_no_cache "js/staff/rules/enrolled_program.js" %}"></script>

--- a/cassdegrees/templates/widgets/rules/incompatibility.html
+++ b/cassdegrees/templates/widgets/rules/incompatibility.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% load cache_control %}
 
 {% verbatim %}
 <script type="text/x-template" id="incompatibilityRuleTemplate">
@@ -29,4 +29,4 @@
 </script>
 {% endverbatim %}
 
-<script type="text/javascript" src="{% static "js/staff/rules/incompatibility.js" %}"></script>
+<script type="text/javascript" src="{% static_no_cache "js/staff/rules/incompatibility.js" %}"></script>

--- a/cassdegrees/templates/widgets/rules/rule.html
+++ b/cassdegrees/templates/widgets/rules/rule.html
@@ -1,5 +1,5 @@
 {# Generic visual container for rules with options to duplicate and delete #}
-{% load static %}
+{% load cache_control %}
 
 {% verbatim %}
 <script type="text/x-template" id="ruleTemplate">
@@ -37,4 +37,4 @@
 </script>
 {% endverbatim %}
 
-<script type="text/javascript" src="{% static "js/staff/rules/rule.js" %}"></script>
+<script type="text/javascript" src="{% static_no_cache "js/staff/rules/rule.js" %}"></script>

--- a/cassdegrees/templates/widgets/rules/rule_container.html
+++ b/cassdegrees/templates/widgets/rules/rule_container.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% load cache_control %}
 
 {% verbatim %}
 <script type="text/x-template" id="ruleContainerTemplate">
@@ -48,4 +48,4 @@
     </div>
 </script>
 
-<script type="text/javascript" src="{% static "js/staff/rules/rule_container.js" %}"></script>
+<script type="text/javascript" src="{% static_no_cache "js/staff/rules/rule_container.js" %}"></script>

--- a/cassdegrees/templates/widgets/rules/subplan.html
+++ b/cassdegrees/templates/widgets/rules/subplan.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% load cache_control %}
 
 {% verbatim %}
 <script type="text/x-template" id="subplanRuleMultiselectTemplate">
@@ -74,4 +74,4 @@
 </script>
 {% endverbatim %}
 
-<script type="text/javascript" src="{% static "js/staff/rules/subplan.js" %}"></script>
+<script type="text/javascript" src="{% static_no_cache "js/staff/rules/subplan.js" %}"></script>

--- a/cassdegrees/templates/widgets/staff/course_rules.html
+++ b/cassdegrees/templates/widgets/staff/course_rules.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% load cache_control %}
 
 <fieldset id="rulesContainer">
     <legend>Add Requisites/Incompatibilities</legend>
@@ -18,7 +18,7 @@
 {% include "widgets/rules/rule.html" %}
 {% include "widgets/rules/rule_container.html" with component_names="component_groups.requisites" kind="requisite/incompatibility" %}
 
-<script src="{% static 'js/staff/rules.js' %}" type="application/javascript"></script>
+<script src="{% static_no_cache 'js/staff/rules.js' %}" type="application/javascript"></script>
 
 {% if rules != None %}
     <script>

--- a/cassdegrees/templates/widgets/staff/coursecreatepopup.html
+++ b/cassdegrees/templates/widgets/staff/coursecreatepopup.html
@@ -1,4 +1,3 @@
-{% load static %}
 <div id="createCoursePopup" class="modal" {% if course_creation.hidden %}hidden{% endif %} >
     <div class="modal-background"></div>
     <div class="wide-modal-card card">

--- a/cassdegrees/templates/widgets/staff/courselistingwidget.html
+++ b/cassdegrees/templates/widgets/staff/courselistingwidget.html
@@ -1,8 +1,8 @@
-{% load static %}
 
 {# Usage: Must pass in a string app_name that is id of the particular widget the app is to be bound to#}
 {# Must include imports below once in the relevant template prior to insertion of a widget #}
-{% comment %}    <script src="{% static "js/vendor/vue.js" %}"></script>
+{% comment %}    {% load static %}
+    <script src="{% static "js/vendor/vue.js" %}"></script>
     <script src="{% static "js/vendor/vue-multiselect.js" %}"></script>
     <script src="{% static "js/vendor/vue-resource.js" %}"></script>
     <link rel="stylesheet" href="{% static "css/vue-multiselect.css" %}">{% endcomment %}

--- a/cassdegrees/templates/widgets/staff/global_requirements.html
+++ b/cassdegrees/templates/widgets/staff/global_requirements.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load cache_control %}
 
 <fieldset id="globalRequirementsContainer">
     <legend>Add Global Requirements</legend>
@@ -211,4 +212,4 @@
 {% endverbatim %}
 
 <script src="{% static 'js/vendor/vue.js' %}" type="application/javascript"></script>
-<script src="{% static 'js/staff/globalrequirements.js' %}" type="application/javascript"></script>
+<script src="{% static_no_cache 'js/staff/globalrequirements.js' %}" type="application/javascript"></script>

--- a/cassdegrees/templates/widgets/staff/program_rules.html
+++ b/cassdegrees/templates/widgets/staff/program_rules.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% load cache_control %}
 
 <fieldset id="rulesContainer">
     <legend>Add Rules</legend>
@@ -17,7 +17,7 @@
 {% include "widgets/rules/rule.html" %}
 {% include "widgets/rules/rule_container.html" with component_names="component_groups.rules" kind="Rule" %}
 
-<script src="{% static 'js/staff/rules.js' %}" type="application/javascript"></script>
+<script src="{% static_no_cache 'js/staff/rules.js' %}" type="application/javascript"></script>
 
 {% if rules != None %}
     <script>

--- a/cassdegrees/templates/widgets/staff/subplan_rules.html
+++ b/cassdegrees/templates/widgets/staff/subplan_rules.html
@@ -1,4 +1,4 @@
-{% load static %}
+{% load cache_control %}
 
 <fieldset id="rulesContainer">
     <legend>Add Rules</legend>
@@ -13,7 +13,7 @@
 {% include "widgets/rules/rule.html" %}
 {% include "widgets/rules/rule_container.html" with component_names="component_groups.rules" kind="Rule" single_rule="course_list" %}
 
-<script src="{% static 'js/staff/rules.js' %}" type="application/javascript"></script>
+<script src="{% static_no_cache 'js/staff/rules.js' %}" type="application/javascript"></script>
 
 {% if rules != None %}
     <script>

--- a/cassdegrees/ui/templatetags/cache_control.py
+++ b/cassdegrees/ui/templatetags/cache_control.py
@@ -1,0 +1,17 @@
+from django import template
+from django.conf import settings
+from django.template import Template
+
+from pathlib import Path
+
+register = template.Library()
+
+
+@register.simple_tag(takes_context=True)
+def static_no_cache(context, url):
+    path = Path("."+settings.STATIC_URL + url)
+    print(str(path)+ "?modified=" + str(path.stat().st_mtime))
+    if path.exists():
+        return Template(settings.STATIC_URL + url + "?version=" + str(path.stat().st_mtime)).render(context)
+    else:
+        return Template(settings.STATIC_URL + url).render(context)

--- a/cassdegrees/ui/templatetags/cache_control.py
+++ b/cassdegrees/ui/templatetags/cache_control.py
@@ -9,8 +9,8 @@ register = template.Library()
 
 @register.simple_tag(takes_context=True)
 def static_no_cache(context, url):
-    path = Path("."+settings.STATIC_URL + url)
-    print(str(path)+ "?modified=" + str(path.stat().st_mtime))
+    path = Path("." + settings.STATIC_URL + url)
+    print(str(path) + "?modified=" + str(path.stat().st_mtime))
     if path.exists():
         return Template(settings.STATIC_URL + url + "?version=" + str(path.stat().st_mtime)).render(context)
     else:


### PR DESCRIPTION
Closes #230 

Adds verification to created CSS and JS files to ensure the latest versions are available. This PR will add a version number to each file (set by the last edited time) so that if the server tries to access a CSS/JS file that has been updated, it won't be able to find it in the cache. However, if the file has not changed, it will be able to find it, and will use that file instead. Since you can't send headers when you load CSS or JS, this approach is commonly used.

NOTE: This was only done to our files, so files like `vue.js` will be cached as normal.