### PR TITLE
Fix course list issues and OR unit count verification

### DIFF
--- a/cassdegrees/static/js/staff/rules/course_selection.js
+++ b/cassdegrees/static/js/staff/rules/course_selection.js
@@ -59,6 +59,8 @@ Vue.component('rule_course_list', {
             "info_msg": INFO_MSGS['course'],
             "list_type_label": "",
             "unit_value_label": "",
+            "max_unit_value_label": "",
+            "min_unit_value_label": "",
 
             // Display related warnings if true
             "non_unique_options": false,
@@ -113,8 +115,7 @@ Vue.component('rule_course_list', {
         this.parent_update_units_fn = this.$parent.get_or_rule_update_units_fn();
 
         // update labels based on existing or default values
-        this.updateListTypeLabel()
-        this.updateUnitCountLabel()
+        this.updateListTypeLabel();
     },
 
     computed: {
@@ -246,13 +247,19 @@ Vue.component('rule_course_list', {
             this.do_redraw();
         },
 
-        updateUnitCountLabel() {
-            this.unit_value_label = this.details.unit_count
-        },
-
         updateListTypeLabel() {
             if (this.details.list_type !== "") {
-                this.list_type_label = this.list_types[this.details.list_type].toLowerCase()
+                if (this.details.list_type !== "min_max") {
+                    this.details.max_unit_count = this.details.unit_count = "0";
+                    this.details.min_unit_count = this.details.unit_count = "0";
+                }
+                else
+                    this.details.unit_count = this.details.min_unit_count = "0";
+
+                this.list_type_label = this.list_types[this.details.list_type].toLowerCase();
+
+                this.update_units();
+                this.do_redraw();
             }
         },
 
@@ -309,6 +316,9 @@ Vue.component('rule_course_list', {
 
         update_units() {
             // To be called whenever the unit count is updated. Will ask the OR rule to re-evaluate the unit count
+            this.unit_value_label = this.details.unit_count;
+            this.min_unit_value_label = this.details.min_unit_count;
+            this.max_unit_value_label = this.details.max_unit_count;
             this.parent_update_units_fn();
             this.check_options(false);
         },

--- a/cassdegrees/templates/widgets/rules/course_selection.html
+++ b/cassdegrees/templates/widgets/rules/course_selection.html
@@ -21,18 +21,18 @@
         <p class="form-group" v-if="details.list_type == 'min_max'">
             <label style="width: 20.8333%; text-align: right; float: left;">Minimum units:</label>
             <input style="margin-left: 0;" class="text" onkeydown="javascript: return checkKeys(event)" type="number"
-                   v-on:change="updateUnitCountLabel()" v-model="details.min_unit_count" min="0" step="6" max="1000" required>
+                   v-on:change="update_units()" v-model="details.min_unit_count" min="0" step="6" max="1000" required>
         </p>
         <p class="form-group" v-if="details.list_type == 'min_max'">
             <label style="width: 20.8333%; text-align: right; float: left;">Maximum units:</label>
             <input style="margin-left: 0;" class="text" onkeydown="javascript: return checkKeys(event)" type="number"
-                   v-on:change="updateUnitCountLabel()" v-model="details.max_unit_count" min="0" step="6" max="1000" required>
+                   v-on:change="update_units()" v-model="details.max_unit_count" min="0" step="6" max="1000" required>
         </p>
 
         <p class="form-group" v-if="details.list_type !='min_max'">
             <label style="width: 20.8333%; text-align: right; float: left;">Number of units:</label>
             <input style="margin-left: 0;" class="text" onkeydown="javascript: return checkKeys(event)" type="number"
-                   v-on:change="updateUnitCountLabel()" v-model="details.unit_count" min="0" step="6" max="1000" required>
+                   v-on:change="update_units()" v-model="details.unit_count" min="0" step="6" max="1000" required>
         </p>
 
         <br>
@@ -47,8 +47,8 @@
             Students must select {{ list_type_label }} {{ unit_value_label }} units from the following courses:
         </p>
         <p v-if="details.list_type == 'min_max'">
-            Students must select a minimum of {{details.min_unit_count}} units
-            and a maximum of {{ details.max_unit_count }} units from the following courses:
+            Students must select a minimum of {{ min_unit_value_label }} units
+            and a maximum of {{ max_unit_value_label }} units from the following courses:
         </p>
 
         <br>


### PR DESCRIPTION
Closes #417, Closes #422 

This PR fixes the OR rule verification that didn't work with the courses rule, fixes the `Minimum and Maximum`  option so it updates the text below, and fix an issue where clicking a different option after `Minimum and Maximum` would not update the rule display.