### PR TITLE
Modify PDF styling to improve various aspects of display

### DIFF
--- a/cassdegrees/templates/pdf_base.html
+++ b/cassdegrees/templates/pdf_base.html
@@ -47,6 +47,10 @@
             padding: 0.25cm;
         }
 
+        .sub-box {
+            padding-bottom: 0.1cm;
+        }
+
         .box p {
             margin: 0;
         }

--- a/cassdegrees/templates/pdf_base.html
+++ b/cassdegrees/templates/pdf_base.html
@@ -91,7 +91,7 @@
         }
 
         .try-complete-box {
-            page-break-inside: avoid;
+            break-inside: avoid-page;
         }
     </style>
 

--- a/cassdegrees/templates/pdf_base.html
+++ b/cassdegrees/templates/pdf_base.html
@@ -18,7 +18,7 @@
 
         @page {
             size: A4 landscape;
-            margin: 1cm;
+            margin: 0.5cm;
         }
 
         /* Basic column rules */
@@ -29,6 +29,11 @@
 
         .columns-3 {
             column-count: 3;
+            column-fill: auto;
+        }
+
+        .columns-4 {
+            column-count: 4;
             column-fill: auto;
         }
 
@@ -53,6 +58,11 @@
         .no-bottom-margin {
             margin-bottom: 0 !important;
             padding-bottom: 0 !important;
+        }
+
+        .no-top-margin {
+            margin-top: 0 !important;
+            padding-top: 0 !important;
         }
 
         .grey-text {

--- a/cassdegrees/templates/pdf_program.html
+++ b/cassdegrees/templates/pdf_program.html
@@ -10,20 +10,19 @@
     </div>
 
     {% if plan != None %}
-        <h1 class="no-bottom-margin">{{ plan.name }} ({{ program.name }}, {{ program.year }}, {{ program.units }} units)</h1>
+        <h2 class="no-bottom-margin">{{ plan.name }}</h2>
+        <p class="no-bottom-margin no-top-margin">({{ program.name }}, {{ program.year }}, {{ program.units }} units)</p>
     {% else %}
         <h1 class="no-bottom-margin">{{ program.name }} ({{ program.year }}, {{ program.units }} units)</h1>
     {% endif %}
 
     <br />
 
-    <div class="columns-3 columns-no-gap">
+    <div class="columns-4 columns-no-gap">
 
         {% for rule in program.rules %}
-            {% include "widgets/pdf_rules.html" %}
+            {% include "widgets/pdf_rules.html" with render_rules=True render_units=True %}
         {% endfor %}
-
-        <div class="break-column"></div>
 
         <div class="box small-text">
             <p>
@@ -34,7 +33,7 @@
         </div>
 
         {% for rule in program.globalRequirements %}
-            <div class="box {% if forloop.last %} break-column{% endif %}">
+            <div class="box">
                 {% if rule.type == "general" %}
                     <p>
                         {{rule.prettyList}}

--- a/cassdegrees/templates/student/edit.html
+++ b/cassdegrees/templates/student/edit.html
@@ -53,7 +53,7 @@
                 <h3>Program</h3>
 
                 {% for rule in program.rules %}
-                    {% include "widgets/student/rules.html" %}
+                    {% include "widgets/student/rules.html" with render_rules=True render_units=True %}
                 {% endfor %}
             </div>
 

--- a/cassdegrees/templates/widgets/pdf_rules.html
+++ b/cassdegrees/templates/widgets/pdf_rules.html
@@ -3,7 +3,7 @@
 
 {# Renders rule a rule for a PDF program #}
 {% if render_rules|default_if_none:True %}
-    <div class="box try-complete-box">
+    <div class="box{% if rule.type != "either_or" %} try-complete-box{% endif %}">
         {% if rule.type == "subplan" %}
             <p>Completion of {{ rule.kind }} for {{ rule.units }} units:</p>
         {% elif rule.type == 'elective' %}
@@ -81,10 +81,6 @@
 
                 {% if not forloop.last %}
                     <p class="bottom-margin top-margin">or...</p>
-                {% else %}
-                    {% for rule in group %}
-                        {% include "widgets/pdf_rules.html" with render_rules=False render_units=True %}
-                    {% endfor %}
                 {% endif %}
             {% endfor %}
         {% elif rule.type == "custom_text" %}
@@ -94,6 +90,18 @@
             ERROR: Unknown rule type "{{ rule.type }}"!
         {% endif %}
     </div>
+
+    {% if rule.type == "either_or" %}
+        {% for group in rule.either_or %}
+            {% if forloop.last %}
+                {% for rule in group %}
+                    {% include "widgets/pdf_rules.html" with render_rules=False render_units=True %}
+                {% endfor %}
+            {% endif %}
+        {% endfor %}
+
+        {% if forloop.last %}<div class="break-box"></div>{% endif %}
+    {% endif %}
 {% endif %}
 
 {% if render_units %}

--- a/cassdegrees/templates/widgets/pdf_rules.html
+++ b/cassdegrees/templates/widgets/pdf_rules.html
@@ -3,7 +3,7 @@
 
 {# Renders rule a rule for a PDF program #}
 {% if render_rules|default_if_none:True %}
-    <div class="box{% if rule.type != "either_or" %} try-complete-box{% endif %}">
+    <div class="{% if render_units %}box{% else %}sub-box{% endif %}{% if rule.type != "either_or" %} try-complete-box{% endif %}">
         {% if rule.type == "subplan" %}
             <p>Completion of {{ rule.kind }} for {{ rule.units }} units:</p>
         {% elif rule.type == 'elective' %}

--- a/cassdegrees/templates/widgets/pdf_rules.html
+++ b/cassdegrees/templates/widgets/pdf_rules.html
@@ -2,104 +2,126 @@
 {% load math %}
 
 {# Renders rule a rule for a PDF program #}
-<div class="box try-complete-box">
-    {% if rule.type == "subplan" %}
-        <p>Completion of {{ rule.kind }} for {{ rule.units }} units:</p>
-    {% elif rule.type == 'elective' %}
-        <p>
-            {{ rule.unit_count }} units from
-            {% if rule.year_level != 'all' %}
-                {{ rule.year_level }}-level
-            {% endif %}
-            {% if rule.subject_area != 'all' %}
-                {{ rule.subject_area }}
-            {% else %}
-                elective
-            {% endif %}
-            courses:
-        </p>
-    {% elif rule.type == "year_level" %}
-        <p>Complete {{ rule.unit_count }} units from {% if rule.unit_count|add:"0" <= 6 %}a{% endif %}
-            {{ rule.year_level }}-level course{% if rule.unit_count|add:"0" > 6 %}s{% endif %}:</p>
-    {% elif rule.type == "course" %}
-        {# Find out if all courses are required #}
-        {% with courses_provided=rule.codes|length %}
-            {% if rule.list_type != 'min_max' %}
-                {% with courses_needed=rule.unit_count|divide:6 %}
-                    {% if courses_provided == courses_needed %}
-                        {# All courses specified are required - render all #}
-                        <p>Complete {{ rule.unit_count }} units from the following
-                            {% if rule.unit_count|add:"0" <= 6 %}course{% else %}set of courses{% endif %}:</p>
-                    {% else %}
-                        {# Not all required courses - give descriptions #}
-                        <p>Complete {{ rule.unit_count }} units from a selection of:</p>
-                        {% for code in rule.codes %}
-                            {{ code.code }}{% if not forloop.last %}, {% endif %}
-                        {% endfor %}
-                    {% endif %}
-                {% endwith %}
-            {% else %}
-                {% with courses_needed=rule.min_unit_count|divide:6 %}
-                    {% if courses_provided == courses_needed %}
-                        {# All courses specified are required - render all #}
-                        <p>Complete a minimum of {{ rule.min_unit_count }} units and a maximum of
-                            {{ rule.max_unit_count }} units from the following
-                            {% if rule.unit_count|add:"0" <= 6 %}course{% else %}set of courses{% endif %}:</p>
-                    {% else %}
-                        {# Not all required courses - give descriptions #}
-                        <p><p>Complete a minimum of {{ rule.min_unit_count }} units and a maximum of
-                            {{ rule.max_unit_count }} units from a selection of:</p>
-                        {% for code in rule.codes %}
-                            {{ code.code }}{% if not forloop.last %}, {% endif %}
-                        {% endfor %}
-                    {% endif %}
-                {% endwith %}
-            {% endif %}
-        {% endwith %}
-    {% elif rule.type == "either_or" %}
-        <p class="bottom-margin">Either:</p>
+{% if render_rules|default_if_none:True %}
+    <div class="box try-complete-box">
+        {% if rule.type == "subplan" %}
+            <p>Completion of {{ rule.kind }} for {{ rule.units }} units:</p>
+        {% elif rule.type == 'elective' %}
+            <p>
+                {{ rule.unit_count }} units from
+                {% if rule.year_level != 'all' %}
+                    {{ rule.year_level }}-level
+                {% endif %}
+                {% if rule.subject_area != 'all' %}
+                    {{ rule.subject_area }}
+                {% else %}
+                    elective
+                {% endif %}
+                courses
+                {% if render_units %}:{% endif %}
+            </p>
+        {% elif rule.type == "year_level" %}
+            <p>Complete {{ rule.unit_count }} units from {% if rule.unit_count|add:"0" <= 6 %}a{% endif %}
+                {{ rule.year_level }}-level course{% if rule.unit_count|add:"0" > 6 %}s{% endif %}
+                {% if render_units %}:{% endif %}</p>
+        {% elif rule.type == "course_list" %}
+            {# Find out if all courses are required #}
+            {% with courses_provided=rule.codes|length %}
+                {% if rule.list_type != 'min_max' %}
+                    {% with courses_needed=rule.unit_count|divide:6 %}
+                        {% if courses_provided == courses_needed %}
+                            {# All courses specified are required - render all #}
+                            <p>Complete {{ rule.unit_count }} units from the following
+                                {% if rule.unit_count|add:"0" <= 6 %}course{% else %}set of courses{% endif %}:
+                            {% if not render_units %}
+                                {% for code in rule.codes %}
+                                    {{ code.code }}{% if not forloop.last %}, {% endif %}
+                                {% endfor %}
+                            {% endif %}
+                        {% else %}
+                            {# Not all required courses - give descriptions #}
+                            <p>Complete {{ rule.unit_count }} units from a selection of:</p>
+                            {% for code in rule.codes %}
+                                {{ code.code }}{% if not forloop.last %}, {% endif %}
+                            {% endfor %}
+                        {% endif %}
+                    {% endwith %}
+                {% else %}
+                    {% with courses_needed=rule.min_unit_count|divide:6 %}
+                        {% if courses_provided == courses_needed %}
+                            {# All courses specified are required - render all #}
+                            <p>Complete a minimum of {{ rule.min_unit_count }} units and a maximum of
+                                {{ rule.max_unit_count }} units from the following
+                                {% if rule.unit_count|add:"0" <= 6 %}course{% else %}set of courses{% endif %}:</p>
+                            {% if not render_units %}
+                                {% for code in rule.codes %}
+                                    {{ code.code }}{% if not forloop.last %}, {% endif %}
+                                {% endfor %}
+                            {% endif %}
+                        {% else %}
+                            {# Not all required courses - give descriptions #}
+                            <p><p>Complete a minimum of {{ rule.min_unit_count }} units and a maximum of
+                                {{ rule.max_unit_count }} units from a selection of:</p>
+                            {% for code in rule.codes %}
+                                {{ code.code }}{% if not forloop.last %}, {% endif %}
+                            {% endfor %}
+                        {% endif %}
+                    {% endwith %}
+                {% endif %}
+            {% endwith %}
+        {% elif rule.type == "either_or" %}
+            <p class="bottom-margin">Either:</p>
 
-        {% for group in rule.either_or %}
-            <div class="left-box">
-                {% for rule in group %}
-                    {% include "widgets/pdf_rules.html" %}
-                {% endfor %}
-            </div>
+            {% for group in rule.either_or %}
+                <div class="left-box">
+                    {% for rule in group %}
+                        {% include "widgets/pdf_rules.html" with render_rules=True render_units=False %}
+                    {% endfor %}
+                </div>
 
-            {% if not forloop.last %}<p class="bottom-margin top-margin">or...</p>{% endif %}
-        {% endfor %}
-    {% elif rule.type == "custom_text" %}
-        <p>For {{ rule.unit_count }} units:</p>
-        <p>{{ rule.text }}</p>
-    {% else %}
-        ERROR: Unknown rule type "{{ rule.type }}"!
-    {% endif %}
-</div>
-
-
-{% if rule.type == "subplan" %}
-    {# Assume all subplans have equal units - else it wouldn't make sense for a complete program #}
-    {% with subplan=subplans|index:rule.ids.0 %}
-        {% course_box subplan.units plan %}
-    {% endwith %}
-{% elif rule.type == "elective" %}
-    {% course_box rule.unit_count plan %}
-{% elif rule.type == "course" %}
-    {% with courses_provided=rule.codes|length %}
-        {% with courses_needed=rule.unit_count|divide:6 %}
-            {% if courses_provided == courses_needed %}
-                {# All courses specified are required - render all #}
-                {% course_box_with_values rule.unit_count rule.codes plan %}
-            {% else %}
-                {# Not all required courses - map them out as blanks #}
-                {% course_box rule.unit_count plan %}
-            {% endif %}
-        {% endwith %}
-    {% endwith %}
-{% elif rule.type == "custom_text" %}
-    {% if rule.show_course_boxes %}
-        {% course_box rule.unit_count plan %}
-    {% endif %}
+                {% if not forloop.last %}
+                    <p class="bottom-margin top-margin">or...</p>
+                {% else %}
+                    {% for rule in group %}
+                        {% include "widgets/pdf_rules.html" with render_rules=False render_units=True %}
+                    {% endfor %}
+                {% endif %}
+            {% endfor %}
+        {% elif rule.type == "custom_text" %}
+            <p>For {{ rule.unit_count }} units:</p>
+            <p>{{ rule.text }}</p>
+        {% else %}
+            ERROR: Unknown rule type "{{ rule.type }}"!
+        {% endif %}
+    </div>
 {% endif %}
 
-{% if forloop.last %}<div class="break-box"></div>{% endif %}
+{% if render_units %}
+        {% if rule.type == "subplan" %}
+            {# Assume all subplans have equal units - else it wouldn't make sense for a complete program #}
+            {% with subplan=subplans|index:rule.ids.0 %}
+                {% course_box subplan.units plan render_rules %}
+            {% endwith %}
+        {% elif rule.type == "elective" %}
+            {% course_box rule.unit_count plan render_rules %}
+        {% elif rule.type == "course_list" %}
+            {% with courses_provided=rule.codes|length %}
+                {% with courses_needed=rule.unit_count|divide:6 %}
+                    {% if courses_provided == courses_needed and render_rules %}
+                        {# All courses specified are required - render all #}
+                        {% course_box_with_values rule.unit_count rule.codes plan %}
+                    {% else %}
+                        {# Not all required courses - map them out as blanks #}
+                        {% course_box rule.unit_count plan render_rules %}
+                    {% endif %}
+                {% endwith %}
+            {% endwith %}
+        {% elif rule.type == "custom_text" %}
+            {% if rule.show_course_boxes %}
+                {% course_box rule.unit_count plan render_rules %}
+            {% endif %}
+        {% endif %}
+
+    {% if forloop.last %}<div class="break-box"></div>{% endif %}
+{% endif %}
+

--- a/cassdegrees/templates/widgets/student/rules.html
+++ b/cassdegrees/templates/widgets/student/rules.html
@@ -80,7 +80,7 @@
                 {% endif %}
             {% endfor %}
         {% elif rule.type == "custom_text" %}
-            <p>For {{ rule.units }} units:</p>
+            <p>For {{ rule.unit_count }} units:</p>
             <p>{{ rule.text }}</p>
         {% else %}
             ERROR: Unknown rule type "{{ rule.type }}"!

--- a/cassdegrees/templates/widgets/student/rules.html
+++ b/cassdegrees/templates/widgets/student/rules.html
@@ -123,7 +123,7 @@
             {% endwith %}
         {% elif rule.type == "custom_text" %}
             {% if rule.show_course_boxes %}
-                {% student_course_box rule.units render_rules %}
+                {% student_course_box rule.unit_count render_rules %}
             {% endif %}
         {% elif rule.type == "elective" %}
             {% student_course_box rule.units render_rules %}

--- a/cassdegrees/templates/widgets/student/rules.html
+++ b/cassdegrees/templates/widgets/student/rules.html
@@ -2,111 +2,131 @@
 {% load math %}
 
 {# Renders rule a rule for a student plan #}
-<div class="card">
-    {% if rule.type == "subplan" %}
-        <p>Completion of {{ rule.kind }} for {{ rule.units }} units:</p>
-    {% elif rule.type == "elective" %}
-        {{ rule.unit_count }} units from completion of
-        {% if rule.year_level != 'all' %}
-            {{ rule.year_level }}-level
-        {% endif %}
-        {% if rule.subject_area == 'all' %}
-            elective courses offered by ANU
+{% if render_rules %}
+    <div class="card">
+        {% if rule.type == "subplan" %}
+            <p>Completion of {{ rule.kind }} for {{ rule.units }} units:</p>
+        {% elif rule.type == "elective" %}
+            {{ rule.unit_count }} units from completion of
+            {% if rule.year_level != 'all' %}
+                {{ rule.year_level }}-level
+            {% endif %}
+            {% if rule.subject_area == 'all' %}
+                elective courses offered by ANU
+            {% else %}
+                courses in the subject area {{ rule.subject_area }}
+            {% endif %}
+        {% elif rule.type == "course_list" %}
+            {# Find out if all courses are required #}
+            {% with courses_provided=rule.codes|length %}
+                {% if rule.list_type != 'min_max' %}
+                    {% with courses_needed=rule.unit_count|divide:6 %}
+                        {% if courses_provided == courses_needed %}
+                            {# All courses specified are required - render all #}
+                            <p>Complete {{ rule.unit_count }} units from the following
+                                {% if rule.unit_count|add:"0" <= 6 %}course{% else %}set of courses{% endif %}:</p>
+                            {% if not render_units %}
+                                {% for code in rule.codes %}
+                                    {{ code.code }}{% if not forloop.last %}, {% endif %}
+                                {% endfor %}
+                            {% endif %}
+                        {% else %}
+                            {# Not all required courses - give descriptions #}
+                            <p>Complete {{ rule.unit_count }} units from a selection of:</p>
+                            {% for code in rule.codes %}
+                                {{ code }}{% if not forloop.last %}, {% endif %}
+                            {% endfor %}
+                        {% endif %}
+                    {% endwith %}
+                {% else %}
+                    {% with courses_needed=rule.min_unit_count|divide:6 %}
+                        {% if courses_provided == courses_needed %}
+                            {# All courses specified are required - render all #}
+                            <p>Complete a minimum of {{ rule.min_unit_count }} units and a maximum of
+                                {{ rule.max_unit_count }} units from the following
+                                {% if rule.unit_count|add:"0" <= 6 %}course{% else %}set of courses{% endif %}:</p>
+                            {% if not render_units %}
+                                {% for code in rule.codes %}
+                                    {{ code.code }}{% if not forloop.last %}, {% endif %}
+                                {% endfor %}
+                            {% endif %}
+                        {% else %}
+                            {# Not all required courses - give descriptions #}
+                            <p><p>Complete a minimum of {{ rule.min_unit_count }} units and a maximum of
+                                {{ rule.max_unit_count }} units from a selection of:</p>
+                            {% for code in rule.codes %}
+                                {{ code.code }}{% if not forloop.last %}, {% endif %}
+                            {% endfor %}
+                        {% endif %}
+                    {% endwith %}
+                {% endif %}
+            {% endwith %}
+        {% elif rule.type == "either_or" %}
+            <p class="bottom-margin">Either:</p>
+
+            {% for group in rule.either_or %}
+                <div class="left-box" style="padding-left: 40px;">
+                    {% for rule in group %}
+                        {% include "widgets/student/rules.html" with render_rules=True render_units=False %}
+                    {% endfor %}
+                </div>
+
+                {% if not forloop.last %}
+                    <p class="bottom-margin top-margin">or...</p>
+                {% else %}
+                    {% for rule in group %}
+                        {% include "widgets/student/rules.html" with render_rules=False render_units=True %}
+                    {% endfor %}
+                {% endif %}
+            {% endfor %}
+        {% elif rule.type == "custom_text" %}
+            <p>For {{ rule.units }} units:</p>
+            <p>{{ rule.text }}</p>
         {% else %}
-            courses in the subject area {{ rule.subject_area }}
+            ERROR: Unknown rule type "{{ rule.type }}"!
         {% endif %}
-    {% elif rule.type == "course" %}
-        {# Find out if all courses are required #}
-        {% with courses_provided=rule.codes|length %}
-            {% if rule.list_type != 'min_max' %}
-                {% with courses_needed=rule.unit_count|divide:6 %}
-                    {% if courses_provided == courses_needed %}
-                        {# All courses specified are required - render all #}
-                        <p>Complete {{ rule.unit_count }} units from the following
-                            {% if rule.unit_count|add:"0" <= 6 %}course{% else %}set of courses{% endif %}:</p>
-                    {% else %}
-                        {# Not all required courses - give descriptions #}
-                        <p>Complete {{ rule.unit_count }} units from a selection of:</p>
-                        {% for code in rule.codes %}
-                            {{ code }}{% if not forloop.last %}, {% endif %}
-                        {% endfor %}
-                    {% endif %}
-                {% endwith %}
-            {% else %}
-                {% with courses_needed=rule.min_unit_count|divide:6 %}
-                    {% if courses_provided == courses_needed %}
-                        {# All courses specified are required - render all #}
-                        <p>Complete a minimum of {{ rule.min_unit_count }} units and a maximum of
-                            {{ rule.max_unit_count }} units from the following
-                            {% if rule.unit_count|add:"0" <= 6 %}course{% else %}set of courses{% endif %}:</p>
-                    {% else %}
-                        {# Not all required courses - give descriptions #}
-                        <p><p>Complete a minimum of {{ rule.min_unit_count }} units and a maximum of
-                            {{ rule.max_unit_count }} units from a selection of:</p>
-                        {% for code in rule.codes %}
-                            {{ code.code }}{% if not forloop.last %}, {% endif %}
-                        {% endfor %}
-                    {% endif %}
-                {% endwith %}
+    </div>
+{% endif %}
+
+{% if render_units %}
+    <div style="padding-left: 20px;">
+        {% if rule.type == "subplan" %}
+            {# Assume all subplans have equal units - else it wouldn't make sense for a complete program #}
+            {% with subplan=subplans|index:rule.ids.0 %}
+                {% include "widgets/student/subplan_choice.html" %}
+            {%  endwith %}
+        {% elif rule.type == "elective" %}
+            {% student_course_box rule.unit_count render_rules %}
+        {% elif rule.type == "course_list" %}
+            {% with courses_provided=rule.codes|length %}
+                {% if rule.list_type != 'min_max' %}
+                    {% with courses_needed=rule.unit_count|divide:6 %}
+                        {% if courses_provided == courses_needed and render_rules %}
+                            {# All courses specified are required - render all #}
+                            {% student_course_box_with_values rule.unit_count rule.codes %}
+                        {% else %}
+                            {# Not all required courses - map them out as blanks #}
+                            {% student_course_box rule.unit_count render_rules %}
+                        {% endif %}
+                    {% endwith %}
+                {% else %}
+                    {% with courses_needed=rule.min_unit_count|divide:6 %}
+                        {% if courses_provided == courses_needed and render_rules %}
+                            {# All courses specified are required - render all #}
+                            {% student_course_box_with_values rule.min_unit_count rule.codes %}
+                        {% else %}
+                            {# Not all required courses - map them out as blanks #}
+                            {% student_course_box rule.max_unit_count render_rules %}
+                        {% endif %}
+                    {% endwith %}
+                {% endif %}
+            {% endwith %}
+        {% elif rule.type == "custom_text" %}
+            {% if rule.show_course_boxes %}
+                {% student_course_box rule.units render_rules %}
             {% endif %}
-        {% endwith %}
-    {% elif rule.type == "either_or" %}
-        <p class="bottom-margin">Either:</p>
-
-        {% for group in rule.either_or %}
-            <div class="left-box" style="padding-left: 40px;">
-                {% for rule in group %}
-                    {% include "widgets/student/rules.html" %}
-                {% endfor %}
-            </div>
-
-            {% if not forloop.last %}<p class="bottom-margin top-margin">or...</p>{% endif %}
-        {% endfor %}
-    {% elif rule.type == "custom_text" %}
-        <p>For {{ rule.units }} units:</p>
-        <p>{{ rule.text }}</p>
-    {% else %}
-        ERROR: Unknown rule type "{{ rule.type }}"!
-    {% endif %}
-</div>
-
-<div style="padding-left: 20px;">
-    {% if rule.type == "subplan" %}
-        {# Assume all subplans have equal units - else it wouldn't make sense for a complete program #}
-        {% with subplan=subplans|index:rule.ids.0 %}
-            {% include "widgets/student/subplan_choice.html" %}
-        {%  endwith %}
-    {% elif rule.type == "elective" %}
-        {% student_course_box rule.unit_count %}
-    {% elif rule.type == "course" %}
-        {% with courses_provided=rule.codes|length %}
-            {% if rule.list_type != 'min_max' %}
-                {% with courses_needed=rule.unit_count|divide:6 %}
-                    {% if courses_provided == courses_needed %}
-                        {# All courses specified are required - render all #}
-                        {% student_course_box_with_values rule.unit_count rule.codes %}
-                    {% else %}
-                        {# Not all required courses - map them out as blanks #}
-                        {% student_course_box rule.unit_count %}
-                    {% endif %}
-                {% endwith %}
-            {% else %}
-                {% with courses_needed=rule.min_unit_count|divide:6 %}
-                    {% if courses_provided == courses_needed %}
-                        {# All courses specified are required - render all #}
-                        {% student_course_box_with_values rule.min_unit_count rule.codes %}
-                    {% else %}
-                        {# Not all required courses - map them out as blanks #}
-                        {% student_course_box rule.max_unit_count %}
-                    {% endif %}
-                {% endwith %}
-            {% endif %}
-        {% endwith %}
-    {% elif rule.type == "custom_text" %}
-        {% if rule.show_course_boxes %}
-            {% student_course_box rule.units %}
+        {% elif rule.type == "elective" %}
+            {% student_course_box rule.units render_rules %}
         {% endif %}
-    {% elif rule.type == "elective" %}
-        {% student_course_box rule.units %}
-    {% endif %}
-</div>
+    </div>
+{% endif %}

--- a/cassdegrees/templates/widgets/student/subplan_choice.html
+++ b/cassdegrees/templates/widgets/student/subplan_choice.html
@@ -33,5 +33,5 @@
             {% endfor %}
         </div>
     </div>
-    {% student_course_box subplan.units %}
+    {% student_course_box subplan.units render_rules %}
 </div>

--- a/cassdegrees/ui/templatetags/course_boxes.py
+++ b/cassdegrees/ui/templatetags/course_boxes.py
@@ -5,7 +5,7 @@ register = template.Library()
 
 
 @register.simple_tag(takes_context=True)
-def course_box(context, count, plan):
+def course_box(context, count, plan, display_course_index):
     output = ""
     iters = int(int(count) / 6)
 
@@ -16,11 +16,18 @@ def course_box(context, count, plan):
             course_name = None
 
         # Noting that pop() might also return None if a user hasn't selected a course yet:
-        if course_name:
-            output += "<div class=\"box grey-box\"><span class=\"grey-text\">Course #" + str(i + 1) + ":</span> " \
-                      + course_name + "</div>"
+        if display_course_index:
+            if course_name:
+                output += "<div class=\"box grey-box\"><span class=\"grey-text\">Course #" + str(i + 1) + ":</span> " \
+                          + course_name + "</div>"
+            else:
+                output += "<div class=\"box grey-text grey-box\">Course #" + str(i + 1) + ":</div>"
         else:
-            output += "<div class=\"box grey-text grey-box\">Course #" + str(i + 1) + ":</div>"
+            if course_name:
+                output += "<div class=\"box grey-box\"><span class=\"grey-text\">Course:</span> " \
+                          + course_name + "</div>"
+            else:
+                output += "<div class=\"box grey-text grey-box\">Course:</div>"
 
     return Template(output).render(context)
 

--- a/cassdegrees/ui/templatetags/student_course_boxes.py
+++ b/cassdegrees/ui/templatetags/student_course_boxes.py
@@ -20,16 +20,16 @@ def student_course_box(context, count, display_course_index):
                       "<div class=\"box-solid course-drop dropzone\">" \
                       "<span class=\"grey-text\">Course #" + str(i + 1) + ":&nbsp;</span>" \
                       "<span class=\"course-code\"></span>&nbsp;" \
-                      "<input type=\"button\" class=\"course-clear-button\" onclick=\"clearCourse(this.parentElement)\" " \
-                      "class=\"btn-uni-grad btn-snall\" value=\"Remove\" />" \
+                      "<input type=\"button\" onclick=\"clearCourse(this.parentElement)\" " \
+                      "class=\"course-clear-button btn-uni-grad btn-snall\" value=\"Remove\" />" \
                       "</div></div>"
         else:
             output += "<div class=\"card selectable-card\">" \
                       "<div class=\"box-solid course-drop dropzone\">" \
                       "<span class=\"grey-text\">Course:&nbsp;</span>" \
                       "<span class=\"course-code\"></span>&nbsp;" \
-                      "<input type=\"button\" class=\"course-clear-button\" onclick=\"clearCourse(this.parentElement)\" " \
-                      "class=\"btn-uni-grad btn-snall\" value=\"Remove\" />" \
+                      "<input type=\"button\" onclick=\"clearCourse(this.parentElement)\" " \
+                      "class=\"course-clear-button btn-uni-grad btn-snall\" value=\"Remove\" />" \
                       "</div></div>"
 
     return Template(output).render(context)

--- a/cassdegrees/ui/templatetags/student_course_boxes.py
+++ b/cassdegrees/ui/templatetags/student_course_boxes.py
@@ -10,18 +10,27 @@ register = template.Library()
 
 
 @register.simple_tag(takes_context=True)
-def student_course_box(context, count):
+def student_course_box(context, count, display_course_index):
     output = ""
     iters = int(int(count) / 6)
 
     for i in range(iters):
-        output += "<div class=\"card selectable-card\">" \
-                  "<div class=\"box-solid course-drop dropzone\">" \
-                  "<span class=\"grey-text\">Course #" + str(i + 1) + ":&nbsp;</span>" \
-                  "<span class=\"course-code\"></span>&nbsp;" \
-                  "<input type=\"button\" class=\"course-clear-button\" onclick=\"clearCourse(this.parentElement)\" " \
-                  "class=\"btn-uni-grad btn-snall\" value=\"Remove\" />" \
-                  "</div></div>"
+        if display_course_index:
+            output += "<div class=\"card selectable-card\">" \
+                      "<div class=\"box-solid course-drop dropzone\">" \
+                      "<span class=\"grey-text\">Course #" + str(i + 1) + ":&nbsp;</span>" \
+                      "<span class=\"course-code\"></span>&nbsp;" \
+                      "<input type=\"button\" class=\"course-clear-button\" onclick=\"clearCourse(this.parentElement)\" " \
+                      "class=\"btn-uni-grad btn-snall\" value=\"Remove\" />" \
+                      "</div></div>"
+        else:
+            output += "<div class=\"card selectable-card\">" \
+                      "<div class=\"box-solid course-drop dropzone\">" \
+                      "<span class=\"grey-text\">Course:&nbsp;</span>" \
+                      "<span class=\"course-code\"></span>&nbsp;" \
+                      "<input type=\"button\" class=\"course-clear-button\" onclick=\"clearCourse(this.parentElement)\" " \
+                      "class=\"btn-uni-grad btn-snall\" value=\"Remove\" />" \
+                      "</div></div>"
 
     return Template(output).render(context)
 


### PR DESCRIPTION
Closes #385.

Closes #442.

Should close #440.

(Another big one, sorry!)

This PR fixes a few issues with PDF styling to improve both the overall layout and to improve fonts/consistency.

Firstly, this fixes issues with OR rules rendering multiple course boxes for all the branches. This now renders this as one. This does remove any pre-filled values from the template, though these are now listed as part of the rule description itself when this occurs.

Student filled values will still fill as per normal (note the changes as well to the student-facing frontend to fix that there as well).

The top title has been tweaked to maximise space, noting that if a student put in a really long title this would cause issues. This provides (at least) a little more space there.

Breaks between boxes has been removed, noting that a smaller plan was preferred in testing (ideally, one page). Further, we now render 4 columns (rather than 3) as this doesn't really affect readability and allows us to get more course boxes onto the page. Page margins have also been tweaked.

Edit: Sample image:
![DaringIssue](https://user-images.githubusercontent.com/1404334/65964048-92516a00-e44b-11e9-9724-ef58b59ace38.png)

**Jack's Edit:** Will also Close #416, as through testing this PR seems to remove the bug
