### PR TITLE
Implement Several Small Improvements

### DIFF
--- a/cassdegrees/static/js/staff/rules/course_elective.js
+++ b/cassdegrees/static/js/staff/rules/course_elective.js
@@ -6,7 +6,7 @@ Vue.component('rule_elective', {
             validator(value) {
                 // Ensure that the object has all the attributes we need
                 if (!value.hasOwnProperty("unit_count")) {
-                    value.unit_count = 0;
+                    value.unit_count = 24;
                 }
 
                 if (!value.hasOwnProperty("subject_area")) {
@@ -69,7 +69,7 @@ Vue.component('rule_elective', {
 
             // Ensure Unit Count is valid:
             if (this.details.unit_count !== "") {
-                this.invalid_units = this.details.unit_count < 0;
+                this.invalid_units = this.details.unit_count <= 0;
                 this.invalid_units_step = this.details.unit_count % 6 !== 0;
             } else {
                 this.invalid_units = false;

--- a/cassdegrees/static/js/staff/rules/course_selection.js
+++ b/cassdegrees/static/js/staff/rules/course_selection.js
@@ -272,15 +272,14 @@ Vue.component('rule_course_list', {
             if (is_submission) {
                 this.is_blank = blank_count || blank_codes || blank_listtype;
                 // Ensure Unit Count is valid:
-                if (this.details.list_type != "min_max") {
+                if (this.details.list_type !== "min_max") {
                     if (this.details.unit_count != null) {
                         this.invalid_units = this.details.unit_count <= 0;
                         this.invalid_units_step = this.details.unit_count % 6 !== 0;
                     }
                 } else {
-                    console.log("TELL ME WHYYYYY");
                     if (this.details.min_unit_count != null && this.details.max_unit_count != null) {
-                        this.invalid_units = this.details.min_unit_count <= 0 || this.details.max_unit_count <= 0;
+                        this.invalid_units = this.details.min_unit_count < 0 || this.details.max_unit_count <= 0;
                         this.invalid_units_step = this.details.min_unit_count %6 !== 0 || this.details.max_unit_count %6 !== 0;
 
                         this.invalid_min_max_units = parseInt(this.details.min_unit_count) > parseInt(this.details.max_unit_count);
@@ -293,6 +292,12 @@ Vue.component('rule_course_list', {
                 // remove error if user corrects prior to resubmission
                 if (!blank_listtype && !blank_codes && !blank_count) {
                     this.is_blank = false;
+                }
+                if (this.details.unit_count != null){
+                    if (this.details.unit_count > 0)
+                        this.invalid_units = false;
+                    if (this.details.unit_count % 6 === 0)
+                        this.invalid_units_step = false
                 }
             }
 

--- a/cassdegrees/static/js/staff/rules/custom_text.js
+++ b/cassdegrees/static/js/staff/rules/custom_text.js
@@ -10,7 +10,7 @@ Vue.component('rule_custom_text', {
                 }
 
                 if (!value.hasOwnProperty("unit_count")) {
-                    value.unit_count = "0";
+                    value.unit_count = "6";
                 }
 
                 if (!value.hasOwnProperty("show_course_boxes")) {
@@ -24,6 +24,7 @@ Vue.component('rule_custom_text', {
     data() {
         return {
             "not_divisible": false,
+            "invalid_units": false,
             "is_blank": false
         }
     },
@@ -36,6 +37,7 @@ Vue.component('rule_custom_text', {
         check_options(is_submission) {
             this.is_blank = this.details.text === "";
 
+            this.invalid_units = this.details.unit_count <= 0;
             this.not_divisible = this.details.unit_count % 6 !== 0;
 
             return !this.not_divisible && !this.is_blank;

--- a/cassdegrees/templates/widgets/rules/course_elective.html
+++ b/cassdegrees/templates/widgets/rules/course_elective.html
@@ -5,12 +5,12 @@
     <fieldset v-if="!redraw">
 
         <div v-if="subject_areas.length != 0">
-            <div class="msg-error" v-if="invalid_units">Unit count must be non-negative!</div>
+            <div class="msg-error" v-if="invalid_units">Unit count must be non-zero!</div>
             <div class="msg-error" v-if="invalid_units_step">Unit count should be divisible by 6!</div>
             <div class="msg-error" v-if="is_blank">All options must be filled in!</div>
             <p>
                 Students must complete
-                <input style="margin-left: 0;" class="text" v-on:change="update_units" onkeydown="javascript: return checkKeys(event)" type="number" min="0" step="6" max="1000" v-model="details.unit_count" aria-required="true" required>
+                <input style="margin-left: 0;" class="text" v-on:change="update_units" onkeydown="javascript: return checkKeys(event)" type="number" min="6" step="6" max="1000" v-model="details.unit_count" aria-required="true" required>
                 units from
                 <select v-model="details.year_level" required>
                     <option value="all" selected>All</option>

--- a/cassdegrees/templates/widgets/rules/course_selection.html
+++ b/cassdegrees/templates/widgets/rules/course_selection.html
@@ -26,13 +26,13 @@
         <p class="form-group" v-if="details.list_type == 'min_max'">
             <label style="width: 20.8333%; text-align: right; float: left;">Maximum units:</label>
             <input style="margin-left: 0;" class="text" onkeydown="javascript: return checkKeys(event)" type="number"
-                   v-on:change="update_units()" v-model="details.max_unit_count" min="0" step="6" max="1000" required>
+                   v-on:change="update_units()" v-model="details.max_unit_count" min="6" step="6" max="1000" required>
         </p>
 
         <p class="form-group" v-if="details.list_type !='min_max'">
             <label style="width: 20.8333%; text-align: right; float: left;">Number of units:</label>
             <input style="margin-left: 0;" class="text" onkeydown="javascript: return checkKeys(event)" type="number"
-                   v-on:change="update_units()" v-model="details.unit_count" min="0" step="6" max="1000" required>
+                   v-on:change="update_units()" v-model="details.unit_count" min="6" step="6" max="1000" required>
         </p>
 
         <br>

--- a/cassdegrees/templates/widgets/rules/custom_text.html
+++ b/cassdegrees/templates/widgets/rules/custom_text.html
@@ -15,10 +15,11 @@
 
         <p class="form-group">
             <label>Unit value for this item:</label>
-            <input class="text" v-on:change="update_units" onkeydown="javascript: return checkKeys(event)" type="number" min="0" max="1000" v-model="details.unit_count" aria-required="true" required>
+            <input class="text" v-on:change="update_units" onkeydown="javascript: return checkKeys(event)" type="number" min="6" max="1000" step="6" v-model="details.unit_count" aria-required="true" required>
         </p>
 
         <div class="msg-error" v-if="not_divisible">Units must be divisible by 6!</div>
+        <div class="msg-error" v-if="invalid_units">Unit count must be non-zero!</div>
 
         <p class="form-group">
             <label>Show 6-unit course boxes in plans (e.g. PDF):</label>


### PR DESCRIPTION
This PR implements the following changes in preparation for todays UAT:

- **Elective Rule:**
   - Default value is now 24 instead of 0
   - Values of 0 are now considered invalid (Can't complete 0 units of electives)
   - Minimum value of the unit scroll option is now 6 instead of 0
- **Course Selection Rule:**
   - Removed debug print statement
   - When choosing from the `Minimum and Maximum` option, a minimum of 0 is now valid
   - Error messages now disappear as soon as they are fixed
   - Standard and Max unit count boxes now have the minimum set to 6 instead of 0
- **Custom (Text) Rule:**
   - Default value now set to 6
   - Added verification on 
   - Minimum value of the unit scroll option is now 6 instead of 0
   - Step value was set to 6 for unit count