### PR TITLE
Select All (In Current Page/All Entries) in Course/Subplan/Program List

### DIFF
--- a/cassdegrees/static/css/style.css
+++ b/cassdegrees/static/css/style.css
@@ -41,6 +41,13 @@
     width: 98.36%; /* textarea need custom width as anu styling width makes it longer */
 }
 
+.list_menu {
+    height: 50px;
+    background-color: white;
+    position: sticky;
+    top: 0px;
+}
+
 .custom_search_bar input[type=text]{
     height: 30px;
     width: 78%;

--- a/cassdegrees/static/css/style.css
+++ b/cassdegrees/static/css/style.css
@@ -48,6 +48,10 @@
     top: 0px;
 }
 
+.shadow {
+    box-shadow: 0 5px 0 rgba(0,0,0,0.1);
+}
+
 .custom_search_bar input[type=text]{
     height: 30px;
     width: 78%;

--- a/cassdegrees/static/css/style.css
+++ b/cassdegrees/static/css/style.css
@@ -41,15 +41,11 @@
     width: 98.36%; /* textarea need custom width as anu styling width makes it longer */
 }
 
-.list_menu {
+.list-menu {
     height: 50px;
     background-color: white;
     position: sticky;
     top: 0px;
-}
-
-.shadow {
-    box-shadow: 0 5px 0 rgba(0,0,0,0.1);
 }
 
 .custom_search_bar input[type=text]{

--- a/cassdegrees/templates/staff/list.html
+++ b/cassdegrees/templates/staff/list.html
@@ -59,13 +59,13 @@
                 <div class="list-menu">
                     <p class="left">
                         <input class="btn-uni-grad btn-medium" type ="submit" formmethod="get" formaction="{{ render.staff_url_prefix }}create/{% if title == 'Program' %}program{% elif title == 'Subplan' %}subplan{% elif title == 'Course' %}course{% elif title == 'List' %}list{% endif %}/" value="+ New {{ title }}">
+                        {% if title == "Course" %}
+                            <input class="btn-uni-grad btn-medium" type ="submit" formmethod="get" formaction="{{ render.staff_url_prefix }}report/course/" value="View Courses Report">
+                        {% endif %}
+                    </p>
+                    <p class="right">
                         <input class="btn-uni-grad btn-medium" type ="submit" formaction="{{ render.staff_url_prefix }}delete/{% if title == 'Program' %}programs{% elif title == 'Subplan' %}subplans{% elif title == 'Course' %}courses{% elif title == 'List' %}lists{% endif %}/" value="&times Delete Selected">
                     </p>
-                    {% if title == "Course" %}
-                        <p class="right">
-                            <input class="btn-uni-grad btn-medium" type ="submit" formmethod="get" formaction="{{ render.staff_url_prefix }}report/course/" value="View Courses Report">
-                        </p>
-                    {% endif %}
                 </div>
 
                 <div id="select_all_div_{{ title }}" class="left fullwidth" hidden>
@@ -87,7 +87,7 @@
                             {% else %}
                                 <th class="text-center">
                                     Select All</br>
-                                    <input id="select_all" title="Select All" type="checkbox" name="select_all" onclick="selectAll(this, '{{ title }}')">
+                                    <input id="select_all" title="Select All" type="checkbox" name="select_all" onchange="selectAll(this, '{{ title }}')">
                                 </th>
                                 <th>{{ title }}</th>
                             {% endif %}
@@ -146,6 +146,8 @@
             var {{ title }}List = new List("{{ title }}Sorter", {{ title }}Options);
             var {{ title }}MsgHidden = true;
 
+            var PAGE_MAX = {{ title }}Options.page;
+
             // Code for Select All (in current page/all entries)
             function selectAll(source, currTitle) {
                 var checkboxes = document.getElementsByClassName('select_' + currTitle);
@@ -160,6 +162,7 @@
                     document.getElementById("select_all_msg_" + currTitle).innerHTML = "All " + checkboxes.length
                         + " " + currTitle + "s in this page are selected. <a href='#' class='show_all'>Select all " + currTitle + "s </a>" ;
                 }
+
                 var showAll = document.querySelector('.show_all');
                 {# checks for when the main select all checkbox is toggled #}
                 if (showAll) {
@@ -167,12 +170,34 @@
                 }
                 function selectAllHandler() {
                     let list = window[currTitle + "List"];
-                    list.page = list.size();
-                    list.update();
+                    updatePagination(list, list.size());
                     selectAll(source, currTitle);
                     document.getElementById("select_all_msg_" + currTitle).innerHTML = "All " + currTitle + "s " +
-                        "are selected.";
+                        "are selected. <a href='#' class='reset_pagination'>Clear All Selection</a>";
+
+                    {# clears all checkboxes #}
+                    var resetPagination = document.querySelector('.reset_pagination');
+                    if (resetPagination) {
+                        resetPagination.addEventListener('click', resetHandler, false);
+                    }
+                    function resetHandler() {
+                        unselectAll(checkboxes);
+                        source.checked = false;
+                        document.getElementById("select_all_div_" + currTitle).style.display = "none";
+                        window[currTitle + "MsgHidden"] = true;
+                    }
                 }
+            }
+
+            function unselectAll(checkboxes) {
+                for (var i=0, n=checkboxes.length; i<n; i++) {
+                    checkboxes[i].checked = false;
+                }
+            }
+
+            function updatePagination(list, number) {
+                list.page = number;
+                list.update();
             }
         </script>
     {% endfor %}

--- a/cassdegrees/templates/staff/list.html
+++ b/cassdegrees/templates/staff/list.html
@@ -56,7 +56,7 @@
                 {% csrf_token %}
                 {# Allow manage_courses() function to behave appropriately based on origin of request. The post request can either come from list.html or managecourses.html #}
                 <input type="hidden" id="perform_function" name="perform_function" value="retrieve view from selected">
-                <div class="list_menu">
+                <div class="list_menu shadow">
                     <p class="left">
                         <input class="btn-uni-grad btn-medium" type ="submit" formmethod="get" formaction="{{ render.staff_url_prefix }}create/{% if title == 'Program' %}program{% elif title == 'Subplan' %}subplan{% elif title == 'Course' %}course{% elif title == 'List' %}list{% endif %}/" value="+ New {{ title }}">
                         <input class="btn-uni-grad btn-medium" type ="submit" formaction="{{ render.staff_url_prefix }}delete/{% if title == 'Program' %}programs{% elif title == 'Subplan' %}subplans{% elif title == 'Course' %}courses{% elif title == 'List' %}lists{% endif %}/" value="&times Delete Selected">

--- a/cassdegrees/templates/staff/list.html
+++ b/cassdegrees/templates/staff/list.html
@@ -59,6 +59,7 @@
                 <div>
                     <p class="left">
                         <input class="btn-uni-grad btn-medium" type ="submit" formmethod="get" formaction="{{ render.staff_url_prefix }}create/{% if title == 'Program' %}program{% elif title == 'Subplan' %}subplan{% elif title == 'Course' %}course{% elif title == 'List' %}list{% endif %}/" value="+ New {{ title }}">
+                        <input class="btn-uni-grad btn-medium" type ="submit" formaction="{{ render.staff_url_prefix }}delete/{% if title == 'Program' %}programs{% elif title == 'Subplan' %}subplans{% elif title == 'Course' %}courses{% elif title == 'List' %}lists{% endif %}/" value="&times Delete Selected">
                     </p>
                     {% if title == "Course" %}
                         <p class="right">
@@ -125,11 +126,6 @@
                         </tr>
                     </tfoot>
                 </table>
-                <div class="right">
-                    <p class="right">
-                       <input class="btn-uni-grad btn-large" type ="submit" formaction="{{ render.staff_url_prefix }}delete/{% if title == 'Program' %}programs{% elif title == 'Subplan' %}subplans{% elif title == 'Course' %}courses{% elif title == 'List' %}lists{% endif %}/" value="&#128465Delete Selected">
-                    </p>
-                </div>
                 {% endif %}
             </form>
         </div>

--- a/cassdegrees/templates/staff/list.html
+++ b/cassdegrees/templates/staff/list.html
@@ -67,6 +67,10 @@
                     {% endif %}
                 </div>
 
+                <div id="select_all_div_{{ title }}" class="left fullwidth" hidden>
+                    <p id="select_all_msg_{{ title }}" class="msg-info"></p>
+                </div>
+
                 {# If there is no data available, notify the user #}
                 {% if not content %}
                     <p class="left fullwidth">No {{ title }}s to display</p>
@@ -81,8 +85,8 @@
                                 <th class="sort" data-sort="{{ title }}{{ key }}">{{ key }}</th>
                             {% else %}
                                 <th class="text-center">
-                                    Select All </br>
-                                    <input title="Select All" type="checkbox" name="select_all" onclick="selectAll(this, '{{ title }}')">
+                                    Select All</br>
+                                    <input id="select_all" title="Select All" type="checkbox" name="select_all" onclick="selectAll(this, '{{ title }}')">
                                 </th>
                                 <th>{{ title }}</th>
                             {% endif %}
@@ -144,6 +148,35 @@
             };
 
             var {{ title }}List = new List("{{ title }}Sorter", {{ title }}Options);
+            var {{ title }}MsgHidden = true;
+
+            function selectAll(source, currTitle) {
+                var checkboxes = document.getElementsByClassName('select_' + currTitle);
+                {# toggles all current rows displayed #}
+                for (var i=0, n=checkboxes.length; i<n; i++) {
+                    checkboxes[i].checked = source.checked;
+                }
+                {# if popup msg for current tab is still hidden #}
+                if (window[currTitle + "MsgHidden"]) {
+                    document.getElementById("select_all_div_" + currTitle).style.display = "block";
+                    window[currTitle + "MsgHidden"] = false;
+                    document.getElementById("select_all_msg_" + currTitle).innerHTML = "All " + checkboxes.length
+                        + " " + currTitle + "s in this page are selected. <a href='#' class='show_all'>Select all " + currTitle + "s </a>" ;
+                }
+                var showAll = document.querySelector('.show_all');
+                {# checks for when the main select all checkbox is toggled #}
+                if (showAll) {
+                    showAll.addEventListener('click', selectAllHandler, false);
+                }
+                function selectAllHandler() {
+                    let list = window[currTitle + "List"];
+                    list.page = list.size();
+                    list.update();
+                    selectAll(source, currTitle);
+                    document.getElementById("select_all_msg_" + currTitle).innerHTML = "All " + currTitle + "s " +
+                        "are selected.";
+                }
+            }
         </script>
     {% endfor %}
 
@@ -167,14 +200,6 @@
             document.getElementById(label+"Table").style.display = "block";
 
             oldLabel = label;
-        }
-
-        {# https://stackoverflow.com/questions/386281/how-to-implement-select-all-check-box-in-html #}
-        function selectAll(source, title) {
-            var checkboxes = document.getElementsByClassName('select_' + title);
-            for(var i=0, n=checkboxes.length; i<n; i++) {
-                checkboxes[i].checked = source.checked;
-            }
         }
 
         var openElement = (new URLSearchParams(window.location.search)).get("view");

--- a/cassdegrees/templates/staff/list.html
+++ b/cassdegrees/templates/staff/list.html
@@ -153,7 +153,12 @@
                 var checkboxes = document.getElementsByClassName('select_' + currTitle);
                 {# toggles all current rows displayed #}
                 for (var i=0, n=checkboxes.length; i<n; i++) {
-                    checkboxes[i].checked = source.checked;
+                    if (source.checked) {
+                        checkboxes[i].checked = source.checked;
+                    } else {
+                        checkboxes[i].checked = true;
+                        source.checked = true;
+                    }
                 }
                 {# if popup msg for current tab is still hidden #}
                 if (window[currTitle + "MsgHidden"]) {

--- a/cassdegrees/templates/staff/list.html
+++ b/cassdegrees/templates/staff/list.html
@@ -56,7 +56,7 @@
                 {% csrf_token %}
                 {# Allow manage_courses() function to behave appropriately based on origin of request. The post request can either come from list.html or managecourses.html #}
                 <input type="hidden" id="perform_function" name="perform_function" value="retrieve view from selected">
-                <div class="list_menu shadow">
+                <div class="list-menu">
                     <p class="left">
                         <input class="btn-uni-grad btn-medium" type ="submit" formmethod="get" formaction="{{ render.staff_url_prefix }}create/{% if title == 'Program' %}program{% elif title == 'Subplan' %}subplan{% elif title == 'Course' %}course{% elif title == 'List' %}list{% endif %}/" value="+ New {{ title }}">
                         <input class="btn-uni-grad btn-medium" type ="submit" formaction="{{ render.staff_url_prefix }}delete/{% if title == 'Program' %}programs{% elif title == 'Subplan' %}subplans{% elif title == 'Course' %}courses{% elif title == 'List' %}lists{% endif %}/" value="&times Delete Selected">
@@ -146,6 +146,7 @@
             var {{ title }}List = new List("{{ title }}Sorter", {{ title }}Options);
             var {{ title }}MsgHidden = true;
 
+            // Code for Select All (in current page/all entries)
             function selectAll(source, currTitle) {
                 var checkboxes = document.getElementsByClassName('select_' + currTitle);
                 {# toggles all current rows displayed #}

--- a/cassdegrees/templates/staff/list.html
+++ b/cassdegrees/templates/staff/list.html
@@ -157,7 +157,6 @@
                         checkboxes[i].checked = source.checked;
                     } else {
                         checkboxes[i].checked = true;
-                        source.checked = true;
                     }
                 }
                 {# if popup msg for current tab is still hidden #}

--- a/cassdegrees/templates/staff/list.html
+++ b/cassdegrees/templates/staff/list.html
@@ -56,7 +56,7 @@
                 {% csrf_token %}
                 {# Allow manage_courses() function to behave appropriately based on origin of request. The post request can either come from list.html or managecourses.html #}
                 <input type="hidden" id="perform_function" name="perform_function" value="retrieve view from selected">
-                <div>
+                <div class="list_menu">
                     <p class="left">
                         <input class="btn-uni-grad btn-medium" type ="submit" formmethod="get" formaction="{{ render.staff_url_prefix }}create/{% if title == 'Program' %}program{% elif title == 'Subplan' %}subplan{% elif title == 'Course' %}course{% elif title == 'List' %}list{% endif %}/" value="+ New {{ title }}">
                         <input class="btn-uni-grad btn-medium" type ="submit" formaction="{{ render.staff_url_prefix }}delete/{% if title == 'Program' %}programs{% elif title == 'Subplan' %}subplans{% elif title == 'Course' %}courses{% elif title == 'List' %}lists{% endif %}/" value="&times Delete Selected">


### PR DESCRIPTION
closes #276.

Note: Inspired by how Gmail does Select All.
What happens is:
- If you click on the 'Select All' checkbox, all the current checkboxes on the screen will be checked. A popup message will then be shown:
![image](https://user-images.githubusercontent.com/24206502/66017591-cb0e4380-e51e-11e9-97da-6208b870a22e.png)
- If you click on 'Select all Courses/Subplans/Programs' in the popup message, the pagination will be updated and all entries will be shown on screen. All the checkboxes on the screen will be checked. The message on the popup will update and tell you that you have selected all entries:
![image](https://user-images.githubusercontent.com/24206502/66017690-322bf800-e51f-11e9-8a1d-84b0b69182f1.png)
- As this implementation relies on the entries being shown on the screen, I have moved the 'Delete Selected' button from the bottom to the top, next to the 'Add' button. Also, I implemented the most basic form of sticky header (the buttons will stay at the top when you scroll down):
![image](https://user-images.githubusercontent.com/24206502/66017785-977fe900-e51f-11e9-9691-8f8a86f64c0a.png)
I'm not too sure of the idea of putting all the entries on the page when wanting to select all entries, but it's the only way I could do it where all the checkboxes can be seen as checked (even for gmail, when you select all entries, and you go through the pages, only the first page's checkboxes are checked).

Another Note: this took me way longer than expected due to not being experienced with javascript. Fortunately, I was able to eventually create a solution.
