### PR TITLE
Fix minor uat issues

### DIFF
--- a/cassdegrees/static/js/staff/rules.js
+++ b/cassdegrees/static/js/staff/rules.js
@@ -93,10 +93,10 @@ const SUBPLAN_UNITS = {
 
 const INFO_MSGS = {
     'course': '<p>This Requisite requires Courses in the system. Please create Courses ' +
-        '<a href="/staff/create/course/" target="_blank">here</a> or bulk upload Courses ' +
+        '<a href=javascript:document.getElementById("new_course_btn").click()>here</a> or bulk upload Courses ' +
         '<a href="/staff/bulk_upload/" target="_blank">here</a> first before creating this Requisite.</p>',
-    'subplan': '<p>This Requisite requires Subplans in the system. Please create Subplans ' +
-        '<a href="/staff/create/subplan/" target="_blank">here</a> first before creating this Requisite.</p>',
+    'subplan': '<p>There are no subplans of the specified year and type in the system. Please create Subplans ' +
+        '<a href=javascript:document.getElementById("new_subplan_btn").click()>here</a> first before creating this Requisite.</p>',
     'program': '<p>This Requisite requires Programs in the system. Please create Programs ' +
         '<a href="/staff/create/program/" target="_blank">here</a> first before creating this Requisite.</p>'
 };

--- a/cassdegrees/static/js/staff/rules/course_selection.js
+++ b/cassdegrees/static/js/staff/rules/course_selection.js
@@ -250,11 +250,11 @@ Vue.component('rule_course_list', {
         updateListTypeLabel() {
             if (this.details.list_type !== "") {
                 if (this.details.list_type !== "min_max") {
-                    this.details.max_unit_count = this.details.unit_count = "0";
-                    this.details.min_unit_count = this.details.unit_count = "0";
+                    this.details.max_unit_count = this.details.unit_count;
+                    this.details.min_unit_count = this.details.unit_count;
                 }
                 else
-                    this.details.unit_count = this.details.min_unit_count = "0";
+                    this.details.unit_count = this.details.min_unit_count;
 
                 this.list_type_label = this.list_types[this.details.list_type].toLowerCase();
 

--- a/cassdegrees/static/js/staff/rules/course_selection.js
+++ b/cassdegrees/static/js/staff/rules/course_selection.js
@@ -9,7 +9,7 @@ Vue.component('rule_course_list', {
                     codes: [],
                     list_description: "",
                     list_type: "",
-                    unit_count: 0
+                    unit_count: 6
                 }
             },
 

--- a/cassdegrees/static/js/staff/rules/either_or.js
+++ b/cassdegrees/static/js/staff/rules/either_or.js
@@ -124,10 +124,14 @@ Vue.component('rule_either_or', {
                 // Sum up the units of the or group
                 const group_units = {"exact": 0, "max": 0, "min": 0};
                 for (const details of or_group) {
-                    const child_units = this.find_rule(details).count_units();
-                    for (const key in child_units) {
-                        group_units[key] += child_units[key];
+                    const current_rule = this.find_rule(details);
+                    if(current_rule) {
+                        const child_units = current_rule.count_units();
+                        for (const key in child_units) {
+                            group_units[key] += child_units[key];
+                        }
                     }
+                    else break;
                 }
 
                 // If units has not been set yet, set it to the current OR group
@@ -194,10 +198,14 @@ Vue.component('rule_either_or', {
             for (const or_group of this.details.either_or) {
                 const group_units = {"exact": 0, "max": 0, "min": 0};
                 for (const details of or_group){
-                    const child_units = this.find_rule(details).count_units();
-                    for (const key in child_units) {
-                        group_units[key] += child_units[key];
+                    const current_rule = this.find_rule(details);
+                    if(current_rule) {
+                        const child_units = current_rule.count_units();
+                        for (const key in child_units) {
+                            group_units[key] += child_units[key];
+                        }
                     }
+                    else break;
                 }
 
                 if (group_units.exact + group_units.min > 48) {

--- a/cassdegrees/static/js/staff/rules/either_or.js
+++ b/cassdegrees/static/js/staff/rules/either_or.js
@@ -5,7 +5,7 @@ Vue.component('rule_either_or', {
             validator(value) {
                 // Ensure that the object has all the attributes we need
                 if (!value.hasOwnProperty("either_or")) {
-                    value.either_or = [];
+                    value.either_or = [[], []];
                 }
 
                 return true;

--- a/cassdegrees/templates/staff/creation/createprogram.html
+++ b/cassdegrees/templates/staff/creation/createprogram.html
@@ -55,7 +55,7 @@
                         {{ field }}
                     </p>
                     {% if field.name == "publish" %}
-                        <p class="text-center">Please tick the checkbox above as 'published' if you want this to be searchable as a requirement and by students</p>
+                        <p class="text-center">Please tick the 'published' checkbox above if you want to make this plan available to students</p>
                     {% endif %}
                     {% for error in field.errors %}
                          <div class="msg-error inline-error">{{ error }}</div>
@@ -100,9 +100,9 @@
     </div>
 
     <p class="left text-left">
-        <input class="btn-uni-grad btn-large" type="button" value="New Course"
+        <input id="new_course_btn" class="btn-uni-grad btn-large" type="button" value="New Course"
                onclick="toggleCourseCreationPopup()">
-        <input type="submit" class="btn-uni-grad btn-large" value="New Subplan"
+        <input id="new_subplan_btn" type="submit" class="btn-uni-grad btn-large" value="New Subplan"
                onclick="force_submit_form(this.value)">
     </p>
     <p class="right text-right">

--- a/cassdegrees/templates/staff/creation/createprogram.html
+++ b/cassdegrees/templates/staff/creation/createprogram.html
@@ -55,7 +55,7 @@
                         {{ field }}
                     </p>
                     {% if field.name == "publish" %}
-                        <p class="text-center">Please tick the 'published' checkbox above if you want to make this plan available to students</p>
+                        <p class="text-center">Please tick the 'publish' checkbox above if you want to make this plan available to students</p>
                     {% endif %}
                     {% for error in field.errors %}
                          <div class="msg-error inline-error">{{ error }}</div>

--- a/cassdegrees/templates/staff/creation/createsubplan.html
+++ b/cassdegrees/templates/staff/creation/createsubplan.html
@@ -54,7 +54,7 @@
                     {{ field }}
                 </p>
                 {% if field.name == "publish" %}
-                    <p class="text-center">Please tick the 'published' checkbox above if you want this subplan to be selectable in programs</p>
+                    <p class="text-center">Please tick the 'publish' checkbox above if you want this subplan to be selectable in programs</p>
                 {% endif %}
                 {% for error in field.errors %}
                      <div class="msg-error inline-error">{{ error }}</div>

--- a/cassdegrees/templates/staff/creation/createsubplan.html
+++ b/cassdegrees/templates/staff/creation/createsubplan.html
@@ -54,7 +54,7 @@
                     {{ field }}
                 </p>
                 {% if field.name == "publish" %}
-                    <p class="text-center">Please tick the checkbox above as 'published' if you want this to be searchable as a requirement by programs and students</p>
+                    <p class="text-center">Please tick the 'published' checkbox above if you want this subplan to be selectable in programs</p>
                 {% endif %}
                 {% for error in field.errors %}
                      <div class="msg-error inline-error">{{ error }}</div>
@@ -72,7 +72,7 @@
     </form>
 
     <p class="text-right">
-        <input class="left btn-uni-grad btn-large" type="button" value="New Course"
+        <input id="new_course_btn" class="left btn-uni-grad btn-large" type="button" value="New Course"
                onclick="toggleCourseCreationPopup()">
         <input class="btn-uni-grad btn-large" type="button" value="Cancel"
                onclick="{% if edit or 'list' in request.META.HTTP_REFERER %}returnToList('Subplan'){% else %}goBack(){% endif %}">

--- a/cassdegrees/templates/widgets/rules/course_selection.html
+++ b/cassdegrees/templates/widgets/rules/course_selection.html
@@ -51,38 +51,37 @@
                 Students must select a minimum of {{ min_unit_value_label }} units
                 and a maximum of {{ max_unit_value_label }} units from the following courses:
             </p>
-
-            <br>
-            <div class="align_right" style="margin-bottom: 5px">
-                <input type="button" value="Search Lists" class="btn-uni-grad btn-small" style="margin-left: 0"
-                       v-on:click="toggleListMode();"
-                       onclick="(this.value=='Search Lists') ? this.value='Search Courses' : this.value='Search Lists';">
-                <input type="button" value="Sort Courses" class="btn-uni-grad btn-small" style="margin-left: 0"
-                       @click="selected_courses=sortedSelectedList;">
-                <input type="button" value="Hide Courses" class="btn-uni-grad btn-small" style="margin-left: 0"
-                       v-on:click="is_courses_view_hidden=!is_courses_view_hidden"
-                       onclick="(this.value=='Hide Courses') ? this.value='Show Courses' : this.value='Hide Courses';"/>
-            </div>
-
-            <multiselect
-                    :options="courses"
-                    :value="optionsProxy"
-                    @input="updateSelected"
-                    :show-labels="true"
-                    :multiple="true"
-                    :searchable="true"
-                    :close-on-select="false"
-                    :placeholder="placeholderText"
-                    :custom-label="customLabel"
-                    track-by="name"
-                    :max-height="200"
-                    :open-direction="'top'"
-                    :loading="showLoadingSpinner"
-                    ref="multiselectref"
-            >
-            </multiselect>
         </div>
         <div v-else v-html="info_msg"></div>
+
+        <br>
+        <div class="align_right" style="margin-bottom: 5px">
+            <input type="button" value="Search Lists" class="btn-uni-grad btn-small" style="margin-left: 0"
+                   v-on:click="toggleListMode();"
+                   onclick="(this.value=='Search Lists') ? this.value='Search Courses' : this.value='Search Lists';">
+            <input type="button" value="Sort Courses" class="btn-uni-grad btn-small" style="margin-left: 0"
+                   @click="selected_courses=sortedSelectedList;">
+            <input type="button" value="Hide Courses" class="btn-uni-grad btn-small" style="margin-left: 0"
+                   v-on:click="is_courses_view_hidden=!is_courses_view_hidden"
+                   onclick="(this.value=='Hide Courses') ? this.value='Show Courses' : this.value='Hide Courses';"/>
+        </div>
+        <multiselect
+                :options="courses"
+                :value="optionsProxy"
+                @input="updateSelected"
+                :show-labels="true"
+                :multiple="true"
+                :searchable="true"
+                :close-on-select="false"
+                :placeholder="placeholderText"
+                :custom-label="customLabel"
+                track-by="name"
+                :max-height="200"
+                :open-direction="'top'"
+                :loading="showLoadingSpinner"
+                ref="multiselectref"
+        >
+        </multiselect>
 
         <div class="msg-warn" v-if="is_list_search">Searching in list mode,
         <a href="javascript:void(0);" @click="toggleListMode()">return to course mode</a></div>
@@ -100,7 +99,6 @@
                     </div>
                 </li>
             </template>
-            <div class="msg-warn" v-if="selected_courses.length == 0">You have not added any courses yet!</div>
         </ul>
 
         <div class="msg-warn" v-if="is_courses_view_hidden">This course list has been hidden!</div>

--- a/cassdegrees/templates/widgets/rules/course_selection.html
+++ b/cassdegrees/templates/widgets/rules/course_selection.html
@@ -43,36 +43,39 @@
         <div class="msg-error" v-if="is_blank">All options must be filled in!</div>
         <div class="msg-error" v-if="invalid_min_max_units">Minimum units count can not be greater than maximum units count!</div>
 
-        <p v-if="details.list_type != 'min_max'">
-            Students must select {{ list_type_label }} {{ unit_value_label }} units from the following courses:
-        </p>
-        <p v-if="details.list_type == 'min_max'">
-            Students must select a minimum of {{ min_unit_value_label }} units
-            and a maximum of {{ max_unit_value_label }} units from the following courses:
-        </p>
+        <div v-if="courses.length != 0">
+            <p v-if="details.list_type != 'min_max'">
+                Students must select {{ list_type_label }} {{ unit_value_label }} units from the following courses:
+            </p>
+            <p v-if="details.list_type == 'min_max'">
+                Students must select a minimum of {{ min_unit_value_label }} units
+                and a maximum of {{ max_unit_value_label }} units from the following courses:
+            </p>
 
-        <br>
+            <br>
 
-        <multiselect
-                :options="courses"
-                :value="optionsProxy"
-                @input="updateSelected"
-                :show-labels="true"
-                :multiple="true"
-                :searchable="true"
-                :close-on-select="false"
-                :placeholder="placeholderText"
-                :custom-label="customLabel"
-                track-by="name"
-                :max-height="200"
-                :open-direction="'top'"
-                :loading="showLoadingSpinner"
-                ref="multiselectref"
-        >
-        </multiselect>
+            <multiselect
+                    :options="courses"
+                    :value="optionsProxy"
+                    @input="updateSelected"
+                    :show-labels="true"
+                    :multiple="true"
+                    :searchable="true"
+                    :close-on-select="false"
+                    :placeholder="placeholderText"
+                    :custom-label="customLabel"
+                    track-by="name"
+                    :max-height="200"
+                    :open-direction="'top'"
+                    :loading="showLoadingSpinner"
+                    ref="multiselectref"
+            >
+            </multiselect>
+        </div>
+        <div v-else v-html="info_msg"></div>
 
         <div class="msg-warn" v-if="is_list_search">Searching in list mode,
-            <a href="javascript:void(0);" @click="toggleListMode()">return to course mode</a></div>
+        <a href="javascript:void(0);" @click="toggleListMode()">return to course mode</a></div>
 
         <ul class="resources-list">
             <template v-for="(resource, index) in sortedSelectedList">

--- a/cassdegrees/templates/widgets/rules/subplan.html
+++ b/cassdegrees/templates/widgets/rules/subplan.html
@@ -31,7 +31,10 @@
 
         <div v-if="sortedSubplanList.length != 0">
             <p>Students must pick one {{ student_description_label }} from the following {{ subplan_type_label }}:</p>
+        </div>
+        <div v-else-if="program_year != '' && details.subplan_type != ''" v-html="info_msg"></div>
 
+        <div v-if="program_year != '' && details.subplan_type != ''">
             <br>
             <div class="align_right" style="margin-bottom: 5px">
                 <input type="button" value="Sort Subplans" class="btn-uni-grad btn-small" style="margin-left: 0"
@@ -71,13 +74,10 @@
                         </div>
                     </li>
                 </template>
-                <div class="msg-warn" v-if="selected_subplans.length == 0">You have not added any subplans yet!</div>
             </ul>
-            <div class="msg-warn" v-if="is_subplans_view_hidden">This subplan list has been hidden!</div>
         </div>
         <div v-else-if="program_year == ''">Please select a year for the current program</div>
         <div v-else-if="details.subplan_type == ''">Please select a subplan type</div>
-        <div v-else v-html="info_msg"></div>
 
     </fieldset>
 </script>

--- a/cassdegrees/templates/widgets/rules/subplan.html
+++ b/cassdegrees/templates/widgets/rules/subplan.html
@@ -3,34 +3,33 @@
 {% verbatim %}
 <script type="text/x-template" id="subplanRuleMultiselectTemplate">
     <fieldset v-if="!redraw">
+        <div class="msg-error" v-if="non_unique_options">Options must be unique!</div>
+        <div class="msg-error" v-if="inconsistent_units">Options have different unit values!</div>
+        <div class="msg-error" v-if="wrong_year_selected">Selected subplans must have same year as program!</div>
+        <div class="msg-error" v-if="is_blank">All options must be filled in!</div>
 
-        <div v-if="subplans.length != 0">
-            <div class="msg-error" v-if="non_unique_options">Options must be unique!</div>
-            <div class="msg-error" v-if="inconsistent_units">Options have different unit values!</div>
-            <div class="msg-error" v-if="wrong_year_selected">Selected subplans must have same year as program!</div>
-            <div class="msg-error" v-if="is_blank">All options must be filled in!</div>
+        <p class="form-group">
+            <Label style="width: 20.8333%; text-align: right; float: left;">List name:</Label>
+            <input class="text tfull" v-model="details.list_description"
+                   placeholder="Optional description for CASS Staff Reference, e.g. CASS Majors" style="margin-left: 0;">
+        </p>
 
-            <p class="form-group">
-                <Label style="width: 20.8333%; text-align: right; float: left;">List name:</Label>
-                <input class="text tfull" v-model="details.list_description"
-                       placeholder="Optional description for CASS Staff Reference, e.g. CASS Majors" style="margin-left: 0;">
-            </p>
+        <p class="form-group">
+            <label style="width: 20.8333%; text-align: right; float: left;">Student description:</label>
+            <input class="text tfull" v-model="details.kind" v-on:change="updateStudentDescriptionLabel()" aria-required="true"
+                   placeholder="e.g. Arts Major - brief description for students here" style="margin-left: 0;">
+        </p>
 
-            <p class="form-group">
-                <label style="width: 20.8333%; text-align: right; float: left;">Student description:</label>
-                <input class="text tfull" v-model="details.kind" v-on:change="updateStudentDescriptionLabel()" aria-required="true"
-                       placeholder="e.g. Arts Major - brief description for students here" style="margin-left: 0;">
-            </p>
+        <p class="form-group">
+            <label style="width: 20.8333%; text-align: right; float: left;">Subplan type:</label>
+            <select v-model="details.subplan_type" v-on:change="change_filter" required style="margin-left: 0;">
+                <option v-for="(msg, type) in subplan_types" v-bind:value="type">{{ msg }}</option>
+            </select>
+        </p>
 
-            <p class="form-group">
-                <label style="width: 20.8333%; text-align: right; float: left;">Subplan type:</label>
-                <select v-model="details.subplan_type" v-on:change="change_filter" required style="margin-left: 0;">
-                    <option v-for="(msg, type) in subplan_types" v-bind:value="type">{{ msg }}</option>
-                </select>
-            </p>
+        <br>
 
-            <br>
-
+        <div v-if="sortedSubplanList.length != 0">
             <p>Students must pick one {{ student_description_label }} from the following {{ subplan_type_label }}:</p>
 
             <br>
@@ -52,23 +51,25 @@
                     ref="multiselectref"
             >
             </multiselect>
-
-            <ul class="resources-list">
-                <template v-for="(resource, index) in sortedSelectedList">
-                    <li class="resource-item" :data-index="index">
-                        <div class="resource-info">
-                            <div class="resource-title" :id="index">
-                                <span>{{ resource.code }} - {{ resource.name }} </span>
-                            </div>
-                        </div>
-                        <div class="delete-controls" v-on:click.prevent="remove_subplan(index)">
-                            <i class="fa fa-times fa-fw"></i>
-                        </div>
-                    </li>
-                </template>
-            </ul>
         </div>
+        <div v-else-if="program_year == ''">Please select a year for the current program</div>
+        <div v-else-if="details.subplan_type == ''">Please select a subplan type</div>
         <div v-else v-html="info_msg"></div>
+
+        <ul class="resources-list">
+            <template v-for="(resource, index) in sortedSelectedList">
+                <li class="resource-item" :data-index="index">
+                    <div class="resource-info">
+                        <div class="resource-title" :id="index">
+                            <span>{{ resource.code }} - {{ resource.name }} </span>
+                        </div>
+                    </div>
+                    <div class="delete-controls" v-on:click.prevent="remove_subplan(index)">
+                        <i class="fa fa-times fa-fw"></i>
+                    </div>
+                </li>
+            </template>
+        </ul>
 
     </fieldset>
 </script>

--- a/cassdegrees/ui/templatetags/cache_control.py
+++ b/cassdegrees/ui/templatetags/cache_control.py
@@ -10,7 +10,6 @@ register = template.Library()
 @register.simple_tag(takes_context=True)
 def static_no_cache(context, url):
     path = Path("." + settings.STATIC_URL + url)
-    print(str(path) + "?modified=" + str(path.stat().st_mtime))
     if path.exists():
         return Template(settings.STATIC_URL + url + "?version=" + str(path.stat().st_mtime)).render(context)
     else:


### PR DESCRIPTION
I figured I could remove around 10 "Easy" UAT items for the effort of any other "Easy" if I just quickly work through the basic ones. Here is the list of fixes:

1. Make the links in empty subplan/course lists function the same as the New Subplan/Course buttons
2. Make the "Empty List" error messages show up where the list would, rather than overwriting the entire rule
3. Reword the "Publish" tooltip
    - Programs: Please tick the 'published' checkbox above if you want to make this plan available to students
    - Subplans: Please tick the 'published' checkbox above if you want this subplan to be selectable in programs
4. Set the default course list unit count to 6
5. Make OR rules start with two groups by default
6. Removed cache debug code
7. Fix a bug where the course list unit count wasn't saving
8. Fix a bug where a lack of all rules would cause errors to print to the javascript console

**Examples of Item 2:**
<img width="789" alt="Screen Shot 2019-10-02 at 9 21 16 pm" src="https://user-images.githubusercontent.com/36946090/66040512-f57df200-e55a-11e9-8f36-c237ad85b35e.png">
<img width="782" alt="Screen Shot 2019-10-02 at 9 22 55 pm" src="https://user-images.githubusercontent.com/36946090/66040513-f57df200-e55a-11e9-956c-f38a0f4e1bdc.png">

**Edit:** Course selection box now remains when there are no courses
<img width="879" alt="Screen Shot 2019-10-03 at 4 01 03 pm" src="https://user-images.githubusercontent.com/36946090/66102890-37f50c80-e5f7-11e9-8d89-e63fb89cae7d.png">


