### PR TITLE
View/Download Bulk Upload Failures

### DIFF
--- a/cassdegrees/static/css/style.css
+++ b/cassdegrees/static/css/style.css
@@ -156,6 +156,11 @@ select.text{
     background: rgba(0, 0, 0, 0.5);
 }
 
+.modal-body {
+    max-height: calc(100vh - 210px);
+    overflow-y: auto;
+}
+
 .modal-card {
     position: absolute;
     left: 35%;

--- a/cassdegrees/static/css/style.css
+++ b/cassdegrees/static/css/style.css
@@ -43,7 +43,8 @@
 
 .custom_search_bar input[type=text]{
     height: 30px;
-    width: 67%;
+    width: 58%;
+    min-width: 420px;
     padding-left: 5px;
     margin-right: 1%;
     box-sizing: border-box;
@@ -54,8 +55,9 @@
 .custom_search_bar input[type=submit]{
     height: 30px;
     margin: 0;
-    width: 15%;
-    min-width: 80px;
+    width: 14%;
+    font-size: 50%;
+    min-width: 110px;
     box-sizing: border-box;
     display:inline-block;
     border-radius: 5px;

--- a/cassdegrees/static/css/style.css
+++ b/cassdegrees/static/css/style.css
@@ -43,8 +43,7 @@
 
 .custom_search_bar input[type=text]{
     height: 30px;
-    width: 58%;
-    min-width: 420px;
+    width: 67%;
     padding-left: 5px;
     margin-right: 1%;
     box-sizing: border-box;
@@ -55,9 +54,8 @@
 .custom_search_bar input[type=submit]{
     height: 30px;
     margin: 0;
-    width: 14%;
-    font-size: 50%;
-    min-width: 110px;
+    width: 15%;
+    min-width: 80px;
     box-sizing: border-box;
     display:inline-block;
     border-radius: 5px;

--- a/cassdegrees/templates/staff/bulkupload.html
+++ b/cassdegrees/templates/staff/bulkupload.html
@@ -40,6 +40,42 @@
             </form>
         </div>
     {% endfor %}
+
+
+
+    <div id="failedItemsPopup" class="modal" hidden>
+        <div class="modal-background"></div>
+        <div class="wide-modal-card card">
+            <header class="box-header">
+                Failed Items
+            </header>
+            <div class="box-solid box-has-footer">
+                <div class="modal-body">
+                    <table class="fullwidth tbl-cell-bdr">
+                        <tr>
+                            <th>Code</th>
+                            <th>Name</th>
+                            <th>Reason</th>
+                        </tr>
+                        {% for item in failed_items %}
+                            <tr>
+                                <td>{{ item.item_code }}</td>
+                                <td>{{ item.item_name }}</td>
+                                <td>{{ item.error }}</td>
+                            </tr>
+                        {% endfor %}
+                    </table>
+                </div>
+            </div>
+            <footer class="box-solid text-right">
+                <input onclick="toggleFailedItemsPopup()" type="button" class="left btn-uni-grad btn-small" value="Close" />
+                <input onclick="downloadFailuresCSV({{ failed_items }})" type="button" class="left btn-uni-grad btn-small" value="Download as CSV" />
+                <br>
+            </footer>
+        </div>
+    </div>
+
+
     {# Function to hide the previous tab while opening a new one #}
     <script>
         {# If user was already on a tab (e.g. uploaded a subplan file and got a message), stay on the same tab #}
@@ -63,6 +99,35 @@
         }
 
         var openElement = (new URLSearchParams(window.location.search)).get("view");
-        setActive(openElement)
+        setActive(openElement);
+
+        // Toggle whether the failed items popup is hidden or shown
+        function toggleFailedItemsPopup() {
+            var toggle = document.getElementById("failedItemsPopup");
+            toggle.hidden = !toggle.hidden;
+        }
+
+        /*
+         * Given the list of failed items, this function converts them into a CSV file
+         * and downloads it.
+         */
+        function downloadFailuresCSV(failures) {
+            let csvContent = "data:text/csv;charset=utf-8,";
+
+            // Convert array of failures into a csv format
+            failures.forEach(function(rowDict) {
+                let row = rowDict['item_code'] + "," + rowDict['item_name'].replace(/,/g, '') + "," + rowDict['error'];
+                csvContent += row + "\r\n";
+            });
+
+            // Download CSV file by creating and clicking a link
+            var encodedUri = encodeURI(csvContent);
+            var link = document.createElement("a");
+            link.setAttribute("href", encodedUri);
+            link.setAttribute("download", "bulk_upload_failed_items.csv");
+            document.body.appendChild(link); // Required for FF
+
+            link.click();
+        }
     </script>
 {% endblock %}

--- a/cassdegrees/ui/views/staff/bulk_data_upload.py
+++ b/cassdegrees/ui/views/staff/bulk_data_upload.py
@@ -393,8 +393,8 @@ def bulk_data_upload(request):
                                   " list and try manually adding ones that failed through the dedicated " \
                                   "forms. <br><br>The following " + content_type + " could not be added: " + \
                                   failed_str + \
-                                  "<br><a onclick='toggleFailedItemsPopup();'>Click here to see a complete list of " + \
-                                  "all " + content_type + " that could not be added.</a><br><br>" + \
+                                  "<br><a href='#' onclick='toggleFailedItemsPopup();'>Click here to see a complete " + \
+                                  "list of all " + content_type + " that could not be added.</a><br><br>" + \
                                   str(upload_count) + " items were uploaded successfully!"
             context['err_type'] = "warn"
 

--- a/cassdegrees/ui/views/staff/bulk_data_upload.py
+++ b/cassdegrees/ui/views/staff/bulk_data_upload.py
@@ -393,8 +393,8 @@ def bulk_data_upload(request):
                                   " list and try manually adding ones that failed through the dedicated " \
                                   "forms. <br><br>The following " + content_type + " could not be added: " + \
                                   failed_str + \
-                                  "<br><a href='#' onclick='toggleFailedItemsPopup();'>Click here to see a complete " + \
-                                  "list of all " + content_type + " that could not be added.</a><br><br>" + \
+                                  "<br><a onclick='toggleFailedItemsPopup();'>Click here to see a complete list of " + \
+                                  "all " + content_type + " that could not be added.</a><br><br>" + \
                                   str(upload_count) + " items were uploaded successfully!"
             context['err_type'] = "warn"
 

--- a/cassdegrees/ui/views/staff/bulk_data_upload.py
+++ b/cassdegrees/ui/views/staff/bulk_data_upload.py
@@ -319,8 +319,10 @@ def bulk_data_upload(request):
                         any_success = True
                         correctly_uploaded.append(course_str)
                     except:
-                        error_message = course_str + " Couldn't add: Check for duplicate course"
-                        failed_to_upload.append(error_message)
+                        error_message = "Couldn't add: Check for duplicate course"
+                        failed_to_upload.append({'item_code': course_instance.code,
+                                                 'item_name': course_instance.name,
+                                                 'error': error_message})
                         any_error = True
 
                 elif content_type == 'Subplans':
@@ -344,7 +346,10 @@ def bulk_data_upload(request):
                         correctly_uploaded.append(subplan_str)
                     except:
                         any_error = True
-                        failed_to_upload.append(subplan_str)
+                        error_message = "Couldn't add: Check for duplicate subplan"
+                        failed_to_upload.append({'item_code': subplan_instance.code,
+                                                 'item_name': subplan_instance.name,
+                                                 'error': error_message})
 
             else:
                 i = 0
@@ -361,10 +366,11 @@ def bulk_data_upload(request):
             correctly_uploaded = correctly_uploaded[0:show_count]
             correctly_uploaded.append("... and {} more items".format(upload_count - show_count))
 
+        failed_to_upload = sorted(failed_to_upload, key=lambda k: k['item_code'])
+        context['failed_items'] = failed_to_upload
         fail_count = len(failed_to_upload)
         if fail_count > show_count:
             failed_to_upload = failed_to_upload[0:show_count]
-            failed_to_upload.append("... and {} more items".format(fail_count - show_count))
 
         # Display error messages depending on the level of success of bulk upload.
         # There are 3 categories: All successful, some successful or none successful.
@@ -375,21 +381,21 @@ def bulk_data_upload(request):
         elif any_success and any_error:
             # for course in failed_to_upload:
             failed_str = ""
-            correct_str = ""
 
             for record in failed_to_upload:
-                failed_str = failed_str + "<br> - " + record
-
-            for record in correctly_uploaded:
-                correct_str = correct_str + "<br> - " + record
+                failed_str = failed_str + "<br> - " + record['item_code'] + " " + record['item_name']
+            if fail_count > show_count:
+                failed_str = failed_str + (("<br>... and {} more items").format(fail_count - show_count))
 
             context['user_msg'] = "Some items could not be added. They may already be present in the database" \
                                   " or the data may not be in the correct format. Please check the " \
                                   + content_type + \
                                   " list and try manually adding ones that failed through the dedicated " \
                                   "forms. <br><br>The following " + content_type + " could not be added: " + \
-                                  failed_str + "<br><br> " \
-                                  "The following " + content_type + " uploaded successfully: " + correct_str
+                                  failed_str + \
+                                  "<br><a onclick='toggleFailedItemsPopup();'>Click here to see a complete list of " + \
+                                  "all " + content_type + " that could not be added.</a><br><br>" + \
+                                  str(upload_count) + " items were uploaded successfully!"
             context['err_type'] = "warn"
 
         elif not any_success and any_error:


### PR DESCRIPTION
Closes #401.

Added a link where users can view ALL the courses/subplans that failed to be uploaded, and can download them as a CSV file. 

Removed the listings for successfully uploaded items and just replaced it with a number of successes. 

![image](https://user-images.githubusercontent.com/37424867/66100232-7685c980-e5ed-11e9-95a0-b3c4094d1b7c.png)

![image](https://user-images.githubusercontent.com/37424867/66100254-8bfaf380-e5ed-11e9-9a44-707d55f65061.png)
