### PR TITLE
Fixed bug where other_offering was always set as 'True'.

### DIFF
--- a/cassdegrees/ui/views/staff/bulk_data_upload.py
+++ b/cassdegrees/ui/views/staff/bulk_data_upload.py
@@ -147,7 +147,7 @@ def bulk_data_upload(request):
                         comments = comments.upper() if comments is not None else ""
 
                         # Semester columns with 'other' and non-empty Comments column are marked with 'other_offering'.
-                        other_offering = semesters == "OTHER" or comments != ""
+                        other_offering = semesters == "OTHER" or comments is None
 
                         sem_offer_set = False  # Marks whether semester 1, 2 offerings are set in the "Semesters" column
 


### PR DESCRIPTION
Original Issue: #432 

This fixes a bug in bulk_uploader that accidently marked all courses in the CASS custom excel sheet to have 'other offering'.

Since this is such a simple fix, I will merge it in straight away.

Before:
![image](https://user-images.githubusercontent.com/37033052/66271742-8d5a4380-e8ad-11e9-8a82-b4ab61cfedf3.png)

After:
![image](https://user-images.githubusercontent.com/37033052/66271741-86cbcc00-e8ad-11e9-80a3-d7c382b3c1f4.png)
