### PR TITLE
Truncate courses in course lists in PDFs to avoid filling up entire page

### DIFF
--- a/cassdegrees/templates/pdf_base.html
+++ b/cassdegrees/templates/pdf_base.html
@@ -58,6 +58,10 @@
             break-after: page;
         }
 
+        .break-page {
+            break-after: left;
+        }
+
         .no-bottom-margin {
             margin-bottom: 0 !important;
             padding-bottom: 0 !important;

--- a/cassdegrees/templates/pdf_program.html
+++ b/cassdegrees/templates/pdf_program.html
@@ -21,7 +21,7 @@
     <div class="columns-4 columns-no-gap">
 
         {% for rule in program.rules %}
-            {% include "widgets/pdf_rules.html" with render_rules=True render_units=True %}
+            {% include "widgets/pdf_rules.html" with render_rules=True render_units=True cache_large_lists=True %}
         {% endfor %}
 
         <div class="box small-text">
@@ -58,4 +58,6 @@
             </div>
         {% endfor %}
     </div>
+
+    {% print_extended_course_lists %}
 {% endblock %}

--- a/cassdegrees/templates/widgets/pdf_rules.html
+++ b/cassdegrees/templates/widgets/pdf_rules.html
@@ -34,16 +34,12 @@
                             <p>Complete {{ rule.unit_count }} units from the following
                                 {% if rule.unit_count|add:"0" <= 6 %}course{% else %}set of courses{% endif %}:
                             {% if not render_units %}
-                                {% for code in rule.codes %}
-                                    {{ code.code }}{% if not forloop.last %}, {% endif %}
-                                {% endfor %}
+                                {% truncate_course_list rule.codes %}
                             {% endif %}
                         {% else %}
                             {# Not all required courses - give descriptions #}
                             <p>Complete {{ rule.unit_count }} units from a selection of:</p>
-                            {% for code in rule.codes %}
-                                {{ code.code }}{% if not forloop.last %}, {% endif %}
-                            {% endfor %}
+                            {% truncate_course_list rule.codes %}
                         {% endif %}
                     {% endwith %}
                 {% else %}
@@ -54,17 +50,13 @@
                                 {{ rule.max_unit_count }} units from the following
                                 {% if rule.unit_count|add:"0" <= 6 %}course{% else %}set of courses{% endif %}:</p>
                             {% if not render_units %}
-                                {% for code in rule.codes %}
-                                    {{ code.code }}{% if not forloop.last %}, {% endif %}
-                                {% endfor %}
+                                {% truncate_course_list rule.codes %}
                             {% endif %}
                         {% else %}
                             {# Not all required courses - give descriptions #}
                             <p><p>Complete a minimum of {{ rule.min_unit_count }} units and a maximum of
                                 {{ rule.max_unit_count }} units from a selection of:</p>
-                            {% for code in rule.codes %}
-                                {{ code.code }}{% if not forloop.last %}, {% endif %}
-                            {% endfor %}
+                            {% truncate_course_list rule.codes %}
                         {% endif %}
                     {% endwith %}
                 {% endif %}

--- a/cassdegrees/templates/widgets/pdf_rules.html
+++ b/cassdegrees/templates/widgets/pdf_rules.html
@@ -34,12 +34,12 @@
                             <p>Complete {{ rule.unit_count }} units from the following
                                 {% if rule.unit_count|add:"0" <= 6 %}course{% else %}set of courses{% endif %}:
                             {% if not render_units %}
-                                {% truncate_course_list rule.codes %}
+                                {% truncate_course_list rule.codes cache_large_lists %}
                             {% endif %}
                         {% else %}
                             {# Not all required courses - give descriptions #}
                             <p>Complete {{ rule.unit_count }} units from a selection of:</p>
-                            {% truncate_course_list rule.codes %}
+                            {% truncate_course_list rule.codes cache_large_lists %}
                         {% endif %}
                     {% endwith %}
                 {% else %}
@@ -50,13 +50,13 @@
                                 {{ rule.max_unit_count }} units from the following
                                 {% if rule.unit_count|add:"0" <= 6 %}course{% else %}set of courses{% endif %}:</p>
                             {% if not render_units %}
-                                {% truncate_course_list rule.codes %}
+                                {% truncate_course_list rule.codes cache_large_lists %}
                             {% endif %}
                         {% else %}
                             {# Not all required courses - give descriptions #}
                             <p><p>Complete a minimum of {{ rule.min_unit_count }} units and a maximum of
                                 {{ rule.max_unit_count }} units from a selection of:</p>
-                            {% truncate_course_list rule.codes %}
+                            {% truncate_course_list rule.codes cache_large_lists %}
                         {% endif %}
                     {% endwith %}
                 {% endif %}
@@ -67,7 +67,7 @@
             {% for group in rule.either_or %}
                 <div class="left-box">
                     {% for rule in group %}
-                        {% include "widgets/pdf_rules.html" with render_rules=True render_units=False %}
+                        {% include "widgets/pdf_rules.html" with render_rules=True render_units=False cache_large_lists=True %}
                     {% endfor %}
                 </div>
 

--- a/cassdegrees/ui/templatetags/course_boxes.py
+++ b/cassdegrees/ui/templatetags/course_boxes.py
@@ -78,7 +78,6 @@ def truncate_course_list(context, courses, cache_large_lists, count=5):
 @register.simple_tag(takes_context=True)
 def print_extended_course_lists(context):
     if not hasattr(context, "large_course_lists"):
-        print("No large course lists. Ah well.")
         return Template("").render(context)
 
     output = "<div class=\"break-page\"></div>" \

--- a/cassdegrees/ui/templatetags/course_boxes.py
+++ b/cassdegrees/ui/templatetags/course_boxes.py
@@ -51,6 +51,23 @@ def course_box_with_values(context, count, courses, plan):
 
     return Template(output).render(context)
 
+
+@register.simple_tag(takes_context=True)
+def truncate_course_list(context, courses, count=5):
+    output = ""
+    for i in range(0, len(courses)):
+        output += str(courses[i]['code'])
+
+        if i >= count - 1 and count < len(courses):
+            output += " and " + str(len(courses) - count) + " more"
+            break
+
+        if i + 1 < len(courses):
+            output += ", "
+
+    return Template(output).render(context)
+
+
 # https://stackoverflow.com/questions/4651172/reference-list-item-by-index-within-django-template/29664945#29664945
 @register.filter
 def index(List, i):

--- a/cassdegrees/ui/templatetags/course_boxes.py
+++ b/cassdegrees/ui/templatetags/course_boxes.py
@@ -53,20 +53,54 @@ def course_box_with_values(context, count, courses, plan):
 
 
 @register.simple_tag(takes_context=True)
-def truncate_course_list(context, courses, count=5):
+def truncate_course_list(context, courses, cache_large_lists, count=5):
+    if len(courses) > count and cache_large_lists:
+        # Store this for later, and assign it an appendix id
+        if not hasattr(context, "large_course_lists"):
+            context.large_course_lists = {}
+
+        id = len(context.large_course_lists) + 1 # Zero-indexed -> human readable
+
+        context.large_course_lists[id] = courses
+
+        return Template("See appendix #" + str(id) + " for complete course list.").render(context)
+
     output = ""
     for i in range(0, len(courses)):
         output += str(courses[i]['code'])
-
-        if i >= count - 1 and count < len(courses):
-            output += " and " + str(len(courses) - count) + " more"
-            break
 
         if i + 1 < len(courses):
             output += ", "
 
     return Template(output).render(context)
 
+
+@register.simple_tag(takes_context=True)
+def print_extended_course_lists(context):
+    if not hasattr(context, "large_course_lists"):
+        print("No large course lists. Ah well.")
+        return Template("").render(context)
+
+    output = "<div class=\"break-page\"></div>" \
+             "<div class=\"columns-4 columns-no-gap\">" \
+             "<h2>Appendix</h2>"
+
+    for (id, courses) in context.large_course_lists.items():
+        output += "<h3>Course List #" + str(id) + ":</h3>"
+
+        output += "<div>"
+
+        for i in range(0, len(courses)):
+            output += str(courses[i]['code'])
+
+            if i + 1 < len(courses):
+                output += ", "
+
+        output += "</div>"
+
+    output += "</div>"
+
+    return Template(output).render(context)
 
 # https://stackoverflow.com/questions/4651172/reference-list-item-by-index-within-django-template/29664945#29664945
 @register.filter

--- a/cassdegrees/ui/templatetags/course_boxes.py
+++ b/cassdegrees/ui/templatetags/course_boxes.py
@@ -63,7 +63,7 @@ def truncate_course_list(context, courses, cache_large_lists, count=5):
 
         context.large_course_lists[id] = courses
 
-        return Template("See appendix #" + str(id) + " for complete course list.").render(context)
+        return Template("See appendix #" + str(id) + ".").render(context)
 
     output = ""
     for i in range(0, len(courses)):

--- a/cassdegrees/ui/templatetags/course_boxes.py
+++ b/cassdegrees/ui/templatetags/course_boxes.py
@@ -59,7 +59,7 @@ def truncate_course_list(context, courses, cache_large_lists, count=5):
         if not hasattr(context, "large_course_lists"):
             context.large_course_lists = {}
 
-        id = len(context.large_course_lists) + 1 # Zero-indexed -> human readable
+        id = len(context.large_course_lists) + 1  # Zero-indexed -> human readable
 
         context.large_course_lists[id] = courses
 


### PR DESCRIPTION
Closes #349

This PR truncates courses in course lists to prevent issues where a large course list can consume way too much space. It would be much more preferable for students to consult P&C in these cases as it isn't feasible to communicate all possible course combinations in templates.

Preview:
![VacantCloud](https://user-images.githubusercontent.com/1404334/66286281-30b45400-e8c0-11e9-87d8-dfead89f300c.png)
