### PR TITLE
Implement check to verify that unsaved changes are acknowledged

### DIFF
--- a/cassdegrees/templates/staff/creation/createcourse.html
+++ b/cassdegrees/templates/staff/creation/createcourse.html
@@ -87,6 +87,9 @@
     <script>
         function submit_form(form_action, redirect) {
             if (app.export_rules()) {
+                // Disable check for unsaved changes - we are saving them here!
+                contentsSubmission = true;
+
                 document.getElementById('mainForm').action.value = form_action;
                 document.getElementById('redirect').value = redirect;
                 document.getElementById('mainForm').submit();

--- a/cassdegrees/templates/staff/creation/createprogram.html
+++ b/cassdegrees/templates/staff/creation/createprogram.html
@@ -135,6 +135,9 @@
                     return false;
                 }
 
+                // Disable check for unsaved changes - we are saving them here!
+                contentsSubmission = true;
+
                 document.getElementById('mainForm').action.value = form_action;
                 document.getElementById('redirect').value = redirect;
                 document.getElementById('mainForm').submit();
@@ -147,6 +150,9 @@
         function force_submit_form(form_action, redirect) {
             app.export_rules();
             globalRequirementsApp.export_requirements();
+
+            // Disable check for unsaved changes - we are saving them here!
+            contentsSubmission = true;
 
             document.getElementById('mainForm').action.value = form_action;
             document.getElementById('redirect').value = redirect;

--- a/cassdegrees/templates/staff/creation/createsubplan.html
+++ b/cassdegrees/templates/staff/creation/createsubplan.html
@@ -92,7 +92,10 @@
                 document.getElementById('mainForm').year.value = "{{ year }}";
         });
 
-        function submit_course_form(){
+        function submit_course_form() {
+            // Disable check for unsaved changes - we are saving them here!
+            contentsSubmission = true;
+
             app.export_rules();
             document.getElementById('mainForm').submit();
         }
@@ -115,6 +118,9 @@
                         return false;
                     }
                 }
+
+                // Disable check for unsaved changes - we are saving them here!
+                contentsSubmission = true;
 
                 document.getElementById('redirect').value = redirect;
                 document.getElementById('mainForm').submit();


### PR DESCRIPTION
Closes #408

This PR implements a check to ensure that users aren't losing work when they navigate off a page after making changes to any field. This won't occur in scenarios where a user is submitting a form, but will based on browser navigation or clicking on links. Note that this will not work in all browsers - a few niche browsers intentionally block the ability to block page navigation.

This wasn't been implemented on the student facing side as that uses a different blob of js and would need further investigation.

In Firefox, for example:

![change-page](https://user-images.githubusercontent.com/1404334/66290569-264d8680-e8cf-11e9-90e3-b199dd8f5f5f.png)
