### PR TITLE
Fix outputting of JSON on student page for specific rules

### DIFF
--- a/cassdegrees/templates/widgets/student/rules.html
+++ b/cassdegrees/templates/widgets/student/rules.html
@@ -34,7 +34,7 @@
                             {# Not all required courses - give descriptions #}
                             <p>Complete {{ rule.unit_count }} units from a selection of:</p>
                             {% for code in rule.codes %}
-                                {{ code }}{% if not forloop.last %}, {% endif %}
+                                {{ code.code }}{% if not forloop.last %}, {% endif %}
                             {% endfor %}
                         {% endif %}
                     {% endwith %}


### PR DESCRIPTION
1-liner to fix issue with student frontend where certain rules would output JSON instead of course codes.

Previous:
![student-json](https://user-images.githubusercontent.com/1404334/66291321-074ff400-e8d1-11e9-90c4-0defaecc050f.png)
