### PR TITLE
Draggable rules

### DIFF
--- a/cassdegrees/static/css/style.css
+++ b/cassdegrees/static/css/style.css
@@ -120,8 +120,13 @@
 
 .hovering {
     z-index:100;
-    box-shadow: 5px 10px 8px #888888;
+    box-shadow: 15px 30px 24px #888888;
     position: relative;
+    opacity: 0.8;
+}
+
+.hidden-outer {
+    height: 0px;
 }
 
 

--- a/cassdegrees/static/css/style.css
+++ b/cassdegrees/static/css/style.css
@@ -107,6 +107,20 @@
     color:#FFF;
 }
 
+.dropzone-area {
+    width: 100%;
+    height: 60px;
+    border: 2px green dashed;
+    margin-bottom: 10px;
+}
+
+.hovering {
+    z-index:100;
+    box-shadow: 5px 10px 8px #888888;
+    position: relative;
+}
+
+
 /* Adds carets to list sorting options */
 table th {}
 .sort:after{

--- a/cassdegrees/static/css/style.css
+++ b/cassdegrees/static/css/style.css
@@ -107,6 +107,10 @@
     color:#FFF;
 }
 
+.draggable-group {
+    background-color: white;
+}
+
 .dropzone-area {
     width: 100%;
     height: 60px;

--- a/cassdegrees/static/js/staff/rules.js
+++ b/cassdegrees/static/js/staff/rules.js
@@ -173,8 +173,7 @@ function isValidUnitCount(value) {
 // Resets the on-screen position of a particular draggable
 function resetDraggable(target) {
     target.style.webkitTransform =
-        target.style.transform =
-            'translate(' + 0 + 'px, ' + 0 + 'px)';
+        target.style.transform = null;
 }
 
 // Moves the element to the x, y position
@@ -212,10 +211,10 @@ interact('.draggable-rule').draggable({
         // To my knowledge, there is no reliable way to get this information otherwise
         var or_y = 0;
         var dropzone_height = 72;
-        var id = event.target.parentNode.parentNode.id;
+        var id = event.target.parentNode.parentNode.getAttribute('drag_id');
         for (var dropzone of dropzones) {
             // Set the dropzone id
-            var dz_id = dropzone.parentNode.id;
+            var dz_id = dropzone.parentNode.getAttribute('drag_id');
 
             // If the dropzone is in an OR rule, don't add the height directly in case we are dragging the OR rule
             if (dz_id.split('_').length === 3){
@@ -275,8 +274,8 @@ interact('.dropzone').dropzone({
         target.classList.remove("hover");
 
         // Get IDs of focus and target objects, which provides information on their location
-        var focus_id = courseObject.parentNode.parentNode.id;
-        var target_id = target.parentNode.id;
+        var focus_id = courseObject.parentNode.parentNode.getAttribute('drag_id');
+        var target_id = target.parentNode.getAttribute('drag_id');
 
         // Deconstruct the vue rule information
         var old_parent_id = parseInt(focus_id .split('_')[0]);
@@ -370,10 +369,10 @@ interact('.draggable-group').draggable({
         // Changes the Y value by the amount of dropzones that will appear
         // To my knowledge, there is no reliable way to get this information otherwise
         var dropzone_height = 72;
-        var id = event.target.id;
+        var id = event.target.getAttribute('drag_id');
         for (var dropzone of dropzones) {
             // Set the dropzone id
-            var dz_id = dropzone.parentNode.id;
+            var dz_id = dropzone.parentNode.getAttribute('drag_id');
 
             // If we have found the dragged rule, don't ad any more dropzones
             if(dz_id === id)
@@ -415,8 +414,8 @@ interact('.group-dropzone').dropzone({
         target.classList.remove("hover");
 
         // Get IDs of focus and target objects, which provides information on their location
-        var focus_id = courseObject.id;
-        var target_id = target.parentNode.id;
+        var focus_id = courseObject.getAttribute('drag_id');
+        var target_id = target.parentNode.getAttribute('drag_id');
 
         // Deconstruct the vue rule information
         var old_parent_id = parseInt(focus_id .split('_')[0]);

--- a/cassdegrees/static/js/staff/rules.js
+++ b/cassdegrees/static/js/staff/rules.js
@@ -194,12 +194,15 @@ interact('.draggable-rule').draggable({
     onstart: function(event) {
         // Make the class look like it's hovering
         event.target.parentNode.classList.add('hovering');
-        // Unhide all of the drop zones, then re-hide the one belowe the currently held element
+        // Unhide all of the drop zones
         var dropzones = document.getElementsByClassName('dropzone dropzone-area');
         for (var dropzone of dropzones) {
             dropzone.hidden = false;
         }
-        event.target.parentNode.parentNode.getElementsByClassName('dropzone dropzone-area')[0].hidden = true;
+        // Hide all dropzones belonging to the current component
+        for (var dropzone of event.target.parentNode.parentNode.getElementsByClassName('dropzone dropzone-area'))
+            dropzone.hidden = true;
+
         for (var rule of document.getElementsByClassName('rule_active_visual'))
             rule.classList.remove('rule_active_visual');
 

--- a/cassdegrees/static/js/staff/rules.js
+++ b/cassdegrees/static/js/staff/rules.js
@@ -1,6 +1,7 @@
 //! Vue.js based means of adding/removing rules. Excludes serialization (see programmanagement.js)
 
 var id_map = {};
+var should_mark_newest_component = false;
 
 // Stores a JSON of all rule names, for internal reference only.
 const ALL_COMPONENT_NAMES = {
@@ -200,6 +201,8 @@ interact('.draggable-rule').draggable({
             dropzone.hidden = false;
         }
         event.target.parentNode.parentNode.getElementsByClassName('dropzone dropzone-area')[0].hidden = true;
+        for (var rule of document.getElementsByClassName('rule_active_visual'))
+            rule.classList.remove('rule_active_visual');
 
         // Set the original X and Y position of the element
         this.x = event.pageX;
@@ -316,6 +319,8 @@ interact('.dropzone').dropzone({
                 old_parent.remove(old_component_id, old_group_id);
             else
                 old_parent.remove(old_component_id);
+
+            new_parent.update_units();
         }
         // If the new parent is not an OR rule (meaning it is a rule-container)
         else{
@@ -325,11 +330,8 @@ interact('.dropzone').dropzone({
             // Insert new rule in to the parent
             new_parent.rules.splice(new_component_id, 0, current_component.details);
 
-            // If the new parent is different from the old one, add the rule values to it
-            if (old_parent_id !== new_parent_id)
-                new_parent.$children.push(current_component);
             // If the new parent is the same, increment the old component ID if it should change
-            else if (new_component_id < old_component_id){
+            if (new_component_id < old_component_id){
                 old_component_id += 1;
             }
 
@@ -339,5 +341,7 @@ interact('.dropzone').dropzone({
             else
                 old_parent.remove(old_component_id);
         }
+
+        should_mark_newest_component = false;
     }
 });

--- a/cassdegrees/static/js/staff/rules.js
+++ b/cassdegrees/static/js/staff/rules.js
@@ -176,12 +176,14 @@ function resetDraggable(target) {
         target.style.transform = null;
 }
 
-// Moves the element to the x, y position
-function dragMoveListener(event, x, y) {
+// Moves the element to the x, y position and scales it
+function dragMoveListener(event, x, y, origin_x, origin_y) {
     var target = event.target.parentNode;
+    target.style.transformOrigin = origin_x + 'px ' + origin_y + 'px';
+
     target.style.webkitTransform =
         target.style.transform =
-            'translate(' + x + 'px, ' + y + 'px)';
+            'translate(' + (event.pageX - x) + 'px, ' + (event.pageY - y) + 'px) scale(0.33)';
 }
 
 interact('.draggable-rule').draggable({
@@ -190,9 +192,12 @@ interact('.draggable-rule').draggable({
 
     x: 0,
     y: 0,
+    origin_x: 0,
+    origin_y: 0,
 
     onstart: function(event) {
         let id = event.target.parentNode.parentNode.getAttribute('drag_id');
+        event.target.parentNode.parentNode.classList.add('hidden-outer');
 
         // Make the class look like it's hovering
         event.target.parentNode.classList.add('hovering');
@@ -224,6 +229,8 @@ interact('.draggable-rule').draggable({
         // Set the original X and Y position of the element
         this.x = event.pageX;
         this.y = event.pageY;
+        this.origin_x = event.x0-event.rect.left;
+        this.origin_y = event.y0-event.rect.top;
 
         // Changes the Y value by the amount of dropzones that will appear
         // To my knowledge, there is no reliable way to get this information otherwise
@@ -261,11 +268,12 @@ interact('.draggable-rule').draggable({
         }
     },
     onmove: function(event) {
-        dragMoveListener(event, event.pageX-this.x, event.pageY-this.y)
+        dragMoveListener(event, this.x, this.y, this.origin_x, this.origin_y)
     },
     onend: function(event) {
         // Flag this course to be moved back to the start
         event.target.parentNode.classList.remove("hovering");
+        event.target.parentNode.parentNode.classList.remove('hidden-outer');
         var dropzones = document.getElementsByClassName('dropzone dropzone-area');
         for (var dropzone of dropzones)
             dropzone.hidden = true;
@@ -324,7 +332,7 @@ interact('.dropzone').dropzone({
             new_parent.details.either_or[new_group_id].splice(new_component_id, 0, current_component.details);
             // If the new parent is different from the old one, add the rule values to it
             if (old_parent_id !== new_parent_id)
-                new_parent.$children.push(current_component);
+                new_parent.$forceUpdate();
             // If the new parent is the same, and the group is the same, increment the old component ID if it should change
             else if (old_group_id === new_group_id &&
                     new_component_id < old_component_id){
@@ -369,10 +377,13 @@ interact('.draggable-group').draggable({
 
     x: 0,
     y: 0,
+    origin_x: 0,
+    origin_y: 0,
 
     onstart: function(event) {
         // Make the class look like it's hovering
         event.target.parentNode.classList.add('hovering');
+        event.target.parentNode.classList.add('hidden-outer');
         // Unhide all of the drop zones, then re-hide the one belowe the currently held element
         var dropzones = document.getElementsByClassName('group-dropzone dropzone-area');
         for (var dropzone of dropzones) {
@@ -383,6 +394,8 @@ interact('.draggable-group').draggable({
         // Set the original X and Y position of the element
         this.x = event.pageX;
         this.y = event.pageY;
+        this.origin_x = event.x0-event.rect.left;
+        this.origin_y = event.y0-event.rect.top;
 
         // Changes the Y value by the amount of dropzones that will appear
         // To my knowledge, there is no reliable way to get this information otherwise
@@ -401,11 +414,12 @@ interact('.draggable-group').draggable({
         }
     },
     onmove: function(event) {
-        dragMoveListener(event, event.pageX-this.x, event.pageY-this.y)
+        dragMoveListener(event, this.x, this.y, this.origin_x, this.origin_y)
     },
     onend: function(event) {
         // Flag this course to be moved back to the start
         event.target.parentNode.classList.remove("hovering");
+        event.target.parentNode.classList.remove('hidden-outer');
         var dropzones = document.getElementsByClassName('group-dropzone dropzone-area');
         for (var dropzone of dropzones)
             dropzone.hidden = true;

--- a/cassdegrees/static/js/staff/rules/either_or.js
+++ b/cassdegrees/static/js/staff/rules/either_or.js
@@ -62,26 +62,6 @@ Vue.component('rule_either_or', {
             this.details.either_or[group].push(JSON.parse(JSON.stringify(this.details.either_or[group][index])));
             this.do_redraw();
         },
-        move_up_rule(index, group) {
-            var rules_array = this.details.either_or[group];
-
-            if (index > 0) {
-                var to_move = rules_array[index];
-                rules_array[index] = rules_array[index - 1];
-                rules_array[index - 1] = to_move;
-                this.do_redraw();
-            }
-        },
-        move_down_rule(index, group) {
-            var rules_array = this.details.either_or[group];
-
-            if (index < rules_array.length - 1) {
-                var to_move = rules_array[index];
-                rules_array[index] = rules_array[index + 1];
-                rules_array[index + 1] = to_move;
-                this.do_redraw();
-            }
-        },
         remove_group(group) {
             this.details.either_or.splice(group, 1);
             this.update_units();
@@ -219,6 +199,11 @@ Vue.component('rule_either_or', {
         // https://michaelnthiessen.com/force-re-render/
         do_redraw() {
             this.refresh.push("");
+        },
+        set_id(group, id) {
+            // Used for tracking where elements are dropped outside of Vue
+            id_map[this._uid] = this;
+            return this._uid + "_" + group + "_" + id;
         }
     },
     template: '#eitherOrTemplate'

--- a/cassdegrees/static/js/staff/rules/either_or.js
+++ b/cassdegrees/static/js/staff/rules/either_or.js
@@ -189,7 +189,10 @@ Vue.component('rule_either_or', {
         set_id(group, id) {
             // Used for tracking where elements are dropped outside of Vue
             id_map[this._uid] = this;
-            return this._uid + "_" + group + "_" + id;
+            if (id == null)
+                return this._uid + "_" + group;
+            else
+                return this._uid + "_" + group + "_" + id;
         }
     },
     template: '#eitherOrTemplate'

--- a/cassdegrees/static/js/staff/rules/either_or.js
+++ b/cassdegrees/static/js/staff/rules/either_or.js
@@ -42,10 +42,12 @@ Vue.component('rule_either_or', {
     },
     methods: {
         add_or() {
+            should_mark_newest_component = false;
             this.details.either_or.push([]);
             this.do_redraw();
         },
         add_rule() {
+            should_mark_newest_component = true;
             this.show_add_a_rule_modal = false;
             // Add chosen rule to the right or group (based on the button clicked).
             this.details.either_or[this.which_or].push({
@@ -53,44 +55,28 @@ Vue.component('rule_either_or', {
             });
         },
         remove(index, group) {
+            should_mark_newest_component = false;
             this.details.either_or[group].splice(index, 1);
             this.update_units();
             this.do_redraw();
         },
         duplicate_rule(index, group) {
+            should_mark_newest_component = true;
             // JSON.parse(JSON.stringify(...)) is done to actually duplicate the contents of the rule, rather than just copying the memory references.
             this.details.either_or[group].push(JSON.parse(JSON.stringify(this.details.either_or[group][index])));
             this.do_redraw();
         },
         remove_group(group) {
+            should_mark_newest_component = false;
             this.details.either_or.splice(group, 1);
             this.update_units();
             this.do_redraw();
         },
         duplicate_group(group) {
+            should_mark_newest_component = true;
             // JSON.parse(JSON.stringify(...)) is done to actually duplicate the contents of the rule, rather than just copying the memory references.
             this.details.either_or.splice(group, 0, JSON.parse(JSON.stringify(this.details.either_or[group])));
             this.do_redraw();
-        },
-        move_up(group) {
-            var groups_array = this.details.either_or;
-
-            if (group > 0) {
-                var to_move = groups_array[group];
-                groups_array[group] = groups_array[group - 1];
-                groups_array[group - 1] = to_move;
-                this.do_redraw();
-            }
-        },
-        move_down(group) {
-            var groups_array = this.details.either_or;
-
-            if (group < groups_array.length - 1) {
-                var to_move = groups_array[group];
-                groups_array[group] = groups_array[group + 1];
-                groups_array[group + 1] = to_move;
-                this.do_redraw();
-            }
         },
         check_options(is_submission) {
             let valid = true;

--- a/cassdegrees/static/js/staff/rules/rule.js
+++ b/cassdegrees/static/js/staff/rules/rule.js
@@ -15,41 +15,43 @@ Vue.component('rule', {
         }
     },
     mounted() {
-        const siblings = app.$children[0].$children;
+        if (should_mark_newest_component) {
+            const siblings = app.$children[0].$children;
 
-        // Determine whether this rule is the most recent rule by finding which sibling
-        // has the highest _uid assigned by Vue.
-        let max = 0;
-        const rule_creation_ranks = {};
-        siblings.forEach(function (sib) {
-            if (!sib.$children[0].is_eitheror) {
-                rule_creation_ranks[sib._uid] = sib;
-                sib.$el.classList.remove("rule_active_visual");
-                max = (sib._uid > max) ? sib._uid : max;
-            }
-            // Else we need to get the children of the either or rule
-            else {
-                // If nested or rules get implemented, this section may need to be made recursive
-                const either_or_rules = sib.$children[0].$children;
-                sib.$el.classList.remove("rule_active_visual");
-
-                if (either_or_rules.length > 0) {
-                    either_or_rules.forEach(function (rule) {
-                        rule_creation_ranks[rule._uid] = rule;
-                        rule.$el.classList.remove("rule_active_visual");
-                        max = (rule._uid > max) ? rule._uid : max;
-                    })
-                } else {
+            // Determine whether this rule is the most recent rule by finding which sibling
+            // has the highest _uid assigned by Vue.
+            let max = 0;
+            const rule_creation_ranks = {};
+            siblings.forEach(function (sib) {
+                if (!sib.$children[0].is_eitheror) {
                     rule_creation_ranks[sib._uid] = sib;
+                    sib.$el.classList.remove("rule_active_visual");
                     max = (sib._uid > max) ? sib._uid : max;
                 }
-            }
-        });
-        const recent_rule = rule_creation_ranks[max];
+                // Else we need to get the children of the either or rule
+                else {
+                    // If nested or rules get implemented, this section may need to be made recursive
+                    const either_or_rules = sib.$children[0].$children;
+                    sib.$el.classList.remove("rule_active_visual");
 
-        // Add a visual cue and scroll to the most recent rule
-        recent_rule.$el.classList.add("rule_active_visual");
-        recent_rule.$el.scrollIntoView({behavior: "smooth"})
+                    if (either_or_rules.length > 0) {
+                        either_or_rules.forEach(function (rule) {
+                            rule_creation_ranks[rule._uid] = rule;
+                            rule.$el.classList.remove("rule_active_visual");
+                            max = (rule._uid > max) ? rule._uid : max;
+                        })
+                    } else {
+                        rule_creation_ranks[sib._uid] = sib;
+                        max = (sib._uid > max) ? sib._uid : max;
+                    }
+                }
+            });
+            const recent_rule = rule_creation_ranks[max];
+
+            // Add a visual cue and scroll to the most recent rule
+            recent_rule.$el.classList.add("rule_active_visual");
+            recent_rule.$el.scrollIntoView({behavior: "smooth"})
+        }
     },
     methods: {
         check_options(is_submission) {

--- a/cassdegrees/static/js/staff/rules/rule.js
+++ b/cassdegrees/static/js/staff/rules/rule.js
@@ -64,14 +64,7 @@ Vue.component('rule', {
         },
 
         count_units() {
-            const units = {"exact": 0, "max": 0, "min": 0};
-            for (const child of this.$children){
-                const child_units = child.count_units();
-                for (const key in child_units) {
-                    units[key] += child_units[key];
-                }
-            }
-            return units;
+            return this.$children[0].count_units();
         },
 
         get_or_rule_update_units_fn() {

--- a/cassdegrees/static/js/staff/rules/rule_container.js
+++ b/cassdegrees/static/js/staff/rules/rule_container.js
@@ -36,26 +36,6 @@ Vue.component('rule_container', {
             // JSON.parse(JSON.stringify(...)) is done to actually duplicate the contents of the rule, rather than just copying the memory references.
             this.rules.push(JSON.parse(JSON.stringify(this.rules[index])));
         },
-        move_up(index) {
-            var rules_array = this.rules;
-
-            if (index > 0) {
-                var to_move = rules_array[index];
-                rules_array[index] = rules_array[index - 1];
-                rules_array[index - 1] = to_move;
-                this.do_redraw();
-            }
-        },
-        move_down(index) {
-            var rules_array = this.rules;
-
-            if (index < rules_array.length - 1) {
-                var to_move = rules_array[index];
-                rules_array[index] = rules_array[index + 1];
-                rules_array[index + 1] = to_move;
-                this.do_redraw();
-            }
-        },
         check_options(is_submission) {
             let valid = true;
             for (const index in this.$children) {
@@ -81,6 +61,11 @@ Vue.component('rule_container', {
             this.$nextTick(() => {
                 this.redraw = false;
             });
+        },
+        set_id(id) {
+            // Used for tracking where elements are dropped outside of Vue
+            id_map[this._uid] = this;
+            return this._uid + "_" + id;
         }
     },
     template: '#ruleContainerTemplate'

--- a/cassdegrees/static/js/staff/rules/rule_container.js
+++ b/cassdegrees/static/js/staff/rules/rule_container.js
@@ -24,15 +24,18 @@ Vue.component('rule_container', {
     },
     methods: {
         add_rule() {
+            should_mark_newest_component = true;
             this.show_add_a_rule_modal = false;
             this.rules.push({
                 type: this.add_a_rule_modal_option,
             });
         },
         remove(index) {
+            should_mark_newest_component = false;
             this.rules.splice(index, 1);
         },
         duplicate_rule(index) {
+            should_mark_newest_component = true;
             // JSON.parse(JSON.stringify(...)) is done to actually duplicate the contents of the rule, rather than just copying the memory references.
             this.rules.push(JSON.parse(JSON.stringify(this.rules[index])));
         },

--- a/cassdegrees/templates/widgets/rules/either_or.html
+++ b/cassdegrees/templates/widgets/rules/either_or.html
@@ -17,11 +17,12 @@
             <fieldset id="orRulesContainer">
                 <legend>Group {{ i + 1 }}</legend>
 
-                <div v-for="(item, j) in details.either_or[i]" :key="j" >
+                <div :id="set_id(i, -1)"><div class="dropzone dropzone-area" hidden></div></div>
+                <div v-for="(item, j) in details.either_or[i]" :key="j" :id="set_id(i, j)" >
                     <rule class="rule-container" v-bind:details="item" v-on:update="update(j, $event)"
-                          v-on:remove="remove(j, i)" v-on:duplicate_rule="duplicate_rule(j, i)"
-                          v-on:move_up="move_up_rule(j, i)" v-on:move_down="move_down_rule(j, i)"></rule>
+                          v-on:remove="remove(j, i)" v-on:duplicate_rule="duplicate_rule(j, i)"></rule>
                     <div v-if="j < details.either_or[i].length - 1 && separator.length > 0">{{ separator }}<br /><br /></div>
+                    <div class="dropzone dropzone-area" hidden></div>
                 </div>
 
                 <input class="btn-uni-grad btn-medium no-left-margin" type="button" v-on:click="show_add_a_rule_modal = true; which_or = i; component_names = component_groups.rules" value="Add New Rule to Group" />

--- a/cassdegrees/templates/widgets/rules/either_or.html
+++ b/cassdegrees/templates/widgets/rules/either_or.html
@@ -15,7 +15,7 @@
 
         <div :id="set_id(-1)"><div class="group-dropzone dropzone-area" hidden></div></div>
         <div v-for="(item, i) in details.either_or" :key="i">
-            <div :id="set_id(i)" class="box bdr-solid bdr-uni draggable draggable-group" style="background-color: white">
+            <div :id="set_id(i)" class="box bdr-solid bdr-uni draggable draggable-group">
                 <fieldset id="orRulesContainer">
                     <legend>Group {{ i + 1 }}</legend>
 

--- a/cassdegrees/templates/widgets/rules/either_or.html
+++ b/cassdegrees/templates/widgets/rules/either_or.html
@@ -13,25 +13,27 @@
         </div>
         <br v-if="large_unit_count" />
 
-        <div class="box bdr-solid bdr-uni" v-for="(item, i) in details.either_or" :key="i">
-            <fieldset id="orRulesContainer">
-                <legend>Group {{ i + 1 }}</legend>
+        <div :id="set_id(-1)"><div class="group-dropzone dropzone-area" hidden></div></div>
+        <div v-for="(item, i) in details.either_or" :key="i">
+            <div :id="set_id(i)" class="box bdr-solid bdr-uni draggable draggable-group" style="background-color: white">
+                <fieldset id="orRulesContainer">
+                    <legend>Group {{ i + 1 }}</legend>
 
-                <div :id="set_id(i, -1)"><div class="dropzone dropzone-area" hidden></div></div>
-                <div v-for="(item, j) in details.either_or[i]" :key="j" :id="set_id(i, j)" >
-                    <rule class="rule-container" v-bind:details="item" v-on:update="update(j, $event)"
-                          v-on:remove="remove(j, i)" v-on:duplicate_rule="duplicate_rule(j, i)"></rule>
-                    <div v-if="j < details.either_or[i].length - 1 && separator.length > 0">{{ separator }}<br /><br /></div>
-                    <div class="dropzone dropzone-area" hidden></div>
-                </div>
+                    <div :id="set_id(i, -1)"><div class="dropzone dropzone-area" hidden></div></div>
+                    <div v-for="(item, j) in details.either_or[i]" :key="j" :id="set_id(i, j)" >
+                        <rule class="rule-container" v-bind:details="item" v-on:update="update(j, $event)"
+                              v-on:remove="remove(j, i)" v-on:duplicate_rule="duplicate_rule(j, i)"></rule>
+                        <div v-if="j < details.either_or[i].length - 1 && separator.length > 0">{{ separator }}<br /><br /></div>
+                        <div class="dropzone dropzone-area" hidden></div>
+                    </div>
 
-                <input class="btn-uni-grad btn-medium no-left-margin" type="button" v-on:click="show_add_a_rule_modal = true; which_or = i; component_names = component_groups.rules" value="Add New Rule to Group" />
-                <input class="btn-uni-grad btn-medium no-left-margin" type="button" v-on:click="remove_group(i)" value="Remove This Group" />
-                <input class="btn-uni-grad btn-medium no-left-margin" type="button" v-on:click="duplicate_group(i)" value="Duplicate This Group" />
-                <input class="btn-uni-grad btn-medium no-left-margin" type="button" v-on:click="move_up(i)" value="Move Up" />
-                <input class="btn-uni-grad btn-medium no-left-margin" type="button" v-on:click="move_down(i)" value="Move Down" />
+                    <input class="btn-uni-grad btn-medium no-left-margin" type="button" v-on:click="show_add_a_rule_modal = true; which_or = i; component_names = component_groups.rules" value="Add New Rule to Group" />
+                    <input class="btn-uni-grad btn-medium no-left-margin" type="button" v-on:click="remove_group(i)" value="Remove This Group" />
+                    <input class="btn-uni-grad btn-medium no-left-margin" type="button" v-on:click="duplicate_group(i)" value="Duplicate This Group" />
 
-            </fieldset>
+                </fieldset>
+            </div>
+            <div :id="set_id(i)"><div class="group-dropzone dropzone-area" hidden></div></div>
         </div>
 
         <input class="btn-uni-grad btn-large no-left-margin" type="button" v-on:click="add_or" value="Add new OR Group" />

--- a/cassdegrees/templates/widgets/rules/either_or.html
+++ b/cassdegrees/templates/widgets/rules/either_or.html
@@ -13,14 +13,14 @@
         </div>
         <br v-if="large_unit_count" />
 
-        <div :id="set_id(-1)"><div class="group-dropzone dropzone-area" hidden></div></div>
+        <div :drag_id="set_id(-1)"><div class="group-dropzone dropzone-area" hidden></div></div>
         <div v-for="(item, i) in details.either_or" :key="i">
-            <div :id="set_id(i)" class="box bdr-solid bdr-uni draggable draggable-group">
+            <div :drag_id="set_id(i)" class="box bdr-solid bdr-uni draggable draggable-group">
                 <fieldset id="orRulesContainer">
                     <legend>Group {{ i + 1 }}</legend>
 
-                    <div :id="set_id(i, -1)"><div class="dropzone dropzone-area" hidden></div></div>
-                    <div v-for="(item, j) in details.either_or[i]" :key="j" :id="set_id(i, j)" >
+                    <div :drag_id="set_id(i, -1)"><div class="dropzone dropzone-area" hidden></div></div>
+                    <div v-for="(item, j) in details.either_or[i]" :key="j" :drag_id="set_id(i, j)" >
                         <rule class="rule-container" v-bind:details="item" v-on:update="update(j, $event)"
                               v-on:remove="remove(j, i)" v-on:duplicate_rule="duplicate_rule(j, i)"></rule>
                         <div v-if="j < details.either_or[i].length - 1 && separator.length > 0">{{ separator }}<br /><br /></div>
@@ -33,7 +33,7 @@
 
                 </fieldset>
             </div>
-            <div :id="set_id(i)"><div class="group-dropzone dropzone-area" hidden></div></div>
+            <div :drag_id="set_id(i)"><div class="group-dropzone dropzone-area" hidden></div></div>
         </div>
 
         <input class="btn-uni-grad btn-large no-left-margin" type="button" v-on:click="add_or" value="Add new OR Group" />

--- a/cassdegrees/templates/widgets/rules/rule.html
+++ b/cassdegrees/templates/widgets/rules/rule.html
@@ -1,10 +1,11 @@
 {# Generic visual container for rules with options to duplicate and delete #}
 {% load cache_control %}
+{% load static %}
 
 {% verbatim %}
 <script type="text/x-template" id="ruleTemplate">
     <div class="card">
-        <header class="box-header">
+        <header class="box-header draggable draggable-rule">
             <p class="card-header-title">
                 {{ component_names[details.type] }}
             </p>
@@ -12,8 +13,6 @@
                  alt="Help button" v-on:click="show_help = true" />
             <input type="button" v-on:click="$emit('remove')" class="btn-uni-grad btn-snall no-left-margin" value="Remove" />
             <input type="button" v-on:click="$emit('duplicate_rule')" class="btn-uni-grad btn-snall no-left-margin" value="Duplicate" />
-            <input type="button" v-on:click="$emit('move_up')" class="btn-uni-grad btn-snall no-left-margin" value="Move Up" />
-            <input type="button" v-on:click="$emit('move_down')" class="btn-uni-grad btn-snall no-left-margin" value="Move Down" />
         </header>
         <div class="box-solid">
             <div class="card-content" v-bind:refresh="refresh" v-bind:is="'rule_' + details.type" v-bind:details="details"></div>
@@ -39,4 +38,5 @@
 </script>
 {% endverbatim %}
 
+<script type="text/javascript" src="{% static 'js/vendor/interact.js' %}"></script>
 <script type="text/javascript" src="{% static_no_cache "js/staff/rules/rule.js" %}"></script>

--- a/cassdegrees/templates/widgets/rules/rule_container.html
+++ b/cassdegrees/templates/widgets/rules/rule_container.html
@@ -3,8 +3,8 @@
 {% verbatim %}
 <script type="text/x-template" id="ruleContainerTemplate">
     <div v-if="!redraw">
-        <div :id="set_id(-1)"><div class="dropzone dropzone-area" hidden></div></div>
-        <div v-for="(item, index) in rules" :key="index" :id="set_id(index)">
+        <div :drag_id="set_id(-1)"><div class="dropzone dropzone-area" hidden></div></div>
+        <div v-for="(item, index) in rules" :key="index" :drag_id="set_id(index)">
             <rule :ref="set_id(index)" class="rule-container" v-bind:details="item" v-on:update="update(index, $event)"
                   v-on:remove="remove(index)" v-on:duplicate_rule="duplicate_rule(index)"></rule>
             <div class="dropzone dropzone-area" hidden></div>

--- a/cassdegrees/templates/widgets/rules/rule_container.html
+++ b/cassdegrees/templates/widgets/rules/rule_container.html
@@ -3,10 +3,11 @@
 {% verbatim %}
 <script type="text/x-template" id="ruleContainerTemplate">
     <div v-if="!redraw">
-        <div v-for="(item, index) in rules" :key="index" >
-            <rule class="rule-container" v-bind:details="item" v-on:update="update(index, $event)"
-                  v-on:remove="remove(index)" v-on:duplicate_rule="duplicate_rule(index)"
-                  v-on:move_up="move_up(index)" v-on:move_down="move_down(index)"></rule>
+        <div :id="set_id(-1)"><div class="dropzone dropzone-area" hidden></div></div>
+        <div v-for="(item, index) in rules" :key="index" :id="set_id(index)">
+            <rule :ref="set_id(index)" class="rule-container" v-bind:details="item" v-on:update="update(index, $event)"
+                  v-on:remove="remove(index)" v-on:duplicate_rule="duplicate_rule(index)"></rule>
+            <div class="dropzone dropzone-area" hidden></div>
             <div v-if="index < rules.length - 1 && separator.length > 0">{{ separator }}<br /><br /></div>
         </div>
 {% endverbatim %}


### PR DESCRIPTION
After a lot of playing around I finally have this working. Currently this lets you drag both or groups and general rules. You can also drag rules in to OR rules, drag groups between different or rules, etc. 

A lot of this was kind of hackish due to the communication between different elements that don't like talking to each other (Vue, Interact, Javascript DOM, etc.). I tried a number of other solutions for each but couldn't do anything else for some. Still, if you think something could be done better let me know.

<img width="1280" alt="Screen Shot 2019-10-07 at 6 23 18 pm" src="https://user-images.githubusercontent.com/36946090/66292245-92f86d80-e92f-11e9-96b8-c7a112b0e524.png">
<img width="1169" alt="Screen Shot 2019-10-06 at 11 38 34 pm" src="https://user-images.githubusercontent.com/36946090/66292246-92f86d80-e92f-11e9-9f0f-1f36bd567488.png">

EDIT: 
Dragged rules now shrink and remove their previous space. 
<img width="1280" alt="Screen Shot 2019-10-08 at 11 20 26 pm" src="https://user-images.githubusercontent.com/36946090/66395197-8a349400-ea22-11e9-980d-beb155bff91d.png">
