### PR TITLE
Remove Flexible Vertical Option from Program Types

### DIFF
--- a/cassdegrees/api/models.py
+++ b/cassdegrees/api/models.py
@@ -88,7 +88,6 @@ class ProgramModel(models.Model):
                      ("mast-sing", "Masters Single Degree"),
                      ("mast-adv", "Masters (Advanced) Degree"),
                      ("mast-doub", "Masters Flexible Double Degree"),
-                     ("vert-doub", "Vertical Flexible Double Degree"),
                      ("other", "Other Degree"))
 
     programType = models.CharField(max_length=10, choices=degreeChoices)


### PR DESCRIPTION
Closes #444.

Simple one liner to remove an unnecessary option. Requires migrations.