### PR TITLE
Fixed Errors with Viewing Programs and Subplans

### DIFF
--- a/cassdegrees/templates/staff/view/viewprogram.html
+++ b/cassdegrees/templates/staff/view/viewprogram.html
@@ -98,7 +98,7 @@
                         </ul>
                     </p>
                 {# Course Rules #}
-                {% elif rule.type == 'course' %}
+                {% elif rule.type == 'course_list' %}
                     <p>
                         {% if rule.list_type != "min_max" %}
                             {% if rule.list_type == "min" %}

--- a/cassdegrees/templates/staff/view/viewprogram.html
+++ b/cassdegrees/templates/staff/view/viewprogram.html
@@ -135,7 +135,7 @@
                     </p>
                 {# Custom-text Rules #}
                 {% elif rule.type == "custom_text" %}
-                    <p>{{ rule.units }} units from {{ rule.text }}</p>
+                    <p>{{ rule.unit_count }} units from {{ rule.text }}</p>
                 {# Elective Rules #}
                 {% elif rule.type == "elective" %}
                     <p>{{ rule.units }} units from the completion of elective courses offered by the ANU</p>

--- a/cassdegrees/templates/staff/view/viewsubplan.html
+++ b/cassdegrees/templates/staff/view/viewsubplan.html
@@ -75,34 +75,81 @@
             {% endif %}
         {% endfor %}
 
-        {# Displays all of the required courses in a table #}
-        {% for rule in data.rules %}
-            <p>
-                <i>
-                    {% if rule.list_type != "min_max" %}
-                        {% if rule.list_type == "min" %}
-                            A minimum of
-                        {% elif rule.list_type == "exact" %}
-                            Exactly
-                        {% elif rule.list_type == "max" %}
-                            A maximum of
-                        {% endif %}
-                        {{ rule.unit_count }} units
-                    {% else %}
-                        A minimum of {{ rule.min_unit_count }} units
-                        and a maximum of {{ rule.max_unit_count }} units
-                    {% endif %}
-                    from completion of the following course(s):
-                </i>
-                <table class="tbl-cell-bdr">
-                    <tr><th>Code</th><th>Title</th><th>Units</th></tr>
-                        {% for course in rule.courses %}
-                            <tr><td>{{ course.code }}</td><td>{{ course.name }}</td><td>{{ course.units }}</td></tr>
-                        {% endfor %}
-                </table>
-
-            </p>
-            <br />
-        {% endfor %}
+        <div style="margin-left: 40px">
+            {% for rule in data.rules %}
+                {# Course Rule #}
+                {% if rule.type == "course_list" %}
+                    {# Displays all of the required courses in a table #}
+                    <p>
+                        <i>
+                            {% if rule.list_type != "min_max" %}
+                                {% if rule.list_type == "min" %}
+                                    A minimum of
+                                {% elif rule.list_type == "exact" %}
+                                    Exactly
+                                {% elif rule.list_type == "max" %}
+                                    A maximum of
+                                {% endif %}
+                                {{ rule.unit_count }} units
+                            {% else %}
+                                A minimum of {{ rule.min_unit_count }} units
+                                and a maximum of {{ rule.max_unit_count }} units
+                            {% endif %}
+                            from completion of the following course(s):
+                        </i>
+                        <table class="tbl-cell-bdr">
+                            <tr><th>Code</th><th>Title</th><th>Units</th></tr>
+                                {% for course in rule.courses %}
+                                    <tr><td>{{ course.code }}</td><td>{{ course.name }}</td><td>{{ course.units }}</td></tr>
+                                {% endfor %}
+                        </table>
+                    </p>
+                {# Custom Text Rule #}
+                {% elif rule.type == "custom_text" %}
+                    <p>{{ rule.unit_count }} units from {{ rule.text }}</p>
+                {# Either Or Rules #}
+                {% elif rule.type == 'either_or' %}
+                    Either:
+                    {% for or_rule in rule.either_or %}
+                        <div style="margin-left: 40px">
+                            {% for sub_rule in or_rule %}
+                                {# Course Or Rule #}
+                                {% if sub_rule.type == "course_list" %}
+                                    <p>
+                                        <i>
+                                            {% if sub_rule.list_type != "min_max" %}
+                                                {% if sub_rule.list_type == "min" %}
+                                                    A minimum of
+                                                {% elif sub_rule.list_type == "exact" %}
+                                                    Exactly
+                                                {% elif sub_rule.list_type == "max" %}
+                                                    A maximum of
+                                                {% endif %}
+                                                {{ sub_rule.unit_count }} units
+                                            {% else %}
+                                                A minimum of {{ sub_rule.min_unit_count }} units
+                                                and a maximum of {{ sub_rule.max_unit_count }} units
+                                            {% endif %}
+                                            from completion of the following course(s):
+                                        </i>
+                                        <table class="tbl-cell-bdr">
+                                            <tr><th>Code</th><th>Title</th><th>Units</th></tr>
+                                                {% for course in sub_rule.courses %}
+                                                    <tr><td>{{ course.code }}</td><td>{{ course.name }}</td><td>{{ course.units }}</td></tr>
+                                                {% endfor %}
+                                        </table>
+                                    </p>
+                                {# Custom Text Or Rule #}
+                                {% elif sub_rule.type == "custom_text" %}
+                                    <p>{{ sub_rule.unit_count }} units from {{ sub_rule.text }}</p>
+                                {% endif %}
+                            {% endfor %}
+                        </div>
+                        {% if not forloop.last %}OR{% endif %}
+                    {% endfor %}
+                {% endif %}
+                <br />
+            {% endfor %}
+        </div>
     </div>
 {% endblock %}

--- a/cassdegrees/ui/views/staff/view.py
+++ b/cassdegrees/ui/views/staff/view.py
@@ -42,7 +42,7 @@ def pretty_print_rules(program):
                         subplans[id] = object
                     rule["contents"] = subplans
                     rule["units"] = units
-                if rule["type"] == "course":
+                if rule["type"] == "course_list":
                     gen_request = HttpRequest()
                     gen_request.GET = {'select': 'code,name,units', 'from': 'course'}
                     rule['courses'] = []
@@ -80,17 +80,7 @@ def view_section(request):
 
         subplan = model_to_dict(SubplanModel.objects.get(id=int(id_to_edit)))
         pretty_print_reqs(subplan)
-
-        for rule in subplan['rules']:
-            # Add a new field containing the courses that match the given code
-            rule['courses'] = []
-            for course in rule['codes']:
-                code = course['code']
-                name = course['name']
-                gen_request.GET['code_exact'] = code
-                gen_request.GET['name_exact'] = name
-                courses = json.loads(search(gen_request).content.decode())
-                rule['courses'] += courses
+        pretty_print_rules(subplan)
 
         return render(request, 'staff/view/viewsubplan.html', context={'data': subplan})
 


### PR DESCRIPTION
Closes #441.

This originally started as a quick fix to add the unit count when viewing custom text rules, but expanded to fix a number of issues with viewing subplans and programs.

The renaming of the course rule from "course" to "course_list" broke a number of things, and the subplan view page hadn't been updated to support the new rules that were added.

![image](https://user-images.githubusercontent.com/37424867/66388643-53ef1880-ea12-11e9-950f-cff8e6670048.png)
