### PR TITLE
Tooltips on Add Rule Popup Dialog

### DIFF
--- a/cassdegrees/static/js/staff/rules.js
+++ b/cassdegrees/static/js/staff/rules.js
@@ -21,7 +21,7 @@ const ALL_COMPONENT_HELP = {
     'subplan': "A rule which gives students a choice from a particular set of majors, minors, specialisations or " +
                "other subplans. The description here is used to describe the rule when displaying this rule to " +
                "students.",
-    'course': "A rule which specifies that students should pick a certain amount of units from a set of available " +
+    'course_list': "A rule which specifies that students should pick a certain amount of units from a set of available " +
               "courses.",
     'course_requisite': "A rule which specifies that students should have taken a set of courses before taking this " +
                         "one.",

--- a/cassdegrees/static/js/staff/rules/either_or.js
+++ b/cassdegrees/static/js/staff/rules/either_or.js
@@ -27,7 +27,7 @@ Vue.component('rule_either_or', {
         return {
             show_add_a_rule_modal: false,
             which_or: 0,
-            add_a_rule_modal_option: 'course_list',
+            add_a_rule_modal_option: '',
 
             // Show warnings if appropriate
             large_unit_count: false,
@@ -35,6 +35,7 @@ Vue.component('rule_either_or', {
 
             component_groups: {'rules': EITHER_OR_COMPONENT_NAMES, 'requisites': REQUISITE_EITHER_OR_COMPONENT_NAMES, 'subplan': SUBPLAN_EITHER_OR_COMPONENT_NAMES},
             component_names: EITHER_OR_COMPONENT_NAMES,
+            component_help: ALL_COMPONENT_HELP,
 
             is_eitheror: true,
             "type": document.getElementById('page-title').innerText.split(' ')[1]

--- a/cassdegrees/static/js/staff/rules/rule_container.js
+++ b/cassdegrees/static/js/staff/rules/rule_container.js
@@ -17,12 +17,17 @@ Vue.component('rule_container', {
 
             component_groups: {'rules': COMPONENT_NAMES, 'requisites': REQUISITE_COMPONENT_NAMES, 'subplan': SUBPLAN_COMPONENT_NAMES},
             component_names: null,
+            component_help: ALL_COMPONENT_HELP,
+            active_modal_rule_help: ALL_COMPONENT_HELP['course_list'],
 
             // Forces the element to re-render, if mutable events occurred
             redraw: false,
         }
     },
     methods: {
+        update_modal_help() {
+            this.active_modal_rule_help = this.component_help[this.add_a_rule_modal_option];
+        },
         add_rule() {
             this.show_add_a_rule_modal = false;
             this.rules.push({

--- a/cassdegrees/static/js/staff/rules/rule_container.js
+++ b/cassdegrees/static/js/staff/rules/rule_container.js
@@ -13,21 +13,17 @@ Vue.component('rule_container', {
     data() {
         return {
             show_add_a_rule_modal: false,
-            add_a_rule_modal_option: 'course_list',
+            add_a_rule_modal_option: '',
 
             component_groups: {'rules': COMPONENT_NAMES, 'requisites': REQUISITE_COMPONENT_NAMES, 'subplan': SUBPLAN_COMPONENT_NAMES},
             component_names: null,
             component_help: ALL_COMPONENT_HELP,
-            active_modal_rule_help: ALL_COMPONENT_HELP['course_list'],
 
             // Forces the element to re-render, if mutable events occurred
             redraw: false,
         }
     },
     methods: {
-        update_modal_help() {
-            this.active_modal_rule_help = this.component_help[this.add_a_rule_modal_option];
-        },
         add_rule() {
             this.show_add_a_rule_modal = false;
             this.rules.push({

--- a/cassdegrees/templates/widgets/rules/either_or.html
+++ b/cassdegrees/templates/widgets/rules/either_or.html
@@ -61,6 +61,7 @@
                                 </option>
                             </select>
                         </div>
+                        <p><i>{{ component_help[add_a_rule_modal_option] }}</i></p>
                     </div>
                     <footer class="box-solid">
                         <button class="button is-success" v-on:click="add_rule">Add</button>

--- a/cassdegrees/templates/widgets/rules/rule_container.html
+++ b/cassdegrees/templates/widgets/rules/rule_container.html
@@ -30,12 +30,13 @@
 
 {% verbatim %}
                         <div class="select">
-                            <select v-model="add_a_rule_modal_option">
+                            <select v-model="add_a_rule_modal_option" v-on:change="update_modal_help">
                                 <option v-for="(option, index) in component_names" v-bind:value="index">
                                     {{ option }}
                                 </option>
                             </select>
                         </div>
+                    <p><i>{{ active_modal_rule_help }}</i></p>
                     </div>
                     <footer class="box-solid">
                         <button class="button is-success" v-on:click="add_rule">Add</button>

--- a/cassdegrees/templates/widgets/rules/rule_container.html
+++ b/cassdegrees/templates/widgets/rules/rule_container.html
@@ -30,13 +30,13 @@
 
 {% verbatim %}
                         <div class="select">
-                            <select v-model="add_a_rule_modal_option" v-on:change="update_modal_help">
+                            <select v-model="add_a_rule_modal_option">
                                 <option v-for="(option, index) in component_names" v-bind:value="index">
                                     {{ option }}
                                 </option>
                             </select>
                         </div>
-                    <p><i>{{ active_modal_rule_help }}</i></p>
+                        <p><i>{{ component_help[add_a_rule_modal_option] }}</i></p>
                     </div>
                     <footer class="box-solid">
                         <button class="button is-success" v-on:click="add_rule">Add</button>


### PR DESCRIPTION
Closes #317.

Adds explanations for rules to the pop up dialog so that users can more quickly see and understand what the purpose of each rule is. 

![image](https://user-images.githubusercontent.com/37424867/66388874-c5c76200-ea12-11e9-9937-947a6e45922c.png)
