### PR TITLE
Fix Course Report from generating malformed excel files

### DIFF
--- a/cassdegrees/ui/views/staff/bulk_data_upload.py
+++ b/cassdegrees/ui/views/staff/bulk_data_upload.py
@@ -73,7 +73,7 @@ def bulk_data_upload(request):
             # Used https://www.pythoncircle.com/post/591/how-to-upload-and-process-the-excel-file-in-django/
             # to help me read the excel files.
             excel_file = openpyxl.load_workbook(raw_uploaded_file)
-            sheet = excel_file["Sheet1"]
+            sheet = excel_file[excel_file.sheetnames[0]]  # Get the first sheet in the excel file.
 
             first_row = list(sheet.iter_rows())[0]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ requests==2.21.0
 django-weasyprint==0.5.4
 openpyxl==2.6.3
 django-cors-headers==3.1.0
-xlwt==1.3.0


### PR DESCRIPTION
Original Issue: #427 

Used openpyxl instead of xlwt to generate excel files, as it turns out xlwt did not generate a well formed excel file. Now, with a well formed excel file generated, it works with bulk uploader well.

Example output from Course Report (try this in bulk uploader):
[Course Report.xlsx](https://github.com/cass-degrees/CASS-Degrees-Code/files/3705737/Course.Report.xlsx)

Also changed bulk uploader excel reading function to open the very first worksheet, instead of trying to find 'Sheet1' specifically and crashing if not found.