### PR TITLE
Publish Button Prompt and Workflow

### DIFF
--- a/cassdegrees/templates/staff/creation/createcourse.html
+++ b/cassdegrees/templates/staff/creation/createcourse.html
@@ -31,7 +31,7 @@
             {% csrf_token %}
             <input type="hidden" name="id" value="{{ request.GET.id }}">
             <div class="fullwidth auto-overflow">
-                <input class="btn-uni-grad btn-small right" type ="submit" formaction="/staff/delete/courses/" value="&#128465Delete">
+                <input class="btn-uni-grad btn-small right" type ="submit" formaction="/staff/delete/courses/" value="&times Delete">
             </div>
         </form>
     {% endif %}

--- a/cassdegrees/templates/staff/creation/createlist.html
+++ b/cassdegrees/templates/staff/creation/createlist.html
@@ -37,7 +37,7 @@
             {% csrf_token %}
             <input type="hidden" name="id" value="{{ request.GET.id }}">
             <div class="fullwidth auto-overflow">
-                <input class="btn-uni-grad btn-small right" type ="submit" formaction="/staff/delete/lists/" value="&#128465Delete">
+                <input class="btn-uni-grad btn-small right" type ="submit" formaction="/staff/delete/lists/" value="&times Delete">
             </div>
         </form>
     {% endif %}

--- a/cassdegrees/templates/staff/creation/createprogram.html
+++ b/cassdegrees/templates/staff/creation/createprogram.html
@@ -106,7 +106,8 @@
                 requirement elsewhere.
             </p>
 
-            <p class="form-group" onchange="document.getElementById('id_publish').checked = !(document.getElementById('id_publish').checked);">
+            <p class="form-group" onchange="document.getElementById('id_publish').checked =
+                                            !(document.getElementById('id_publish').checked);">
                 {{ form.publish.label_tag }} {{ form.publish }}
             </p>
         </fieldset>

--- a/cassdegrees/templates/staff/creation/createprogram.html
+++ b/cassdegrees/templates/staff/creation/createprogram.html
@@ -31,7 +31,7 @@
             {% csrf_token %}
             <input type="hidden" name="id" value="{{ request.GET.id }}">
             <div class="fullwidth auto-overflow">
-                <input class="btn-uni-grad btn-small right" type ="submit" formaction="/staff/delete/programs/" value="&#128465Delete">
+                <input class="btn-uni-grad btn-small right" type ="submit" formaction="/staff/delete/programs/" value="&times Delete">
             </div>
         </form>
     {% endif %}
@@ -48,15 +48,12 @@
 
             {% for field in form %}
                 {% if field.name not in render_separately %}
-                    <p class="form-group">
+                    <p class="form-group" {% if field.name == 'publish' %}  hidden {% endif %}>
                         {% if not field.is_hidden and not field == form.staffNotes  %}
                             {{ field.label_tag }}
                         {% endif %}
                         {{ field }}
                     </p>
-                    {% if field.name == "publish" %}
-                        <p class="text-center">Please tick the 'publish' checkbox above if you want to make this plan available to students</p>
-                    {% endif %}
                     {% for error in field.errors %}
                          <div class="msg-error inline-error">{{ error }}</div>
                     {% endfor %}
@@ -99,6 +96,22 @@
     {% include "widgets/staff/program_rules.html" %}
     </div>
 
+    <div class="anuform">
+        <fieldset>
+            <legend>
+                Publish Program
+            </legend>
+            <p>
+                A program that is not published will not be visible to students and cannot be added as a
+                requirement elsewhere.
+            </p>
+
+            <p class="form-group" onchange="document.getElementById('id_publish').checked = !(document.getElementById('id_publish').checked);">
+                {{ form.publish.label_tag }} {{ form.publish }}
+            </p>
+        </fieldset>
+    </div>
+
     <p class="left text-left">
         <input id="new_course_btn" class="btn-uni-grad btn-large" type="button" value="New Course"
                onclick="toggleCourseCreationPopup()">
@@ -121,18 +134,21 @@
     <script>
         function submit_form(form_action, redirect) {
             if (globalRequirementsApp.export_requirements() && app.export_rules()) {
-                // Ensure that the course has been agreed to to being non public on submission.
-                if (!document.getElementById("id_publish").checked &&
-                    !confirm("You haven't marked this program as 'published' - this means this won't appear " +
-                        "to students or be selectable as a requirement elsewhere.\r\n\r\nAre you sure you want to continue?")) {
-                    return false;
-                }
-                // If the user has chosen to publish a plan but the unit count is inconsistent, verify with the user
-                if (document.getElementById("id_publish").checked &&
-                    !isValidUnitCount(parseInt(document.getElementById("id_units").value)) &&
-                    !confirm("You have created a plan that contains a different number of units than you have " +
-                        "specified for the entire plan.\n\nAre you sure you want to continue? (Not Recommended)")) {
-                    return false;
+                if (redirect) {
+                    // Ensure that the course has been agreed to to being non public on submission.
+                    if (!document.getElementById("id_publish").checked &&
+                        !confirm("You haven't marked this program as 'published' - this means this won't appear " +
+                            "to students or be selectable as a requirement elsewhere.\r\n\r\nAre you sure you want to continue?")) {
+                        return false;
+                    }
+
+                    // If the user has chosen to publish a plan but the unit count is inconsistent, verify with the user
+                    if (document.getElementById("id_publish").checked &&
+                        !isValidUnitCount(parseInt(document.getElementById("id_units").value)) &&
+                        !confirm("You have created a plan that contains a different number of units than you have " +
+                            "specified for the entire plan.\n\nAre you sure you want to continue? (Not Recommended)")) {
+                        return false;
+                    }
                 }
 
                 // Disable check for unsaved changes - we are saving them here!

--- a/cassdegrees/templates/staff/creation/createsubplan.html
+++ b/cassdegrees/templates/staff/creation/createsubplan.html
@@ -31,7 +31,7 @@
             {% csrf_token %}
             <input type="hidden" name="id" value="{{ request.GET.id }}">
             <div class="fullwidth auto-overflow">
-                <input class="btn-uni-grad btn-small right" type ="submit" formaction="/staff/delete/subplans/" value="&#128465Delete">
+                <input class="btn-uni-grad btn-small right" type ="submit" formaction="/staff/delete/subplans/" value="&times Delete">
             </div>
         </form>
     {% endif %}
@@ -47,15 +47,12 @@
             {{ form.management_form }}
 
             {% for field in form %}
-                <p class="form-group">
+                <p class="form-group" {% if field.name == 'publish' %}  hidden {% endif %}>
                     {% if not field.is_hidden %}
                         {{ field.label_tag }}
                     {% endif %}
                     {{ field }}
                 </p>
-                {% if field.name == "publish" %}
-                    <p class="text-center">Please tick the 'publish' checkbox above if you want this subplan to be selectable in programs</p>
-                {% endif %}
                 {% for error in field.errors %}
                      <div class="msg-error inline-error">{{ error }}</div>
                 {% endfor %}
@@ -70,6 +67,22 @@
         {% include "widgets/staff/global_requirements.html" %}
         {% include "widgets/staff/subplan_rules.html" %}
     </form>
+
+    <div class="anuform">
+        <fieldset>
+            <legend>
+                Publish Subplan
+            </legend>
+            <p>
+                A subplan that is not published will not be visible to students and cannot be added as a
+                requirement elsewhere.
+            </p>
+
+            <p class="form-group" onchange="document.getElementById('id_publish').checked = !(document.getElementById('id_publish').checked);">
+                {{ form.publish.label_tag }} {{ form.publish }}
+            </p>
+        </fieldset>
+    </div>
 
     <p class="text-right">
         <input id="new_course_btn" class="left btn-uni-grad btn-large" type="button" value="New Course"
@@ -102,20 +115,22 @@
 
         function submit_form(redirect) {
             if (globalRequirementsApp.export_requirements() && app.export_rules()) {
-                // Ensure that the course has been agreed to to being non public on submission.
-                if (!document.getElementById("id_publish").checked &&
-                    !confirm("You haven't marked this subplan as 'published' - this means this won't appear " +
-                        "to students or be selectable as a requirement elsewhere.\r\n\r\nAre you sure you want to continue?")) {
-                    return false;
-                }
-
-                // If the user has chosen to publish a subplan but the unit count is inconsistent, verify with the user
-                if (document.getElementById("id_publish").checked) {
-                    var planType = document.getElementById("id_planType").value;
-                    if (planType && !isValidUnitCount( SUBPLAN_UNITS[planType] ) &&
-                        !confirm("You have created a subplan that does not contain " + SUBPLAN_UNITS[planType] +
-                            " units.\n\nAre you sure you want to continue? (Not Recommended)")){
+                if (redirect) {
+                    // Ensure that the course has been agreed to to being non public on submission.
+                    if (!document.getElementById("id_publish").checked &&
+                        !confirm("You haven't marked this subplan as 'published' - this means this won't appear " +
+                            "to students or be selectable as a requirement elsewhere.\r\n\r\nAre you sure you want to continue?")) {
                         return false;
+                    }
+
+                    // If the user has chosen to publish a subplan but the unit count is inconsistent, verify with the user
+                    if (document.getElementById("id_publish").checked) {
+                        var planType = document.getElementById("id_planType").value;
+                        if (planType && !isValidUnitCount(SUBPLAN_UNITS[planType]) &&
+                            !confirm("You have created a subplan that does not contain " + SUBPLAN_UNITS[planType] +
+                                " units.\n\nAre you sure you want to continue? (Not Recommended)")) {
+                            return false;
+                        }
                     }
                 }
 

--- a/cassdegrees/templates/staff/creation/createsubplan.html
+++ b/cassdegrees/templates/staff/creation/createsubplan.html
@@ -78,7 +78,8 @@
                 requirement elsewhere.
             </p>
 
-            <p class="form-group" onchange="document.getElementById('id_publish').checked = !(document.getElementById('id_publish').checked);">
+            <p class="form-group" onchange="document.getElementById('id_publish').checked =
+                                            !(document.getElementById('id_publish').checked);">
                 {{ form.publish.label_tag }} {{ form.publish }}
             </p>
         </fieldset>


### PR DESCRIPTION
Closes #407.

This PR moves the publish button from the top of the workflow to the bottom, where it was suggested it would be more useful. It also clarifies what publishing an item does.

Additionally, users will only be prompted that their program is unpublished when saving and exiting, not when just saving. 

I also fixed a minor issue where the delete buttons still showed rubbish bins on the program creation pages, whereas it should be a little 'x' like on the list page.

![image](https://user-images.githubusercontent.com/37424867/66492660-7fe8c780-eb00-11e9-98fc-24f67fcc0328.png)
