### PR TITLE
Bugfix   duplicate error on course edit

### DIFF
--- a/cassdegrees/ui/forms.py
+++ b/cassdegrees/ui/forms.py
@@ -360,7 +360,7 @@ class EditCourseFormSnippet(ModelForm):
         if len(data) == 9 and not data[-1:].isalpha():
             raise forms.ValidationError("Extra Key should be a letter e.g. A, B, C")
 
-        # course codes must be unique
+        # course codes must be unique, unless you are editing existing courses
         if CourseModel.objects.filter(code=data) and CourseModel.objects.get(code=data).id != self.instance.id:
             raise forms.ValidationError("A course with this code already exists!")
         return data.upper()

--- a/cassdegrees/ui/forms.py
+++ b/cassdegrees/ui/forms.py
@@ -342,16 +342,26 @@ class EditCourseFormSnippet(ModelForm):
 
     def clean_code(self):
         data = self.cleaned_data['code']
+
+        # enforce 8-9 character long course code length
         if len(data) != 8 and len(data) != 9:
             raise forms.ValidationError("This should be at least 8-9 characters  (4 Letters, 4 Numbers "
                                         "+ 1 Optional Letter)!")
+
+        # all courses must start with 4 digit alpha
         if not data[:4].isalpha():
             raise forms.ValidationError("Course Code should start with 4 letters!")
+
+        # all courses must end with at least 4 digits
         if not data[4:8].isdigit():
             raise forms.ValidationError("Course Code should end with 4 numbers!")
+
+        # where a course code is 9 characters the last must be alpha
         if len(data) == 9 and not data[-1:].isalpha():
             raise forms.ValidationError("Extra Key should be a letter e.g. A, B, C")
-        if CourseModel.objects.filter(code=data):
+
+        # course codes must be unique
+        if CourseModel.objects.filter(code=data) and CourseModel.objects.get(code=data).id != self.instance.id:
             raise forms.ValidationError("A course with this code already exists!")
         return data.upper()
 


### PR DESCRIPTION
Raise validation error if user attempts to make a course with the same course code as a course in the database, where the database IDs for the form course and the database course do not match. Closes #466 

Expected behaviour:
- new course with same code - validation error
- edit existing course - success
- edit existing course with different code to have same code - validation error

Editing existing course:
![image](https://user-images.githubusercontent.com/10462891/66520435-dff96100-eb34-11e9-90a9-952f6701a598.png)

Adding new course with same ID:
![image](https://user-images.githubusercontent.com/10462891/66520374-c3f5bf80-eb34-11e9-94df-52fa36b85279.png)
