### PR TITLE
Add course list rule to `View` OR rules

### DIFF
--- a/cassdegrees/static/css/style.css
+++ b/cassdegrees/static/css/style.css
@@ -363,6 +363,10 @@ select.text{
     user-select: none;
     cursor: move;
 }
+/* Reverts the draggable CSS changes */
+.non-draggable {
+    cursor: default;
+}
 
 /* Ensures course drop boxes are of the right size */
 .course-drop {

--- a/cassdegrees/static/js/staff/rules.js
+++ b/cassdegrees/static/js/staff/rules.js
@@ -186,7 +186,7 @@ function dragMoveListener(event, x, y, origin_x, origin_y) {
             'translate(' + (event.pageX - x) + 'px, ' + (event.pageY - y) + 'px) scale(0.33)';
 }
 
-interact('.draggable-rule').draggable({
+interact('.draggable-rule').ignoreFrom('.btn-snall').draggable({
     inertia: false,
     autoScroll: true,
 
@@ -371,7 +371,7 @@ interact('.dropzone').dropzone({
     }
 });
 
-interact('.draggable-group').draggable({
+interact('.draggable-group').ignoreFrom('.rule-container').draggable({
     inertia: false,
     autoScroll: true,
 

--- a/cassdegrees/templates/staff/view/viewprogram.html
+++ b/cassdegrees/templates/staff/view/viewprogram.html
@@ -191,16 +191,16 @@
                                         </ul>
                                     </p>
                                 {# Elective Or Rule #}
-                                {% elif rule.type == 'elective' %}
+                                {% elif sub_rule.type == 'elective' %}
                                     <p>
-                                        {{ rule.unit_count }} units from completion of
-                                        {% if rule.year_level != 'all' %}
-                                            {{ rule.year_level }}-level
+                                        {{ sub_rule.unit_count }} units from completion of
+                                        {% if sub_rule.year_level != 'all' %}
+                                            {{ sub_rule.year_level }}-level
                                         {% endif %}
-                                        {% if rule.subject_area == 'all' %}
+                                        {% if sub_rule.subject_area == 'all' %}
                                             elective courses offered by ANU
                                         {% else %}
-                                            courses in the subject area {{ rule.subject_area }}
+                                            courses in the subject area {{ sub_rule.subject_area }}
                                         {% endif %}
                                     </p>
                                 {# Custom-text Or Rule #}

--- a/cassdegrees/templates/staff/view/viewprogram.html
+++ b/cassdegrees/templates/staff/view/viewprogram.html
@@ -168,14 +168,25 @@
                                         </ul>
                                     </p>
                                 {# Course Or Rule #}
-                                {% elif sub_rule.type == 'course' %}
+                                {% elif sub_rule.type == 'course_list' %}
                                     <p>
-                                        {{ sub_rule.unit_count }} units from the completion of the following courses:
+                                        {% if sub_rule.list_type != "min_max" %}
+                                            {% if sub_rule.list_type == "min" %}
+                                                A minimum of
+                                            {% elif sub_rule.list_type == "exact" %}
+                                                Exactly
+                                            {% elif sub_rule.list_type == "max" %}
+                                                A maximum of
+                                            {% endif %}
+                                            {{ sub_rule.unit_count }} units
+                                        {% else %}
+                                            A minimum of {{ sub_rule.min_unit_count }} units
+                                            and a maximum of {{ sub_rule.max_unit_count }} units
+                                        {% endif %}
+                                        from the completion of the following courses:
                                         <ul>
                                             {% for course in sub_rule.courses %}
-                                                <li>
-                                                    {{ course.code }} - {{ course.name }} ({{ course.units }} units)
-                                                </li>
+                                                <li>{{ course.code }} - {{ course.name }} ({{ course.units }} units)</li>
                                             {% endfor %}
                                         </ul>
                                     </p>
@@ -195,6 +206,8 @@
                                 {# Custom-text Or Rule #}
                                 {% elif sub_rule.type == "custom_text" %}
                                     <p>{{ sub_rule.units }} units from {{ sub_rule.text }}</p>
+                                {% else %}
+                                    Invalid Rule: {{ rule.type }}
                                 {% endif %}
                             {% endfor %}
                         </div>

--- a/cassdegrees/templates/widgets/rules/either_or.html
+++ b/cassdegrees/templates/widgets/rules/either_or.html
@@ -21,7 +21,7 @@
 
                     <div :drag_id="set_id(i, -1)"><div class="dropzone dropzone-area" hidden></div></div>
                     <div v-for="(item, j) in details.either_or[i]" :key="j" :drag_id="set_id(i, j)" >
-                        <rule class="rule-container" v-bind:details="item" v-on:update="update(j, $event)"
+                        <rule class="rule-container non-draggable" v-bind:details="item" v-on:update="update(j, $event)"
                               v-on:remove="remove(j, i)" v-on:duplicate_rule="duplicate_rule(j, i)"></rule>
                         <div v-if="j < details.either_or[i].length - 1 && separator.length > 0">{{ separator }}<br /><br /></div>
                         <div class="dropzone dropzone-area" hidden></div>


### PR DESCRIPTION
Closes #479 

*As a bonus, this PR also prevents the user from being able to drag child components of OR groups - only the group border themselves should be draggable.*

Previously the view logic for the `Course List` rule wasn't implemented inside OR rules. This PR makes it so course lists now appear when viewing programs again