### PR TITLE
Made unpublished plans and subplans visible on the list page

### DIFF
--- a/cassdegrees/static/css/style.css
+++ b/cassdegrees/static/css/style.css
@@ -107,6 +107,10 @@
     color:#FFF;
 }
 
+.unpublished-color {
+    background-color: #ffa5a5;
+}
+
 .draggable-group {
     background-color: white;
 }

--- a/cassdegrees/templates/staff/list.html
+++ b/cassdegrees/templates/staff/list.html
@@ -86,14 +86,16 @@
                     <thead>
                         <tr>
                         {% for key in content.0 %}
-                            {% if key != "Id" %}
-                                <th class="sort" data-sort="{{ title }}{{ key }}">{{ key }}</th>
-                            {% else %}
-                                <th class="text-center">
-                                    Select All</br>
-                                    <input id="select_all" title="Select All" type="checkbox" name="select_all" onchange="selectAll(this, '{{ title }}')">
-                                </th>
-                                <th>{{ title }}</th>
+                            {% if key != "Publish" %}
+                                {% if key != "Id" %}
+                                    <th class="sort" data-sort="{{ title }}{{ key }}">{{ key }}</th>
+                                {% else %}
+                                    <th class="text-center">
+                                        Select All</br>
+                                        <input id="select_all" title="Select All" type="checkbox" name="select_all" onchange="selectAll(this, '{{ title }}')">
+                                    </th>
+                                    <th>{{ title }}</th>
+                                {% endif %}
                             {% endif %}
                         {% endfor %}
                         </tr>
@@ -103,10 +105,10 @@
                     {% for row in content %}
                         <tr>
                             {% for key, item in row.items %}
-
+                                {% if key != "Publish" %}
                                     {# If the item is in the ID column, generate a link to it instead #}
                                     {% if key != "Id" %}
-                                        <td class="{{ title }}{{ key }}">{{ item }}</td>
+                                        <td class="{{ title }}{{ key }}{% if row.Publish is False %} unpublished-color{% endif %}">{{ item }}</td>
                                     {% else %}
                                         <td><p class="text-center"><input title="Select" type="checkbox" class="select_{{ title }}" name="id" value="{{ item }}"  onchange="sessionStorage.setItem('selected', {{ item }})"/></p></td>
                                         <td>
@@ -116,7 +118,7 @@
                                             {% if title == 'Program' %}<a class="btn-uni-grad" href="{{ render.staff_url_prefix }}pdf/program?id={{ item }}">PDF</a>{% endif %}
                                         </td>
                                     {% endif %}
-
+                                {% endif %}
                             {% endfor %}
                         </tr>
                     {% endfor %}

--- a/cassdegrees/ui/views/staff/listings.py
+++ b/cassdegrees/ui/views/staff/listings.py
@@ -20,8 +20,8 @@ def data_dict_as_displayable(data):
 
     # Columns that are needed
     desired_columns = {
-        'Program': ['id', 'code', 'year', 'name', 'programType', 'units', 'lastUpdated'],
-        'Subplan': ['id', 'code', 'year', 'name', 'planType', 'lastUpdated'],
+        'Program': ['id', 'code', 'year', 'name', 'programType', 'units', 'lastUpdated', 'publish'],
+        'Subplan': ['id', 'code', 'year', 'name', 'planType', 'lastUpdated', 'publish'],
         'Course': ['id', 'code', 'name', 'units', 'lastUpdated'],
         'List': ['id', 'name', 'year', 'lastUpdated']
     }


### PR DESCRIPTION
When creating subplans and program plans, any unpublished ones will appear in red.
<img width="925" alt="Screen Shot 2019-10-17 at 4 44 13 pm" src="https://user-images.githubusercontent.com/36946090/66980689-61389100-f0fd-11e9-9378-a322eec8d6da.png">
